### PR TITLE
test(#2962): canonicalize temp dirs in path-containment tests

### DIFF
--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -642,8 +642,19 @@ func TestResolveAgentSource_NoConfig(t *testing.T) {
 	assert.Empty(t, deps)
 }
 
+// canonTempDir returns t.TempDir() with symlinks resolved, so equality
+// assertions against containedLocalPath's symlink-resolved output hold on
+// hosts where the temp dir sits behind a symlink (e.g. macOS, where /var
+// is a symlink to /private/var).
+func canonTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	return dir
+}
+
 func TestResolveAgentSource_ConfigLocalPath(t *testing.T) {
-	dir := t.TempDir()
+	dir := canonTempDir(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "harness", "custom.yaml"),
@@ -715,7 +726,7 @@ func TestResolveAgentSource_ConfigLocalPathTraversalRejected(t *testing.T) {
 }
 
 func TestContainedLocalPath_Valid(t *testing.T) {
-	dir := t.TempDir()
+	dir := canonTempDir(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "harness", "agent.yaml"), []byte("test"), 0o644))
 	got, err := containedLocalPath(dir, "harness/agent.yaml")
@@ -738,7 +749,7 @@ func TestContainedLocalPath_TraversalRejected(t *testing.T) {
 }
 
 func TestContainedLocalPath_DotSegmentsCleaned(t *testing.T) {
-	dir := t.TempDir()
+	dir := canonTempDir(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "harness", "agent.yaml"), []byte("test"), 0o644))
 	got, err := containedLocalPath(dir, "harness/./agent.yaml")


### PR DESCRIPTION
## Summary
Fixes three `internal/cli` tests that fail on macOS because `containedLocalPath` returns the `filepath.EvalSymlinks`-resolved path while the tests compare against the raw `t.TempDir()` value (`/var` → `/private/var` on macOS). Test-only change; production behavior is unchanged.

## Related Issue
Fixes #2962

## Changes
- Add a `canonTempDir` test helper that resolves `t.TempDir()` through `filepath.EvalSymlinks`
- Use it in `TestResolveAgentSource_ConfigLocalPath`, `TestContainedLocalPath_Valid`, and `TestContainedLocalPath_DotSegmentsCleaned`

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [x] Tests added/updated for new or modified logic

`go test ./internal/cli/` and `go vet ./internal/cli/` pass on macOS (Darwin 25.5.0) and previously failed on a clean checkout of `main`. `go vet -tags e2e ./e2e/...` compiles; live e2e not run.

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it