### PR TITLE
chore: exempt go.mod/go.sum from CODEOWNERS review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # These users have approval access to all resources (wildcard)
 * @fullsend-ai/core
 
-# Allow the review bot to approve dependency updates
-go.mod @fullsend-ai/core @fullsend-ai-review[bot]
-go.sum @fullsend-ai/core @fullsend-ai-review[bot]
+# Exempt dependency files from CODEOWNERS so any reviewer can approve
+go.mod
+go.sum

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,8 @@
 # These users have approval access to all resources (wildcard)
 * @fullsend-ai/core
 
-# Exempt dependency files from CODEOWNERS so any reviewer can approve
+# Exempt dependency files from CODEOWNERS so any reviewer (including
+# bots) can approve. Uses blank-owner entries per:
+# https://github.com/orgs/community/discussions/23064
 go.mod
 go.sum

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,6 @@
 # These users have approval access to all resources (wildcard)
 * @fullsend-ai/core
+
+# Allow the review bot to approve dependency updates
+go.mod @fullsend-ai/core @fullsend-ai-review[bot]
+go.sum @fullsend-ai/core @fullsend-ai-review[bot]


### PR DESCRIPTION
## Summary

- Adds blank-owner CODEOWNERS entries for `go.mod` and `go.sum`, exempting them from code owner review
- This lets any reviewer — including `fullsend-ai-review[bot]` — approve dependency update PRs without needing a `@fullsend-ai/core` member
- Uses the [blank-owner pattern](https://github.com/orgs/community/discussions/23064) recommended by GitHub

## Context

GitHub App bots can't be added as CODEOWNERS (they're not "users" in GitHub's model). The blank-owner pattern is the supported workaround.

Required status checks (`test`, `e2e`, `commit-lint`) and the merge queue still gate all merges, so dependency changes are still validated by CI.

## Also fixed (out of band)

`@fullsend-ai/core` was flagged as an "Unknown owner" because the team didn't have write access to this repo. That's been fixed — CODEOWNERS is now actually enforced for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)