### PR TITLE
fix(#3036): resolve prepare-sandbox script path for per-repo installs

### DIFF
--- a/.github/actions/setup-gcp/action.yml
+++ b/.github/actions/setup-gcp/action.yml
@@ -8,6 +8,10 @@ inputs:
   gcp_project_id:
     description: 'GCP project ID — passed to google-github-actions/auth so the runner env has GOOGLE_CLOUD_PROJECT'
     required: false
+  fullsend-dir:
+    description: 'Path to fullsend config directory (empty for per-org workspace root layout)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -34,4 +38,6 @@ runs:
 
     - name: Prepare sandbox credentials
       shell: bash
-      run: bash scripts/prepare-sandbox-credentials.sh
+      env:
+        FULLSEND_DIR: ${{ inputs.fullsend-dir }}
+      run: bash "${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/prepare-sandbox-credentials.sh"

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -161,6 +161,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Resolve bot identity
         if: steps.validate.outputs.skipped != 'true'

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -373,6 +373,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -148,6 +148,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:


### PR DESCRIPTION
## Summary

- Add optional `fullsend-dir` input to the `setup-gcp` composite action and resolve `prepare-sandbox-credentials.sh` relative to that directory (`.fullsend/scripts/…` in per-repo mode, `scripts/…` in per-org mode).
- Pass `fullsend-dir` from all six reusable agent workflows, matching the existing Run agent step.

Fixes #3036 — per-repo agent runs were failing at **Setup GCP and prepare credentials** with exit 127 after #3000 moved scaffold scripts under `.fullsend/`.

## Test plan

- [x] `actionlint` passes on changed workflow and action files
- [ ] Behaviour CI on #1982 (or manual per-repo triage run) completes **Setup GCP and prepare credentials** successfully
- [ ] Per-org agent runs unchanged (`fullsend-dir` empty → `scripts/prepare-sandbox-credentials.sh`)


Made with [Cursor](https://cursor.com)