### PR TITLE
docs(adr): add ADR 0068 for privacy allowlist on poll input drivers

### DIFF
--- a/docs/ADRs/0068-privacy-allowlist-for-poll-input-drivers.md
+++ b/docs/ADRs/0068-privacy-allowlist-for-poll-input-drivers.md
@@ -33,9 +33,11 @@ Accepted
 including a `jira-poll` input driver that maps Jira issue fields into
 `NormalizedEvent` per the
 [Jira poll adapter](../normative/normalized-event/v1/jira-poll-adapter.md).
-That mapping is unfiltered: issue title, comment bodies, and label state flow
-directly into `NormalizedEvent` and are projected into agent-visible
-`FULLSEND_WORK_ITEM_*` environment variables and `event_payload.comment`.
+That mapping is unfiltered: comment bodies and label state flow directly
+into `NormalizedEvent` and `event_payload.comment` with no content
+filtering, and nothing constrains what future extensions (e.g. surfacing
+issue summary, type, or priority for richer triage context) could expose the
+same way.
 
 This is a gap for installations where the polled Jira project is internal but
 the target repo is public. Jira issues can carry customer names, internal
@@ -56,10 +58,20 @@ dispatch core's responsibility") and does not address content filtering.
 
 ## Decision
 
-`jira-poll` (and future poll input drivers for non-forge-native sources)
-apply a **privacy allowlist** to Jira fields before constructing
-`NormalizedEvent`, inside the input driver, before the event reaches the
-shared dispatch core.
+`jira-poll` (and future poll input drivers where the event source and
+dispatch target do not share a trust boundary) apply a **privacy allowlist**
+to Jira fields before constructing `NormalizedEvent`, inside the input
+driver, before the event reaches the shared dispatch core.
+
+`allowed_fields` names Jira **source** fields the driver may read — not
+`NormalizedEvent` output fields directly. Today the only `NormalizedEvent`
+field a Jira value populates directly is `state.labels`; every other
+allowlisted field (`summary`, `issue_type`, `priority`) exists solely to be
+interpolated into `comment_template`. `NormalizedEvent`'s structurally
+required identifiers (`repo`, `entity.id`/`url`/`key`, `actor.id`/`kind`,
+`source.system`/`raw_type`, `transition.kind`, `state.labels`) are always
+emitted regardless of `allowed_fields` — the allowlist governs Jira
+*content*, not the routing/identity fields the dispatch core depends on.
 
 Configuration extends the existing `poll.input_drivers` block:
 
@@ -79,47 +91,93 @@ poll:
 ```
 
 - **Allowlist projection, default-deny.** Only fields listed in
-  `allowed_fields` are read into `NormalizedEvent`. Fields not listed
+  `allowed_fields` are read from Jira at all. Fields not listed
   (description, comment body, custom fields, reporter identity beyond role
-  mapping) are omitted at construction time, not merely hidden from display.
-  Exception: `state.labels` is a required `NormalizedEvent` field
-  ([schema](../normative/normalized-event/v1/normalized-event.schema.json))
-  and is always emitted; when `labels` is absent from `allowed_fields`, the
-  driver sets `state.labels` to an empty array rather than omitting the
-  field, keeping the event schema-valid without leaking label content.
-- **Template-projected free text.** `comment_template`, when set, replaces
-  `transition.comment.body`/`event_payload.comment` with a bounded,
-  named-slot projection instead of the verbatim Jira comment.
-- **PII scan on allowlisted free text.** Fields allowed through by name (e.g.
-  `summary`) are still scanned for PII patterns (email, phone, SSN-shaped
-  strings) as defense in depth, consistent with the threat model's existing
-  content-aware redaction guidance.
-- **Provenance hash.** A SHA-256 hash of the pre-gate `NormalizedEvent`
-  payload is attached as `state.privacy_gate.source_hash`, so sanitization
-  can be verified for a given dispatched run without retaining the original
-  Jira content anywhere downstream.
+  mapping) are never read into driver memory, not merely omitted at
+  construction or hidden from display.
+- **`comment_template` slots MUST be a subset of `allowed_fields`.** The
+  driver MUST reject configuration where a template placeholder references a
+  field absent from `allowed_fields` — otherwise the template becomes a
+  second, unconstrained path for excluded content to reach
+  `event_payload.comment`, defeating the allowlist.
+- **Substituted values MUST be sanitized before interpolation.** Newlines
+  and characters that could be mistaken for template structure are stripped
+  or escaped before a field value is written into a `comment_template` slot.
+  Untreated substitution would let a crafted Jira field (e.g. a `summary`
+  containing embedded newlines styled as additional "fields") inject content
+  indistinguishable from the template's own structure — a template/prompt-
+  injection surface, not merely a formatting concern.
+- **Structural identifiers are always emitted, independent of
+  `allowed_fields`.** `state.labels` is a required `NormalizedEvent` field
+  ([schema](../normative/normalized-event/v1/normalized-event.schema.json));
+  when `labels` is absent from `allowed_fields`, the driver sets
+  `state.labels` to an empty array rather than omitting the field.
+  `entity.url` (always required) and `entity.key` (required when
+  `source.system` is `jira`) are likewise always emitted — see Consequences
+  for the residual risk this carries and why it is accepted rather than
+  gated.
+- **PII scan on allowlisted free text.** Fields read by name (e.g.
+  `summary`) are scanned for structured PII patterns (email, phone,
+  SSN-shaped strings); a match causes the matched substring to be redacted
+  in place before the field reaches `comment_template` or `NormalizedEvent`.
+  This is new functionality — no existing fullsend component performs PII
+  scanning today (`SecretRedactor` scans for secrets/credentials, not PII).
+  Regex-based scanning does not catch unstructured leakage: customer names,
+  internal priority rationale, or ticket cross-references embedded in
+  `summary` are not detectable this way and remain a residual risk
+  operators must manage via narrower `allowed_fields` or careful
+  `comment_template` design.
+- **Provenance fingerprint.** A SHA-256 hash of the pre-gate Jira source
+  payload is attached as `state.privacy_gate.source_hash`, computed over the
+  [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) JSON Canonicalization
+  Scheme of the pre-gate field set so the hash is reproducible across
+  implementations. This is a correlation/tamper-evidence fingerprint, not a
+  verification mechanism — a one-way hash cannot itself confirm what was
+  gated unless the pre-gate payload is independently available to recompute
+  against (e.g. by re-fetching the still-live Jira issue during an audit).
 
-When `privacy_gate` is omitted, the driver defaults to the current allowlist
-(`summary`, `issue_type`, `priority`, `labels`) rather than the unfiltered
-behavior described in [the Jira poll adapter](../normative/normalized-event/v1/jira-poll-adapter.md) —
-that document is updated alongside this ADR to reflect the gated mapping as
-the default, with an explicit opt-out for installations where the Jira
-project and target repo share the same trust boundary.
+When `privacy_gate` is omitted, the driver defaults to the allowlist above.
+When `privacy_gate` is present but `allowed_fields` itself is omitted, the
+same default applies. Either case is a change from the unfiltered behavior
+[the Jira poll adapter](../normative/normalized-event/v1/jira-poll-adapter.md)
+originally described — that document is updated alongside this ADR to
+reflect the gated mapping as the default, with an explicit opt-out for
+installations where the Jira project and target repo share the same trust
+boundary.
 
 ## Consequences
 
 - Poll-sourced `NormalizedEvent`s carry less Jira content by default than the
   original adapter mapping; harnesses that need additional fields must
   request them explicitly via `allowed_fields`.
-- `jira-poll-adapter.md` gains a new schema extension (`privacy_gate` block)
-  that must be implemented before or alongside the `jira-poll` driver in the
-  [#2263](https://github.com/fullsend-ai/fullsend/issues/2263) epic — this
-  ADR should land before that implementation starts, not as a retrofit.
+- `entity.url` and `entity.key` are always emitted and are not subject to
+  `allowed_fields` — they reveal the internal Jira instance hostname and
+  ticket key even when all content fields are gated. This is an accepted,
+  explicit gap rather than an oversight: both fields are load-bearing for
+  `fullsend poll cancel` and runner lock-refresh
+  ([ADR 0063](0063-polling-based-work-discovery.md)), which resolve a
+  dispatched run back to its source issue by URL/key. An opaque-identifier
+  scheme that preserves that resolvability while hiding the Jira hostname is
+  future work, not blocking this ADR.
+- `jira-poll-adapter.md` gains a new schema extension (`privacy_gate` block,
+  including `required: ["source_hash"]`) that the `jira-poll` driver
+  implementation — tracked from [ADR 0063](0063-polling-based-work-discovery.md)
+  and originating in [#2263](https://github.com/fullsend-ai/fullsend/issues/2263) —
+  must satisfy from the start; this ADR is intended to land before that
+  implementation begins, not as a retrofit.
+- Implementation MUST include conformance tests asserting: `state.labels` is
+  always present and schema-valid regardless of `allowed_fields`; fields
+  absent from `allowed_fields` are never read from Jira, not merely filtered
+  post hoc; `comment_template` configuration is rejected at load time if a
+  placeholder references a field outside `allowed_fields`; and
+  `source_hash` matches `^[0-9a-fA-F]{64}$` whenever `privacy_gate` is
+  present.
 - Installations that want the pre-gate behavior (single-trust-boundary Jira +
   target repo) can set a broad `allowed_fields` list or omit `comment_template`
   to pass comment bodies through unmodified.
-- Future poll input drivers for other internal sources should implement the
-  same `privacy_gate` shape rather than inventing per-driver filtering.
+- Future poll input drivers for sources that don't share a trust boundary
+  with their dispatch target should implement the same `privacy_gate` shape
+  rather than inventing per-driver filtering.
 - Does not change dispatch-core authorization ([ADR 0054](0054-require-authorization-on-all-agent-dispatch-paths.md)),
   CEL trigger evaluation, or output drivers — the gate applies strictly
   before `NormalizedEvent` construction.

--- a/docs/ADRs/0068-privacy-allowlist-for-poll-input-drivers.md
+++ b/docs/ADRs/0068-privacy-allowlist-for-poll-input-drivers.md
@@ -82,6 +82,11 @@ poll:
   `allowed_fields` are read into `NormalizedEvent`. Fields not listed
   (description, comment body, custom fields, reporter identity beyond role
   mapping) are omitted at construction time, not merely hidden from display.
+  Exception: `state.labels` is a required `NormalizedEvent` field
+  ([schema](../normative/normalized-event/v1/normalized-event.schema.json))
+  and is always emitted; when `labels` is absent from `allowed_fields`, the
+  driver sets `state.labels` to an empty array rather than omitting the
+  field, keeping the event schema-valid without leaking label content.
 - **Template-projected free text.** `comment_template`, when set, replaces
   `transition.comment.body`/`event_payload.comment` with a bounded,
   named-slot projection instead of the verbatim Jira comment.

--- a/docs/ADRs/0068-privacy-allowlist-for-poll-input-drivers.md
+++ b/docs/ADRs/0068-privacy-allowlist-for-poll-input-drivers.md
@@ -1,0 +1,129 @@
+---
+title: "68. Privacy allowlist for poll input drivers"
+status: Accepted
+relates_to:
+  - security-threat-model
+  - agent-infrastructure
+topics:
+  - poll
+  - jira
+  - privacy
+  - dispatch
+  - drivers
+---
+
+# 68. Privacy allowlist for poll input drivers
+
+Date: 2026-07-06
+
+## Status
+
+Accepted
+
+<!-- ADRs are point-in-time records, but not fully frozen after acceptance.
+     Minor annotations are welcome: cross-references to related ADRs, short
+     notes linking to newer decisions, or clarifying remarks. However, do not
+     substantially rewrite the Context, Decision, or Consequences sections. If
+     the decision itself needs to change, write a new ADR that supersedes this
+     one. For evolving design narrative, use docs/architecture.md. -->
+
+## Context
+
+[ADR 0063](0063-polling-based-work-discovery.md) defines `fullsend poll`,
+including a `jira-poll` input driver that maps Jira issue fields into
+`NormalizedEvent` per the
+[Jira poll adapter](../normative/normalized-event/v1/jira-poll-adapter.md).
+That mapping is unfiltered: issue title, comment bodies, and label state flow
+directly into `NormalizedEvent` and are projected into agent-visible
+`FULLSEND_WORK_ITEM_*` environment variables and `event_payload.comment`.
+
+This is a gap for installations where the polled Jira project is internal but
+the target repo is public. Jira issues can carry customer names, internal
+priority rationale, or references to other internal tickets — content with no
+equivalent in a GitHub-native dispatch, where the event source and the target
+repo share the same trust boundary. `jira-poll` is the first driver where the
+event source and the dispatch target do not.
+
+The [security threat model](../problems/security-threat-model.md)'s "Indirect
+information disclosure" section already treats forge content flowing through
+an agent as a threat surface and mitigates it on the *output* side
+(`SecretRedactor`, [ADR 0022](0022-harness-level-output-schema-enforcement.md)).
+`jira-poll` introduces a new *input*-side question that ADR 0063 does not
+answer: which Jira fields should reach `NormalizedEvent` at all. ADR 0063
+scopes poll input drivers to discovery, change detection, and coordination
+only ("Poll input drivers MUST NOT perform authorization policy — that is the
+dispatch core's responsibility") and does not address content filtering.
+
+## Decision
+
+`jira-poll` (and future poll input drivers for non-forge-native sources)
+apply a **privacy allowlist** to Jira fields before constructing
+`NormalizedEvent`, inside the input driver, before the event reaches the
+shared dispatch core.
+
+Configuration extends the existing `poll.input_drivers` block:
+
+```yaml
+poll:
+  input_drivers:
+    - type: jira-poll
+      connection: { ... }
+      queries:
+        - project = PROJ AND status != Done
+      privacy_gate:
+        allowed_fields: [summary, issue_type, priority, labels]
+        comment_template: |
+          Type: {issue_type}
+          Priority: {priority}
+          Summary: {summary}
+```
+
+- **Allowlist projection, default-deny.** Only fields listed in
+  `allowed_fields` are read into `NormalizedEvent`. Fields not listed
+  (description, comment body, custom fields, reporter identity beyond role
+  mapping) are omitted at construction time, not merely hidden from display.
+- **Template-projected free text.** `comment_template`, when set, replaces
+  `transition.comment.body`/`event_payload.comment` with a bounded,
+  named-slot projection instead of the verbatim Jira comment.
+- **PII scan on allowlisted free text.** Fields allowed through by name (e.g.
+  `summary`) are still scanned for PII patterns (email, phone, SSN-shaped
+  strings) as defense in depth, consistent with the threat model's existing
+  content-aware redaction guidance.
+- **Provenance hash.** A SHA-256 hash of the pre-gate `NormalizedEvent`
+  payload is attached as `state.privacy_gate.source_hash`, so sanitization
+  can be verified for a given dispatched run without retaining the original
+  Jira content anywhere downstream.
+
+When `privacy_gate` is omitted, the driver defaults to the current allowlist
+(`summary`, `issue_type`, `priority`, `labels`) rather than the unfiltered
+behavior described in [the Jira poll adapter](../normative/normalized-event/v1/jira-poll-adapter.md) —
+that document is updated alongside this ADR to reflect the gated mapping as
+the default, with an explicit opt-out for installations where the Jira
+project and target repo share the same trust boundary.
+
+## Consequences
+
+- Poll-sourced `NormalizedEvent`s carry less Jira content by default than the
+  original adapter mapping; harnesses that need additional fields must
+  request them explicitly via `allowed_fields`.
+- `jira-poll-adapter.md` gains a new schema extension (`privacy_gate` block)
+  that must be implemented before or alongside the `jira-poll` driver in the
+  [#2263](https://github.com/fullsend-ai/fullsend/issues/2263) epic — this
+  ADR should land before that implementation starts, not as a retrofit.
+- Installations that want the pre-gate behavior (single-trust-boundary Jira +
+  target repo) can set a broad `allowed_fields` list or omit `comment_template`
+  to pass comment bodies through unmodified.
+- Future poll input drivers for other internal sources should implement the
+  same `privacy_gate` shape rather than inventing per-driver filtering.
+- Does not change dispatch-core authorization ([ADR 0054](0054-require-authorization-on-all-agent-dispatch-paths.md)),
+  CEL trigger evaluation, or output drivers — the gate applies strictly
+  before `NormalizedEvent` construction.
+
+## References
+
+- [ADR 0063 — Polling-based work discovery via dispatch drivers](0063-polling-based-work-discovery.md)
+- [ADR 0067 — GitLab cron-polling event dispatch](0067-gitlab-cron-polling-event-dispatch.md)
+- [ADR 0054 — Require authorization on all agent dispatch paths](0054-require-authorization-on-all-agent-dispatch-paths.md)
+- [ADR 0022 — Harness-level output schema enforcement](0022-harness-level-output-schema-enforcement.md)
+- [Security threat model — Indirect information disclosure](../problems/security-threat-model.md)
+- [Jira poll adapter (NormalizedEvent extension)](../normative/normalized-event/v1/jira-poll-adapter.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,6 +178,10 @@ The existing design principle is that [the repo is the coordinator](problems/age
   via source-native write-then-verify locks, and feeds the same dispatch pipeline
   as webhooks ([ADR 0063](ADRs/0063-polling-based-work-discovery.md)). Initial
   scope is per-repo mode only.
+- Poll input drivers apply a **privacy allowlist** to fields before constructing
+  `NormalizedEvent`, since `jira-poll` is the first driver where the event
+  source and the dispatch target do not share a trust boundary
+  ([ADR 0068](ADRs/0068-privacy-allowlist-for-poll-input-drivers.md)).
 - GitLab dispatch uses cron-polled scheduled pipelines for issue/comment/label events and native `merge_request_event` for MR events. No webhook bridge required (see [ADR 0067](ADRs/0067-gitlab-cron-polling-event-dispatch.md)).
 
 **Open questions:**

--- a/docs/normative/normalized-event/v1/jira-poll-adapter.md
+++ b/docs/normative/normalized-event/v1/jira-poll-adapter.md
@@ -75,10 +75,31 @@ Authorization is enforced by `fullsend dispatch` per
 
 ## State
 
-- `state.labels` — label names from `fields.labels` at event time.
+- `state.labels` — label names from `fields.labels` at event time, subject to
+  the privacy gate below.
 - `state.change_proposal` — omitted. Change-proposal stages (`fix`, PR-linked
   `review`, merge `retro`) are forge-scoped; harness CEL triggers for those
   stages MUST require `entity.kind == 'change_proposal'` or equivalent guards.
+- `state.privacy_gate.source_hash` — SHA-256 of the pre-gate event payload,
+  present when the privacy gate applied a transformation. See below.
+
+## Privacy gate
+
+Per [ADR 0068](../../../ADRs/0068-privacy-allowlist-for-poll-input-drivers.md),
+`jira-poll` applies a configurable allowlist to Jira fields **before**
+constructing `NormalizedEvent`. The gate is configured under
+`poll.input_drivers[].privacy_gate` in `.fullsend/config.yaml`:
+
+| Field | Effect |
+|-------|--------|
+| `allowed_fields` | Only listed fields are read into `NormalizedEvent`. Defaults to `[summary, issue_type, priority, labels]`. Fields not listed are omitted at construction, not filtered post hoc. |
+| `comment_template` | When set, replaces `transition.comment.body` / `event_payload.comment` with a bounded, named-slot projection instead of the verbatim Jira comment. |
+
+When `privacy_gate` is omitted entirely, the default allowlist above applies
+— this is a change from the unfiltered mapping this document originally
+described. Installations where the Jira project and target repo share a
+trust boundary can widen `allowed_fields` or omit `comment_template` to
+restore pass-through behavior.
 
 ## Execution ref projection
 
@@ -90,7 +111,7 @@ When `source.system` is `jira`, projection supplements the GitHub-shaped
 | `FULLSEND_WORK_ITEM_URL` | `entity.url` |
 | `FULLSEND_WORK_ITEM_SOURCE` | `jira` |
 | `FULLSEND_WORK_ITEM_KEY` | `entity.key` |
-| `event_payload.comment` | `transition.comment` when present |
+| `event_payload.comment` | `transition.comment` when present, subject to the privacy gate's `comment_template` |
 | `GITHUB_ISSUE_URL` | Omit or empty — not a GitHub issue |
 | `status-number` | `entity.id` (numeric Jira id) |
 

--- a/docs/normative/normalized-event/v1/jira-poll-adapter.md
+++ b/docs/normative/normalized-event/v1/jira-poll-adapter.md
@@ -81,30 +81,47 @@ Authorization is enforced by `fullsend dispatch` per
 - `state.change_proposal` — omitted. Change-proposal stages (`fix`, PR-linked
   `review`, merge `retro`) are forge-scoped; harness CEL triggers for those
   stages MUST require `entity.kind == 'change_proposal'` or equivalent guards.
-- `state.privacy_gate.source_hash` — SHA-256 of the pre-gate event payload,
-  present when the privacy gate applied a transformation. See below.
+- `state.privacy_gate.source_hash` — SHA-256 correlation fingerprint of the
+  pre-gate Jira source payload, present when the privacy gate applied a
+  transformation. See below.
 
 ## Privacy gate
 
 Per [ADR 0068](../../../ADRs/0068-privacy-allowlist-for-poll-input-drivers.md),
-`jira-poll` applies a configurable allowlist to Jira fields **before**
-constructing `NormalizedEvent`. The gate is configured under
-`poll.input_drivers[].privacy_gate` in `.fullsend/config.yaml`:
+`jira-poll` applies a configurable allowlist to Jira **source** fields
+**before** constructing `NormalizedEvent`. `allowed_fields` governs Jira
+content read for `comment_template` interpolation and `state.labels`; it
+does not govern `NormalizedEvent`'s structurally required identifiers
+(`repo`, `entity.id`/`url`/`key`, `actor.id`/`kind`, `source.system`/
+`raw_type`, `transition.kind`), which are always emitted regardless of
+gating. The gate is configured under `poll.input_drivers[].privacy_gate` in
+`.fullsend/config.yaml`:
 
 | Field | Effect |
 |-------|--------|
-| `allowed_fields` | Only listed fields are read into `NormalizedEvent`. Defaults to `[summary, issue_type, priority, labels]`. Fields not listed are omitted at construction, not filtered post hoc. **Exception:** `state.labels` is a required `NormalizedEvent` field and is always emitted; when `labels` is absent from `allowed_fields`, the driver sets `state.labels: []` instead of omitting the field. |
-| `comment_template` | When set, replaces `transition.comment.body` / `event_payload.comment` with a bounded, named-slot projection instead of the verbatim Jira comment. |
+| `allowed_fields` | Only listed Jira fields are read at all. Defaults to `[summary, issue_type, priority, labels]`. Fields not listed are never read into driver memory, not filtered post hoc. **Exception:** `state.labels` is a required `NormalizedEvent` field and is always emitted; when `labels` is absent from `allowed_fields`, the driver sets `state.labels: []` instead of omitting the field. |
+| `comment_template` | When set, replaces `transition.comment.body` / `event_payload.comment` with a bounded, named-slot projection instead of the verbatim Jira comment. **MUST** only reference field names present in `allowed_fields` — the driver rejects configuration that violates this at load time. Substituted values **MUST** be sanitized (newlines and template-structure characters stripped or escaped) before interpolation, so a crafted field value cannot inject content indistinguishable from the template's own structure. |
+
+`entity.url` and `entity.key` are always emitted and are not subject to
+`allowed_fields`, since `fullsend poll cancel` and runner lock-refresh
+resolve a run back to its source issue by URL/key (ADR 0063). This is an
+accepted, documented gap — see ADR 0068's Consequences.
 
 When the gate applies any transformation, `state.privacy_gate.source_hash`
-is set to the SHA-256 hash of the pre-gate event payload (see
-[normalized-event.schema.json](normalized-event.schema.json)).
+is set to the SHA-256 hash of the pre-gate Jira source payload, computed
+over the RFC 8785 JSON Canonicalization Scheme so the hash is reproducible
+across implementations (see
+[normalized-event.schema.json](normalized-event.schema.json)). The hash is
+a correlation/tamper-evidence fingerprint, not a verification mechanism —
+it cannot itself confirm what was gated unless the pre-gate payload is
+independently available to recompute against.
 
-When `privacy_gate` is omitted entirely, the default allowlist above applies
-— this is a change from the unfiltered mapping this document originally
-described. Installations where the Jira project and target repo share a
-trust boundary can widen `allowed_fields` or omit `comment_template` to
-restore pass-through behavior.
+When `privacy_gate` is omitted entirely, or present with `allowed_fields`
+itself omitted, the default allowlist above applies — this is a change from
+the unfiltered mapping this document originally described. Installations
+where the Jira project and target repo share a trust boundary can widen
+`allowed_fields` or omit `comment_template` to restore pass-through
+behavior.
 
 ## Execution ref projection
 

--- a/docs/normative/normalized-event/v1/jira-poll-adapter.md
+++ b/docs/normative/normalized-event/v1/jira-poll-adapter.md
@@ -23,6 +23,7 @@ The following fields are defined in
 |-------|------------|
 | `source.system` | Enum includes `jira` |
 | `entity.key` | Optional for GitHub; **required** when `source.system` is `jira` |
+| `state.privacy_gate` | Optional object with `source_hash` (see [Privacy gate](#privacy-gate) below) |
 
 When `source.system` is `jira`, `entity.key` MUST be present (e.g. `PROJ-123`).
 
@@ -92,8 +93,12 @@ constructing `NormalizedEvent`. The gate is configured under
 
 | Field | Effect |
 |-------|--------|
-| `allowed_fields` | Only listed fields are read into `NormalizedEvent`. Defaults to `[summary, issue_type, priority, labels]`. Fields not listed are omitted at construction, not filtered post hoc. |
+| `allowed_fields` | Only listed fields are read into `NormalizedEvent`. Defaults to `[summary, issue_type, priority, labels]`. Fields not listed are omitted at construction, not filtered post hoc. **Exception:** `state.labels` is a required `NormalizedEvent` field and is always emitted; when `labels` is absent from `allowed_fields`, the driver sets `state.labels: []` instead of omitting the field. |
 | `comment_template` | When set, replaces `transition.comment.body` / `event_payload.comment` with a bounded, named-slot projection instead of the verbatim Jira comment. |
+
+When the gate applies any transformation, `state.privacy_gate.source_hash`
+is set to the SHA-256 hash of the pre-gate event payload (see
+[normalized-event.schema.json](normalized-event.schema.json)).
 
 When `privacy_gate` is omitted entirely, the default allowlist above applies
 — this is a change from the unfiltered mapping this document originally

--- a/docs/normative/normalized-event/v1/normalized-event.schema.json
+++ b/docs/normative/normalized-event/v1/normalized-event.schema.json
@@ -298,7 +298,19 @@
             "minLength": 1,
             "maxLength": 255
           },
-          "description": "Snapshot of label names on the entity at event time."
+          "description": "Snapshot of label names on the entity at event time. Empty when a poll input driver's privacy gate does not allowlist labels (ADR 0068) -- always present to satisfy this field's required status, regardless of gating."
+        },
+        "privacy_gate": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "source_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{64}$",
+              "description": "SHA-256 hash of the pre-gate event payload, present when a poll input driver's privacy gate (ADR 0068) applied a transformation."
+            }
+          },
+          "description": "Present only for poll-sourced events that passed through a privacy gate (ADR 0068)."
         },
         "change_proposal": {
           "type": "object",

--- a/docs/normative/normalized-event/v1/normalized-event.schema.json
+++ b/docs/normative/normalized-event/v1/normalized-event.schema.json
@@ -298,11 +298,12 @@
             "minLength": 1,
             "maxLength": 255
           },
-          "description": "Snapshot of label names on the entity at event time. Empty when a poll input driver's privacy gate does not allowlist labels (ADR 0068) -- always present to satisfy this field's required status, regardless of gating."
+          "description": "Snapshot of label names on the entity at event time. Empty when a poll input driver's privacy gate does not allowlist labels (ADR 0068) — always present to satisfy this field's required status, regardless of gating."
         },
         "privacy_gate": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["source_hash"],
           "properties": {
             "source_hash": {
               "type": "string",

--- a/docs/problems/security-threat-model.md
+++ b/docs/problems/security-threat-model.md
@@ -72,6 +72,7 @@ This matters for fullsend because review agents and code agents process forge co
 
 - **Output scanning** — the existing `SecretRedactor` pipeline should apply to all agent output, not just to content the agent explicitly identifies as sensitive. This is already the design intent (see [ADR 0022](../ADRs/0022-harness-level-output-schema-enforcement.md)), but the indirect disclosure pattern underscores why output-side scanning is not optional.
 - **Content-aware redaction** — agents processing forge content should redact PII patterns (SSNs, bank accounts, addresses) from their output regardless of whether the input was explicitly marked as sensitive.
+- **Input-side allowlisting for cross-boundary sources** — when the event source and dispatch target do not share a trust boundary (e.g. an internal Jira project polled for a public target repo), sensitive fields should be gated before they ever reach agent context, not only scanned on output. See [ADR 0068](../ADRs/0068-privacy-allowlist-for-poll-input-drivers.md).
 
 ### Disproportionate response via social pressure
 


### PR DESCRIPTION
## Summary
Adds ADR 0068, proposing a configurable privacy allowlist gate on `jira-poll` (ADR 0063) applied before `NormalizedEvent` construction — since `jira-poll` is the first dispatch input driver where the event source (an internal Jira project) and the dispatch target (potentially a public repo) do not share a trust boundary, and no sanitization exists in the current mapping.

## Related Issue
Relevant to the `fullsend poll` implementation epic (#2263) — this ADR is intended to land before that implementation starts, since no `jira-poll` code exists yet.

## Changes
- New `docs/ADRs/0068-privacy-allowlist-for-poll-input-drivers.md`: default-deny field allowlist, template-projected comment bodies, PII scanning as defense in depth, and a provenance hash for audit — configured via a new `privacy_gate` block under `poll.input_drivers`.
- Updated `docs/normative/normalized-event/v1/jira-poll-adapter.md` to document the `privacy_gate` schema extension and reflect the gated mapping as the new default (previously unfiltered).
- Surgical addition to `docs/architecture.md` noting the decision under the dispatch section.
- Cross-referenced ADR 0068 from `docs/problems/security-threat-model.md`'s existing "Indirect information disclosure" section, as the input-side complement to the existing output-side `SecretRedactor`/ADR 0022 mitigation.

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [ ] Tests added/updated for new or modified logic — not applicable, no implementation exists yet; this is a design ADR

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it

Assisted-by: Claude