### PR TITLE
fix(#4718): wire GH_TOKEN and re-add fail-fast validation for pre-code/pre-fix

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -160,6 +160,7 @@ jobs:
           REPO_FULL_NAME: ${{ inputs.source_repo }}
           GITHUB_ISSUE_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
           COMMENT_BODY: ${{ fromJSON(inputs.event_payload).comment.body }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           FULLSEND_DIR: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
         run: bash "${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/pre-code.sh"
 

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -373,6 +373,7 @@ jobs:
           TRIGGER_SOURCE: ${{ inputs.trigger_source }}
           FIX_ITERATION: ${{ steps.context.outputs.iteration }}
           HUMAN_INSTRUCTION: ${{ steps.context.outputs.instruction }}
+          FIX_SKIP_TOOL_INSTALL: "true"
           FULLSEND_DIR: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
         run: bash "${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/pre-fix.sh"
 


### PR DESCRIPTION
## Summary
Companion PR to fullsend-ai/agents#175. That PR adds `CODE_SKIP_EXISTING_PR_CHECK` and `FIX_SKIP_TOOL_INSTALL` flags to `pre-code.sh`/`pre-fix.sh` and `harness/code.yaml` so the harness `pre_script` invocation (inside `fullsend run`) can skip the work these workflows' inline pre-run steps already did, instead of repeating it. This PR is the fullsend-ai/fullsend half — the two only work together.

## Related Issue
Fixes #4718

## Changes
- `.github/workflows/reusable-code.yml` — pass `GH_TOKEN` to the inline `Validate inputs` step. It never had one, so `pre-code.sh`'s existing-human-PR check (GH API search, `pr-open` label, skip comment) was silently a no-op there — the harness invocation was the only place it ever ran. Once `CODE_SKIP_EXISTING_PR_CHECK` is set on that harness invocation (fullsend-ai/agents#175), the check needs to actually work on this side, or the feature runs nowhere at all. (Caught by `fullsend-ai-review[bot]` on the original #4762.)
- `.github/workflows/reusable-fix.yml` — re-add a lightweight inline `Validate inputs` step with `FIX_SKIP_TOOL_INSTALL=true`, so `PR_NUMBER`/instruction/iteration-cap validation still fails fast before GCP/agent-env setup, without re-running the pre-commit tool auto-install that only the harness invocation needs.

## Testing
- [x] `make lint` passes (staged changes)
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)

## History
This supersedes #4762, which edited `internal/scaffold/fullsend-repo/{harness,scripts}/*` directly — those moved to fullsend-ai/agents and no longer affect runtime behavior (per discussion on #4762 with @rh-hemartin). This PR carries forward only the parts that still belong in this repo.