### PR TITLE
feat(#1880): auto-assign code-agent PRs to triggering human

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -17,6 +17,11 @@ on:
       event_payload:
         required: true
         type: string
+      trigger_source:
+        required: false
+        type: string
+        default: ""
+        description: "GitHub username that triggered /fs-code; empty for label-triggered runs"
       mint_url:
         required: true
         type: string
@@ -199,6 +204,7 @@ jobs:
           REPO_FULL_NAME: ${{ inputs.source_repo }}
           CODE_ALLOWED_TARGET_BRANCHES: ''
           TARGET_BRANCH: main
+          TRIGGER_SOURCE: ${{ inputs.trigger_source }}
         with:
           agent: code
           version: ${{ inputs.fullsend_version }}

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -181,6 +181,7 @@ jobs:
                   if [[ "${ISSUE_IS_PR}" == "false" ]]; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                       STAGE="code"
+                      TRIGGER_SOURCE="${COMMENT_USER_LOGIN}"
                     fi
                   fi
                   ;;
@@ -460,6 +461,7 @@ jobs:
       event_type: ${{ github.event_name }}
       source_repo: ${{ github.repository }}
       event_payload: ${{ needs.route.outputs.event_payload }}
+      trigger_source: ${{ needs.route.outputs.trigger_source }}
       install_mode: ${{ inputs.install_mode }}
       mint_url: ${{ inputs.mint_url }}
       gcp_region: ${{ inputs.gcp_region }}

--- a/internal/harness/scaffold_integration_test.go
+++ b/internal/harness/scaffold_integration_test.go
@@ -296,9 +296,8 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 
 	tests := []struct {
 		file            string
-		topLevelKeys    []string // keys expected in RunnerEnv (deprecated)
-		forgeGithubKeys []string // keys expected in RunnerEnv from forge (deprecated)
-		envRunnerKeys   []string // keys expected in Env.Runner (ADR 0055)
+		topLevelKeys    []string
+		forgeGithubKeys []string
 	}{
 		{
 			file:            "triage.yaml",
@@ -307,7 +306,7 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 		},
 		{
 			file:            "code.yaml",
-			topLevelKeys:    []string{"CODE_ALLOWED_TARGET_BRANCHES", "FULLSEND_OUTPUT_SCHEMA", "FULLSEND_OUTPUT_FILE"},
+			topLevelKeys:    []string{"CODE_ALLOWED_TARGET_BRANCHES", "TRIGGER_SOURCE", "FULLSEND_OUTPUT_SCHEMA", "FULLSEND_OUTPUT_FILE"},
 			forgeGithubKeys: []string{"PUSH_TOKEN", "PUSH_TOKEN_SOURCE", "REPO_FULL_NAME", "ISSUE_NUMBER", "REPO_DIR"},
 		},
 		{
@@ -322,9 +321,8 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 		},
 		{
 			file:            "retro.yaml",
-			topLevelKeys:    []string{}, // migrated to env.runner (ADR 0055)
-			forgeGithubKeys: []string{}, // migrated to env.runner (ADR 0055)
-			envRunnerKeys:   []string{"FULLSEND_OUTPUT_SCHEMA", "ORIGINATING_URL", "REPO_FULL_NAME", "GH_TOKEN"},
+			topLevelKeys:    []string{"FULLSEND_OUTPUT_SCHEMA"},
+			forgeGithubKeys: []string{"ORIGINATING_URL", "REPO_FULL_NAME", "GH_TOKEN"},
 		},
 		{
 			file:            "prioritize.yaml",
@@ -356,10 +354,6 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 			}
 			for _, key := range tt.forgeGithubKeys {
 				assert.Contains(t, combined, key, "merged env should contain forge.github key %s", key)
-			}
-			for _, key := range tt.envRunnerKeys {
-				require.NotNil(t, h.Env, "Env should be non-nil for template with env.runner keys")
-				assert.Contains(t, h.Env.Runner, key, "merged Env.Runner should contain key %s", key)
 			}
 		})
 	}

--- a/internal/harness/scaffold_integration_test.go
+++ b/internal/harness/scaffold_integration_test.go
@@ -296,8 +296,9 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 
 	tests := []struct {
 		file            string
-		topLevelKeys    []string
-		forgeGithubKeys []string
+		topLevelKeys    []string // keys expected in RunnerEnv (deprecated)
+		forgeGithubKeys []string // keys expected in RunnerEnv from forge (deprecated)
+		envRunnerKeys   []string // keys expected in Env.Runner (ADR 0055)
 	}{
 		{
 			file:            "triage.yaml",
@@ -306,8 +307,9 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 		},
 		{
 			file:            "code.yaml",
-			topLevelKeys:    []string{"CODE_ALLOWED_TARGET_BRANCHES", "TRIGGER_SOURCE", "FULLSEND_OUTPUT_SCHEMA", "FULLSEND_OUTPUT_FILE"},
-			forgeGithubKeys: []string{"PUSH_TOKEN", "PUSH_TOKEN_SOURCE", "REPO_FULL_NAME", "ISSUE_NUMBER", "REPO_DIR"},
+			topLevelKeys:    []string{},
+			forgeGithubKeys: []string{},
+			envRunnerKeys:   []string{"CODE_ALLOWED_TARGET_BRANCHES", "TRIGGER_SOURCE", "FULLSEND_OUTPUT_SCHEMA", "FULLSEND_OUTPUT_FILE", "PUSH_TOKEN", "PUSH_TOKEN_SOURCE", "REPO_FULL_NAME", "ISSUE_NUMBER", "REPO_DIR"},
 		},
 		{
 			file:            "review.yaml",
@@ -321,8 +323,9 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 		},
 		{
 			file:            "retro.yaml",
-			topLevelKeys:    []string{"FULLSEND_OUTPUT_SCHEMA"},
-			forgeGithubKeys: []string{"ORIGINATING_URL", "REPO_FULL_NAME", "GH_TOKEN"},
+			topLevelKeys:    []string{}, // migrated to env.runner (ADR 0055)
+			forgeGithubKeys: []string{}, // migrated to env.runner (ADR 0055)
+			envRunnerKeys:   []string{"FULLSEND_OUTPUT_SCHEMA", "ORIGINATING_URL", "REPO_FULL_NAME", "GH_TOKEN"},
 		},
 		{
 			file:            "prioritize.yaml",
@@ -354,6 +357,10 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 			}
 			for _, key := range tt.forgeGithubKeys {
 				assert.Contains(t, combined, key, "merged env should contain forge.github key %s", key)
+			}
+			for _, key := range tt.envRunnerKeys {
+				require.NotNil(t, h.Env, "Env should be non-nil for template with env.runner keys")
+				assert.Contains(t, h.Env.Runner, key, "merged Env.Runner should contain key %s", key)
 			}
 		})
 	}

--- a/internal/scaffold/fullsend-repo/.github/workflows/code.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/code.yml
@@ -22,6 +22,10 @@ on:
       event_payload:
         required: true
         type: string
+      trigger_source:
+        required: false
+        type: string
+        description: "GitHub username that triggered /fs-code; empty for label-triggered runs"
 
 concurrency:
   group: fullsend-code-${{ inputs.source_repo }}-${{ fromJSON(inputs.event_payload).issue.number }}
@@ -34,6 +38,7 @@ jobs:
       event_type: ${{ inputs.event_type }}
       source_repo: ${{ inputs.source_repo }}
       event_payload: ${{ inputs.event_payload }}
+      trigger_source: ${{ inputs.trigger_source || '' }}
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -125,6 +125,7 @@ jobs:
                   if [[ "${ISSUE_HAS_PR}" == "false" ]]; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                       STAGE="code"
+                      TRIGGER_SOURCE="${COMMENT_USER_LOGIN}"
                     fi
                   fi
                   ;;
@@ -446,7 +447,7 @@ jobs:
               -f event_payload="$EVENT_PAYLOAD"
             )
 
-            if [[ -n "${TRIGGER_SOURCE:-}" ]] && [[ "$STAGE" == "fix" ]]; then
+            if [[ -n "${TRIGGER_SOURCE:-}" ]] && [[ "$STAGE" == "fix" || "$STAGE" == "code" ]]; then
               DISPATCH_ARGS+=(-f trigger_source="$TRIGGER_SOURCE")
             fi
 

--- a/internal/scaffold/fullsend-repo/harness/code.yaml
+++ b/internal/scaffold/fullsend-repo/harness/code.yaml
@@ -43,6 +43,7 @@ plugins:
 # These are expanded from the runner environment and NEVER enter the sandbox.
 runner_env:
   CODE_ALLOWED_TARGET_BRANCHES: "${CODE_ALLOWED_TARGET_BRANCHES}"
+  TRIGGER_SOURCE: "${TRIGGER_SOURCE}"
   FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/code-result.schema.json
   FULLSEND_OUTPUT_FILE: code-result.json
 

--- a/internal/scaffold/fullsend-repo/harness/code.yaml
+++ b/internal/scaffold/fullsend-repo/harness/code.yaml
@@ -39,13 +39,13 @@ skills:
 plugins:
   - plugins/gopls-lsp
 
-# Environment variables available to pre/post scripts on the runner.
-# These are expanded from the runner environment and NEVER enter the sandbox.
-runner_env:
-  CODE_ALLOWED_TARGET_BRANCHES: "${CODE_ALLOWED_TARGET_BRANCHES}"
-  TRIGGER_SOURCE: "${TRIGGER_SOURCE}"
-  FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/code-result.schema.json
-  FULLSEND_OUTPUT_FILE: code-result.json
+# Runner env for pre/post scripts (ADR 0055 env.runner).
+env:
+  runner:
+    CODE_ALLOWED_TARGET_BRANCHES: "${CODE_ALLOWED_TARGET_BRANCHES}"
+    TRIGGER_SOURCE: "${TRIGGER_SOURCE}"
+    FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/code-result.schema.json
+    FULLSEND_OUTPUT_FILE: code-result.json
 
 timeout_minutes: 35
 
@@ -53,9 +53,10 @@ forge:
   github:
     pre_script: scripts/pre-code.sh
     post_script: scripts/post-code.sh
-    runner_env:
-      PUSH_TOKEN: "${PUSH_TOKEN}"
-      PUSH_TOKEN_SOURCE: "${PUSH_TOKEN_SOURCE}"
-      REPO_FULL_NAME: "${REPO_FULL_NAME}"
-      ISSUE_NUMBER: "${ISSUE_NUMBER}"
-      REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"
+    env:
+      runner:
+        PUSH_TOKEN: "${PUSH_TOKEN}"
+        PUSH_TOKEN_SOURCE: "${PUSH_TOKEN_SOURCE}"
+        REPO_FULL_NAME: "${REPO_FULL_NAME}"
+        ISSUE_NUMBER: "${ISSUE_NUMBER}"
+        REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"

--- a/internal/scaffold/fullsend-repo/scripts/post-code-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code-test.sh
@@ -778,6 +778,140 @@ run_precommit_retry_test "precommit-passes-with-unstaged" \
 run_precommit_retry_test "precommit-retry-passes-but-left-unstaged" \
   "1" "yes" "0" "blocked:retry-left-unstaged" "yes"
 
+# ---------------------------------------------------------------------------
+# Test helpers — reimplement PR assignee resolution from post-code.sh
+# ---------------------------------------------------------------------------
+is_human_github_user() {
+  local login="${1:-}"
+  if [[ -z "${login}" ]]; then
+    return 1
+  fi
+  case "${login}" in
+    app/*|dependabot) return 1 ;;
+  esac
+  if [[ "${login}" =~ \[bot\]$ ]]; then
+    return 1
+  fi
+  return 0
+}
+
+resolve_pr_assignee_from_context() {
+  local trigger_source="$1"
+  local issue_json="$2"
+
+  if is_human_github_user "${trigger_source}"; then
+    echo "${trigger_source}"
+    return 0
+  fi
+
+  if [[ -z "${issue_json}" ]]; then
+    return 1
+  fi
+
+  local human_assignee
+  human_assignee="$(echo "${issue_json}" | jq -r '
+    [.assignees[].login | select(
+      (startswith("app/") | not) and
+      (test("\\[bot\\]$") | not) and
+      (. != "dependabot")
+    )] | .[0] // empty
+  ')"
+  if [[ -n "${human_assignee}" ]]; then
+    echo "${human_assignee}"
+    return 0
+  fi
+
+  local author_login
+  author_login="$(echo "${issue_json}" | jq -r '.author.login // empty')"
+  if is_human_github_user "${author_login}"; then
+    echo "${author_login}"
+    return 0
+  fi
+
+  return 1
+}
+
+decide_assign_action() {
+  local trigger_source="$1"
+  local issue_json="$2"
+  local existing_assignee_count="$3"
+
+  if [[ "${existing_assignee_count}" != "0" ]]; then
+    echo "skip:has-assignees"
+    return 0
+  fi
+
+  local assignee
+  assignee="$(resolve_pr_assignee_from_context "${trigger_source}" "${issue_json}" || true)"
+  if [[ -z "${assignee}" ]]; then
+    echo "skip:no-candidate"
+    return 0
+  fi
+
+  echo "assign:${assignee}"
+}
+
+run_assignee_test() {
+  local test_name="$1"
+  local trigger_source="$2"
+  local issue_json="$3"
+  local existing_count="$4"
+  local expected="$5"
+
+  local actual
+  actual="$(decide_assign_action "${trigger_source}" "${issue_json}" "${existing_count}")"
+
+  if [ "${actual}" != "${expected}" ]; then
+    echo "FAIL: ${test_name}"
+    echo "  trigger_source: '${trigger_source}'"
+    echo "  existing_count: '${existing_count}'"
+    echo "  expected:       '${expected}'"
+    echo "  actual:         '${actual}'"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+HUMAN_ISSUE_JSON='{
+  "assignees": [{"login": "alice"}],
+  "author": {"login": "bob"}
+}'
+
+BOT_ISSUE_JSON='{
+  "assignees": [{"login": "fullsend-ai-triage[bot]"}],
+  "author": {"login": "app/fullsend-ai-retro"}
+}'
+
+# Human /fs-code invoker wins over issue assignee and author
+run_assignee_test "trigger-source-human-wins" \
+  "ifireball" "${HUMAN_ISSUE_JSON}" "0" "assign:ifireball"
+
+# Bot trigger falls through to first human assignee
+run_assignee_test "bot-trigger-uses-human-assignee" \
+  "fullsend-ai-coder[bot]" "${HUMAN_ISSUE_JSON}" "0" "assign:alice"
+
+# Bot trigger with no human assignee uses human author
+run_assignee_test "bot-trigger-uses-human-author" \
+  "" '{"assignees": [], "author": {"login": "bob"}}' "0" "assign:bob"
+
+# All candidates are bots — no assignment
+run_assignee_test "all-bot-candidates-no-assign" \
+  "fullsend-ai-coder[bot]" "${BOT_ISSUE_JSON}" "0" "skip:no-candidate"
+
+# PR already has assignees — no reassignment
+run_assignee_test "existing-assignees-skip" \
+  "ifireball" "${HUMAN_ISSUE_JSON}" "1" "skip:has-assignees"
+
+# dependabot filtered from assignee chain
+run_assignee_test "dependabot-filtered" \
+  "" '{"assignees": [{"login": "dependabot[bot]"}], "author": {"login": "dependabot"}}' "0" "skip:no-candidate"
+
+# dependabotb is human (not matched by dependabot[bot] glob bug)
+run_assignee_test "dependabotb-is-human" \
+  "" '{"assignees": [], "author": {"login": "dependabotb"}}' "0" "assign:dependabotb"
+
 # --- Summary ---
 
 echo ""

--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -27,6 +27,7 @@
 #
 # Optional environment variables:
 #   PUSH_TOKEN_SOURCE — "github-app" (for logging; default: unknown)
+#   TRIGGER_SOURCE    — GitHub username that triggered /fs-code (empty for label triggers)
 #   CODE_ALLOWED_TARGET_BRANCHES
 #                     — comma-separated list of branches the agent may target,
 #                       or "*" for any. When unset, only the repo's default
@@ -42,6 +43,96 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
+# ---------------------------------------------------------------------------
+# Helper: human GitHub user detection (for PR assignee resolution)
+# ---------------------------------------------------------------------------
+is_human_github_user() {
+  local login="${1:-}"
+  if [[ -z "${login}" ]]; then
+    return 1
+  fi
+  case "${login}" in
+    app/*|dependabot) return 1 ;;
+  esac
+  if [[ "${login}" =~ \[bot\]$ ]]; then
+    return 1
+  fi
+  return 0
+}
+
+# Resolve a human assignee for the PR using precedence:
+#   1. TRIGGER_SOURCE (/fs-code invoker) when human
+#   2. First human issue assignee
+#   3. Human issue author
+# Prints the login on stdout, or nothing when no human matches.
+resolve_pr_assignee() {
+  if is_human_github_user "${TRIGGER_SOURCE:-}"; then
+    echo "${TRIGGER_SOURCE}"
+    return 0
+  fi
+
+  local issue_json
+  issue_json="$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO_FULL_NAME}" \
+    --json assignees,author 2>/dev/null || true)"
+  if [[ -z "${issue_json}" ]]; then
+    return 1
+  fi
+
+  local human_assignee
+  human_assignee="$(echo "${issue_json}" | jq -r '
+    [.assignees[].login | select(
+      (startswith("app/") | not) and
+      (test("\\[bot\\]$") | not) and
+      (. != "dependabot")
+    )] | .[0] // empty
+  ')"
+  if [[ -n "${human_assignee}" ]]; then
+    echo "${human_assignee}"
+    return 0
+  fi
+
+  local author_login
+  author_login="$(echo "${issue_json}" | jq -r '.author.login // empty')"
+  if is_human_github_user "${author_login}"; then
+    echo "${author_login}"
+    return 0
+  fi
+
+  return 1
+}
+
+# Best-effort PR assignee: skip when the PR already has assignees.
+maybe_assign_pr() {
+  local pr_number="$1"
+  local existing_count
+  if ! existing_count="$(gh pr view "${pr_number}" --repo "${REPO_FULL_NAME}" \
+    --json assignees --jq '.assignees | length' 2>/dev/null)"; then
+    echo "::warning::Could not read assignees for PR #${pr_number} — skipping assignment"
+    return 0
+  fi
+  if [[ "${existing_count}" != "0" ]]; then
+    echo "PR #${pr_number} already has assignees — skipping assignment"
+    return 0
+  fi
+
+  local assignee
+  assignee="$(resolve_pr_assignee || true)"
+  if [[ -z "${assignee}" ]]; then
+    echo "No human assignee candidate — leaving PR #${pr_number} unassigned"
+    return 0
+  fi
+
+  echo "Assigning PR #${pr_number} to ${assignee}..."
+  local assign_err
+  assign_err="$(gh pr edit "${pr_number}" --repo "${REPO_FULL_NAME}" \
+    --add-assignee "${assignee}" 2>&1)" || {
+    echo "::warning::Failed to assign PR #${pr_number} to ${assignee} — continuing"
+    if [[ -n "${assign_err}" ]]; then
+      echo "::warning::${assign_err}"
+    fi
+  }
+}
 
 # ---------------------------------------------------------------------------
 # Setup
@@ -435,6 +526,7 @@ if [ -n "${EXISTING_PR_NUM}" ]; then
   echo "PR #${EXISTING_PR_NUM} already exists — branch updated with new commits"
   echo "PR: ${EXISTING_PR_URL}"
   echo "pr_url=${EXISTING_PR_URL}" >> "${GITHUB_OUTPUT:-/dev/null}"
+  maybe_assign_pr "${EXISTING_PR_NUM}"
   exit 0
 fi
 
@@ -516,3 +608,5 @@ gh issue edit "${PR_NUMBER_FROM_URL}" \
   --repo "${REPO_FULL_NAME}" \
   --add-label "ready-for-review" 2>/dev/null || \
   echo "::warning::Failed to apply ready-for-review label to PR #${PR_NUMBER_FROM_URL}"
+
+maybe_assign_pr "${PR_NUMBER_FROM_URL}"

--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -129,7 +129,8 @@ maybe_assign_pr() {
     --add-assignee "${assignee}" 2>&1)" || {
     echo "::warning::Failed to assign PR #${pr_number} to ${assignee} — continuing"
     if [[ -n "${assign_err}" ]]; then
-      echo "::warning::${assign_err}"
+      # Strip :: sequences so API error text cannot inject workflow commands.
+      echo "::warning::${assign_err//::/ }"
     fi
   }
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -530,7 +530,8 @@ func TestCodeHarnessContent(t *testing.T) {
 	assert.Contains(t, s, "agents/code.md")
 	assert.Contains(t, s, "pre_script")
 	assert.Contains(t, s, "post_script")
-	assert.Contains(t, s, "runner_env")
+	assert.Contains(t, s, "env:")
+	assert.Contains(t, s, "TRIGGER_SOURCE")
 	assert.Contains(t, s, "PUSH_TOKEN")
 }
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -668,7 +668,7 @@ func TestHarnessForgeRunnerEnvMerge(t *testing.T) {
 		},
 		{
 			file:            "code.yaml",
-			topLevelKeys:    []string{"CODE_ALLOWED_TARGET_BRANCHES", "FULLSEND_OUTPUT_SCHEMA", "FULLSEND_OUTPUT_FILE"},
+			topLevelKeys:    []string{"CODE_ALLOWED_TARGET_BRANCHES", "TRIGGER_SOURCE", "FULLSEND_OUTPUT_SCHEMA", "FULLSEND_OUTPUT_FILE"},
 			forgeGithubKeys: []string{"PUSH_TOKEN", "PUSH_TOKEN_SOURCE", "REPO_FULL_NAME", "ISSUE_NUMBER", "REPO_DIR"},
 		},
 		{


### PR DESCRIPTION
## Summary

- After `post-code.sh` creates or updates a PR, best-effort assign it to a human using precedence: `/fs-code` invoker → first human issue assignee → human issue author
- Plumb `TRIGGER_SOURCE` through `/fs-code` dispatch (`dispatch.yml` → `reusable-dispatch.yml` → `reusable-code.yml` → `code.yaml` `runner_env`), mirroring the fix-agent pattern
- Filter bot/GitHub App accounts (`app/*`, `*[bot]`, `dependabot`); skip when the PR already has assignees; log and continue on `gh pr edit` failure

Closes #1880

## Test plan

- [x] `bash internal/scaffold/fullsend-repo/scripts/post-code-test.sh` (assignee resolver cases)
- [x] `go test ./internal/scaffold/... ./internal/harness/... -run 'TestHarnessForgeRunnerEnvMerge|TestWorkflowCallInputAlignment|TestResolveForge_ScaffoldRunnerEnvMerge'`
- [ ] CI green including Codecov


Made with [Cursor](https://cursor.com)