### PR TITLE
docs: ADR 0071 — Auto-merge

### DIFF
--- a/docs/ADRs/0062-auto-merge.md
+++ b/docs/ADRs/0062-auto-merge.md
@@ -22,13 +22,14 @@ Accepted
 
 Our review bot (`fullsend-ai-review`) can approve PRs, but GitHub only counts
 an approval toward branch protection when the reviewer has write access
-(`contents: write`) to the repository. The review app intentionally has
-`contents: read` — giving it write access would violate the least-privilege
-boundary established in [ADR 7](0007-per-role-github-apps.md).
+(`contents: write`). The review app has `contents: read` — giving it write
+access would violate the least-privilege boundary in
+[ADR 7](0007-per-role-github-apps.md). See
+[agent-architecture.md](../problems/agent-architecture.md) and
+[security-threat-model.md](../problems/security-threat-model.md).
 
 We also need the bot's approval to satisfy CODEOWNERS for dependency files
-(`go.mod`, `go.sum`). GitHub App bots cannot be listed as CODEOWNERS entries —
-they are not "users" in GitHub's model.
+(`go.mod`, `go.sum`). GitHub App bots cannot appear as CODEOWNERS entries.
 
 ## Options
 
@@ -38,36 +39,53 @@ Collapses the permission boundary between review and implementation roles.
 Every repo that installs the review app would grant it write access it doesn't
 otherwise need.
 
-### B. Create a separate `fullsend-ai-merge` app
+### B. Create a separate merge agent
 
-A new app with `contents: write` and `pull_requests: write`. Repos opt in to
-auto-merge by installing this app instead of (or alongside) the review app.
-The trust escalation is explicit and visible in GitHub's UI.
+A new agent with its own harness config, slug, and app identity
+(`fullsend-ai-merge`). Repos opt in by installing the merge app. Clean
+separation, but duplicates orchestration logic and adds a new agent to
+maintain.
 
-### C. Exempt dependency files via blank-owner CODEOWNERS entries
+### C. New app identity, same review agent, env-var toggle
+
+Create a `fullsend-ai-merge` app with `contents: write` and
+`pull_requests: write`, but teach the existing review agent to auto-merge when
+an env var (`REVIEW_AUTO_MERGE=true`) is set. Repos that want auto-merge
+install the merge app and set the var; repos that want read-only reviews keep
+`fullsend-ai-review` unchanged.
+
+### D. Exempt dependency files via blank-owner CODEOWNERS entries
 
 Use [blank-owner entries](https://github.com/orgs/community/discussions/23064)
-to remove the CODEOWNERS requirement for specific files. This is orthogonal to
-the app permission question — it addresses the CODEOWNERS gate, not the
-approval-counts gate.
+to remove the CODEOWNERS requirement for specific files. Orthogonal to the app
+permission question — addresses the CODEOWNERS gate, not the approval gate.
 
 ## Decision
 
-Use options B and C together:
+Use options C and D together.
 
 1. **Create a `fullsend-ai-merge` app** with `contents: write` and
-   `pull_requests: write`. Its approvals count toward branch protection. Repos
-   that want bot-driven auto-merge install this app; repos that only want
-   informational reviews keep `fullsend-ai-review`.
+   `pull_requests: write`. Repos that want bot-driven auto-merge install this
+   app alongside or instead of `fullsend-ai-review`.
 
-2. **Use blank-owner CODEOWNERS entries** for files that bots should be able to
-   approve (starting with `go.mod` and `go.sum`). This removes the CODEOWNERS
-   gate for those files without affecting other paths.
+2. **Add auto-merge behavior to the review agent**, gated behind
+   `REVIEW_AUTO_MERGE`. When the var is set and the review verdict is
+   `approve`, the post-script enables GitHub auto-merge on the PR. No new
+   agent harness — same `review.yaml`, same skills, same post-script.
+
+3. **Use blank-owner CODEOWNERS entries** for files bots should be able to
+   approve (starting with `go.mod` and `go.sum`).
+
+This is the most **reversible** path. If a dedicated merge agent turns out to
+be the better UX, having once had a more capable review agent does not make
+that harder — we stand up the new agent and deprecate the env var. Going the
+other direction (standalone agent first, then collapsing back) would be.
 
 ## Consequences
 
 - The review app stays read-only — no permission creep.
-- Auto-merge is an explicit opt-in per repo, visible in the GitHub App installation list.
-- Blank-owner CODEOWNERS entries remove code-owner review for the listed files; CI status checks remain the primary safety gate for those paths.
-- Adding a new app increases the number of apps to manage and enroll per org.
-- The merge app's `contents: write` permission is a higher-value target if compromised — the same mitigations from [ADR 7](0007-per-role-github-apps.md) apply (repo-scoped install, PEM in config repo secrets).
+- Auto-merge is opt-in per repo, visible in the GitHub App installation list.
+- No new agent to maintain — auto-merge is a small addition to `post-review.sh`.
+- If the env-var approach proves wrong, standing up a dedicated agent is not made harder by this decision.
+- Blank-owner CODEOWNERS entries remove code-owner review for listed files; CI status checks remain the primary safety gate.
+- The merge app's `contents: write` is a higher-value target if compromised — same mitigations from [ADR 7](0007-per-role-github-apps.md) apply.

--- a/docs/ADRs/0062-auto-merge.md
+++ b/docs/ADRs/0062-auto-merge.md
@@ -1,0 +1,73 @@
+---
+title: "62. Auto-merge"
+status: Accepted
+relates_to:
+  - agent-architecture
+  - security-threat-model
+topics:
+  - github-apps
+  - least-privilege
+  - auto-merge
+---
+
+# 62. Auto-merge
+
+Date: 2026-06-30
+
+## Status
+
+Accepted
+
+## Context
+
+Our review bot (`fullsend-ai-review`) can approve PRs, but GitHub only counts
+an approval toward branch protection when the reviewer has write access
+(`contents: write`) to the repository. The review app intentionally has
+`contents: read` — giving it write access would violate the least-privilege
+boundary established in [ADR 7](0007-per-role-github-apps.md).
+
+We also need the bot's approval to satisfy CODEOWNERS for dependency files
+(`go.mod`, `go.sum`). GitHub App bots cannot be listed as CODEOWNERS entries —
+they are not "users" in GitHub's model.
+
+## Options
+
+### A. Add `contents: write` to the review app
+
+Collapses the permission boundary between review and implementation roles.
+Every repo that installs the review app would grant it write access it doesn't
+otherwise need.
+
+### B. Create a separate `fullsend-ai-merge` app
+
+A new app with `contents: write` and `pull_requests: write`. Repos opt in to
+auto-merge by installing this app instead of (or alongside) the review app.
+The trust escalation is explicit and visible in GitHub's UI.
+
+### C. Exempt dependency files via blank-owner CODEOWNERS entries
+
+Use [blank-owner entries](https://github.com/orgs/community/discussions/23064)
+to remove the CODEOWNERS requirement for specific files. This is orthogonal to
+the app permission question — it addresses the CODEOWNERS gate, not the
+approval-counts gate.
+
+## Decision
+
+Use options B and C together:
+
+1. **Create a `fullsend-ai-merge` app** with `contents: write` and
+   `pull_requests: write`. Its approvals count toward branch protection. Repos
+   that want bot-driven auto-merge install this app; repos that only want
+   informational reviews keep `fullsend-ai-review`.
+
+2. **Use blank-owner CODEOWNERS entries** for files that bots should be able to
+   approve (starting with `go.mod` and `go.sum`). This removes the CODEOWNERS
+   gate for those files without affecting other paths.
+
+## Consequences
+
+- The review app stays read-only — no permission creep.
+- Auto-merge is an explicit opt-in per repo, visible in the GitHub App installation list.
+- Blank-owner CODEOWNERS entries remove code-owner review for the listed files; CI status checks remain the primary safety gate for those paths.
+- Adding a new app increases the number of apps to manage and enroll per org.
+- The merge app's `contents: write` permission is a higher-value target if compromised — the same mitigations from [ADR 7](0007-per-role-github-apps.md) apply (repo-scoped install, PEM in config repo secrets).

--- a/docs/ADRs/0071-auto-merge.md
+++ b/docs/ADRs/0071-auto-merge.md
@@ -31,6 +31,12 @@ access would violate the least-privilege boundary in
 We also need the bot's approval to satisfy CODEOWNERS for dependency files
 (`go.mod`, `go.sum`). GitHub App bots cannot appear as CODEOWNERS entries.
 
+The review agent implementation now lives in `fullsend-ai/agents`, but
+auto-merge touches core design concerns — GitHub App identity boundaries,
+credential isolation, and CODEOWNERS policy — that are central architectural
+decisions. This ADR records the decision here; implementation follows in the
+agents repo.
+
 ## Options
 
 ### A. Add `contents: write` to the review app

--- a/docs/ADRs/0071-auto-merge.md
+++ b/docs/ADRs/0071-auto-merge.md
@@ -1,5 +1,5 @@
 ---
-title: "62. Auto-merge"
+title: "71. Auto-merge"
 status: Accepted
 relates_to:
   - agent-architecture
@@ -10,7 +10,7 @@ topics:
   - auto-merge
 ---
 
-# 62. Auto-merge
+# 71. Auto-merge
 
 Date: 2026-06-30
 

--- a/docs/ADRs/0071-auto-merge.md
+++ b/docs/ADRs/0071-auto-merge.md
@@ -24,7 +24,7 @@ Our review bot (`fullsend-ai-review`) can approve PRs, but GitHub only counts
 an approval toward branch protection when the reviewer has write access
 (`contents: write`). The review app has `contents: read` — giving it write
 access would violate the least-privilege boundary in
-[ADR 7](0007-per-role-github-apps.md). See
+[ADR 0007](0007-per-role-github-apps.md). See
 [agent-architecture.md](../problems/agent-architecture.md) and
 [security-threat-model.md](../problems/security-threat-model.md).
 
@@ -79,7 +79,41 @@ Use options C and D together.
 This is the most **reversible** path. If a dedicated merge agent turns out to
 be the better UX, having once had a more capable review agent does not make
 that harder — we stand up the new agent and deprecate the env var. Going the
-other direction (standalone agent first, then collapsing back) would be.
+other direction (standalone agent first, then collapsing back) would be harder
+because the standalone agent accumulates its own orchestration logic that must
+be reconciled.
+
+### Token handoff
+
+When `REVIEW_AUTO_MERGE` is set, the harness mints a token from the
+`fullsend-ai-merge` app instead of `fullsend-ai-review`. If the merge app is
+not installed on the repo, the agent fails hard — this is a misconfiguration.
+Normal review operations (reading code, posting comments) do not change; only
+the auto-merge step requires the elevated token.
+
+### Security considerations
+
+- **Credential isolation.** The merge app token is minted per-run and scoped to
+  the triggering repo. The review agent never holds both the merge token and a
+  provider credential simultaneously — sandbox isolation
+  ([ADR 0017](0017-credential-isolation-for-sandboxed-agents.md)) keeps them
+  separated.
+- **Prompt injection blast radius.** A compromised review agent with the merge
+  token can enable auto-merge on the PR it was invoked for. It cannot merge
+  arbitrary PRs — branch protection (required reviewers, status checks) still
+  gates the actual merge. The blast radius is one PR, same as today.
+- **CODEOWNERS bypass scope.** Blank-owner entries only remove the code-owner
+  review requirement for the listed paths (`go.mod`, `go.sum`). CI status
+  checks remain the primary safety gate for those files.
+- **`REVIEW_AUTO_MERGE` delivery protection.** The env var is set in the
+  repo's workflow file, not by the agent. An attacker who can modify the
+  workflow file already has write access to the repo.
+
+### Implementation deferral
+
+Implementation of `REVIEW_AUTO_MERGE` in `review.yaml` and `post-review.sh`
+is deferred to a follow-up PR. This ADR records the decision; the follow-up
+wires it up.
 
 ## Consequences
 
@@ -88,4 +122,4 @@ other direction (standalone agent first, then collapsing back) would be.
 - No new agent to maintain — auto-merge is a small addition to `post-review.sh`.
 - If the env-var approach proves wrong, standing up a dedicated agent is not made harder by this decision.
 - Blank-owner CODEOWNERS entries remove code-owner review for listed files; CI status checks remain the primary safety gate.
-- The merge app's `contents: write` is a higher-value target if compromised — same mitigations from [ADR 7](0007-per-role-github-apps.md) apply.
+- The merge app's `contents: write` is a higher-value target if compromised — same mitigations from [ADR 0007](0007-per-role-github-apps.md) apply.


### PR DESCRIPTION
## Summary

- Adds ADR 0062 proposing a separate `fullsend-ai-merge` GitHub App for auto-merge
- Key finding: GitHub only counts approvals toward branch protection when the reviewer has `contents: write` — our review bot has `contents: read`, so its approvals are currently informational only
- Proposes combining a new merge app (opt-in per repo) with blank-owner CODEOWNERS entries for dependency files

Looking for team feedback on the approach before implementation.

## Test plan

- [ ] Review the ADR for correctness and completeness
- [ ] Discuss whether the two-app model is the right tradeoff vs. adding `contents: write` to the review app