### PR TITLE
feat(#5161): analyze-transcript audit subcommand, telemetry detection, HTTP filtering

### DIFF
--- a/skills/analyze-transcript/SKILL.md
+++ b/skills/analyze-transcript/SKILL.md
@@ -6,6 +6,14 @@ description: >
   debug failures, check tool usage, or search transcript content.
   Handles downloading artifacts, finding JSONL files, and running
   the analyzer script.
+allowed-tools:
+  - Bash(gh run view *)
+  - Bash(gh run download *)
+  - Bash(mkdir -p .transcripts/*)
+  - Bash(mkdir -p ".transcripts/*")
+  - Bash(find .transcripts/run-*)
+  - Bash(find ".transcripts/run-*")
+  - Bash(python3 *analyze-transcript.py *)
 ---
 
 # Analyze Agent Transcript
@@ -17,6 +25,26 @@ Download and analyze fullsend agent JSONL transcripts from GitHub Actions runs.
 - `gh` CLI authenticated with access to the target repository
 - Python 3.8+
 
+## Rules
+
+- **Never auto-dispatch subagents.** Try `search`, `errors`, or
+  `conversation --lines` first. Only _suggest_ a subagent if targeted
+  commands aren't enough — never spawn one silently.
+- **Always use relative paths.** Pass `.transcripts/run-<id>/...` to the
+  script, not absolute paths. Absolute paths trigger permission prompts.
+- **No shell variables.** Never assign paths to variables or export them.
+  No `DLDIR=...`, `TRANSCRIPT=...`, `SANDBOX_LOG=...`, `BASE_DIR=...`,
+  `export ...`. Inline the literal path in every command. This applies to
+  the download dir, transcript paths, sandbox log paths, and the script
+  path. Variables cause commands to drift from the allowed-tools patterns
+  and trigger unnecessary permission prompts.
+- **Limit output.** Use `| head -N`, `| tail -N`, or `--lines` to keep
+  transcript output short. Never dump a full conversation into the main
+  context.
+- **Plain `find` only.** Never use `-exec`, `-ls`, or `-printf` with
+  `find`. Use `find ... -print` (the default). If you need file sizes,
+  run `ls -lh` on the directory instead.
+
 ## Script location
 
 The analyzer script lives alongside this skill:
@@ -25,8 +53,23 @@ The analyzer script lives alongside this skill:
 skills/analyze-transcript/analyze-transcript.py
 ```
 
-Resolve the absolute path from the skill's base directory. If this skill was
-loaded from a base directory, the script is at `<base-dir>/analyze-transcript.py`.
+Resolve the path from the skill's base directory. If this skill was loaded
+from a base directory, the script is at `<base-dir>/analyze-transcript.py`.
+
+## Question routing
+
+Route the user's question to the right subcommand before reaching for full
+conversation output:
+
+| User asks about | Start with |
+|---|---|
+| network / POST / REST / blocked / denied | `network`, `netsearch` |
+| error / failed / broke / crash | `errors` |
+| why / decided / reasoning | `search "<keyword>"`, then `conversation --lines` around hits |
+| what changed / commit / diff | `search "git diff"`, `search "git commit"` |
+| how long / duration / timeout | `summary` |
+| token / cost | `summary` |
+| everything / full picture | `audit` |
 
 ## Workflow
 
@@ -50,9 +93,8 @@ If still running, tell the user and offer to watch it.
 ### 3. Download artifacts
 
 ```bash
-DLDIR=".transcripts/run-<run-id>"
-mkdir -p "$DLDIR"
-gh run download <run-id> --repo OWNER/REPO --dir "$DLDIR"
+mkdir -p .transcripts/run-<run-id>
+gh run download <run-id> --repo OWNER/REPO --dir .transcripts/run-<run-id>
 ```
 
 The `.transcripts/` directory is gitignored. Using the working directory avoids
@@ -63,7 +105,7 @@ permission prompts for `/tmp` writes.
 Downloaded artifacts have this structure:
 
 ```
-<DLDIR>/fullsend-<agent>/
+.transcripts/run-<run-id>/fullsend-<agent>/
   agent-<type>-<id>/
     logs/
       openshell-sandbox.log    # OCSF network/process/sandbox events
@@ -77,23 +119,50 @@ Downloaded artifacts have this structure:
 Find transcripts and logs:
 
 ```bash
-find "$DLDIR" -name "*.jsonl" -type f
-find "$DLDIR" -name "openshell-sandbox.log" -type f
+find .transcripts/run-<run-id> -name "*.jsonl" -type f -print
+find .transcripts/run-<run-id> -name "openshell-sandbox.log" -type f -print
 ```
 
-List files with sizes. Each JSONL file is one agent session (main agent or
-subagent). The sandbox log contains all OCSF network events for the run.
+Each JSONL file is one agent session (main agent or subagent). The sandbox
+log contains all OCSF network events for the run. If you need file sizes,
+use `ls -lh` on the directory.
 
-### 5. Run summary on each transcript
+### 5. No transcript found?
 
+If `find` returns no `.jsonl` transcript files, the run likely failed before
+the agent started (security scan, infra failure, OPA denial). Fall back to:
+
+1. Check for non-transcript files in the artifact dir:
+   - `run-summary.json` — structured run metadata
+   - `run-telemetry.jsonl` — OTLP telemetry (not a Claude transcript)
+2. Check sandbox logs for early failures:
+   ```bash
+   python3 <base-dir>/analyze-transcript.py netsearch "DENIED" <sandbox-log>
+   ```
+3. Pull GitHub Actions logs directly:
+   ```bash
+   gh run view <run-id> --repo OWNER/REPO --log-failed
+   ```
+
+**Do not confuse `run-telemetry.jsonl` with Claude transcripts.** Telemetry
+files contain OTLP spans, not conversation messages. The script will detect
+this and warn you.
+
+### 6. Run analysis
+
+**Quick audit (summary + errors + tools in one shot):**
+```bash
+python3 <base-dir>/analyze-transcript.py audit <path-to-jsonl>
+```
+
+**Summary only:**
 ```bash
 python3 <base-dir>/analyze-transcript.py summary <path-to-jsonl>
 ```
-
-This gives: agent type, model, duration, message count, token usage, tool call
+Shows: agent type, model, duration, message count, token usage, tool call
 breakdown, and stop reasons.
 
-### 6. Deeper analysis based on user questions
+### 7. Deeper analysis based on user questions
 
 Use the appropriate subcommand:
 
@@ -105,10 +174,9 @@ Shows assistant text, tool calls, and results with line numbers. Use
 `| head -N` for the start or `| tail -N` for the end of large transcripts.
 Use `--max-width 0` for full untruncated output.
 
-**Context window caution:** Transcript output can be very large. When analyzing
-transcripts from within an agent session, dispatch a subagent to run analysis
-commands and summarize findings rather than running them in your main context.
-Use `| head -N` or `--lines` to limit output when running directly.
+**Note:** System prompts and pre-conversation context are not included in
+`conversation` output. If the user asks "why did the agent do X", search for
+decision-relevant keywords first, then show surrounding conversation lines.
 
 **Tool usage breakdown:**
 ```bash
@@ -137,7 +205,7 @@ python3 <base-dir>/analyze-transcript.py conversation <path> --lines 50-100
 python3 <base-dir>/analyze-transcript.py summary <path> --json
 ```
 
-### 7. Sandbox network analysis
+### 8. Sandbox network analysis
 
 The `openshell-sandbox.log` contains OCSF events for all network connections,
 HTTP requests, process launches, and policy decisions made inside the sandbox.
@@ -155,6 +223,14 @@ python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http
 ```
 Appends a chronological list of every HTTP request with relative timestamps.
 
+**Filter HTTP requests by method or host:**
+```bash
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --method POST
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --method POST,PUT,PATCH,DELETE
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --host github.com
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --method POST,PUT,PATCH --host github.com
+```
+
 **Search network logs:**
 ```bash
 python3 <base-dir>/analyze-transcript.py network-search "DENIED" <sandbox-log>
@@ -162,6 +238,15 @@ python3 <base-dir>/analyze-transcript.py netsearch "github" <sandbox-log>
 ```
 Regex search across all OCSF event lines. Matches against raw log text,
 destination hosts, and HTTP URLs.
+
+## Full audit workflow
+
+When the user wants the full picture, run this sequence:
+
+1. `audit <transcript>` — summary + errors + tools in one pass
+2. `network <sandbox-log>` — denied connections, hosts, policies
+3. `conversation <transcript> | head -80` — how the run started
+4. `conversation <transcript> | tail -50` — how the run ended
 
 ## Common analysis patterns
 
@@ -185,6 +270,8 @@ destination hosts, and HTTP URLs.
   by frequency. Add `--http` for the full request log.
 - **Which OPA policy allowed/denied traffic?** `network` shows policy hit
   counts. `netsearch "policy:<name>"` filters to a specific policy.
+- **Did the agent make write requests to GitHub?** Filter POST/PUT/PATCH to
+  github.com: `network <sandbox-log> --http --method POST,PUT,PATCH --host github.com`
 
 ## Notes
 

--- a/skills/analyze-transcript/SKILL.md
+++ b/skills/analyze-transcript/SKILL.md
@@ -6,6 +6,7 @@ description: >
   debug failures, check tool usage, or search transcript content.
   Handles downloading artifacts, finding JSONL files, and running
   the analyzer script.
+allowed-tools: Bash(gh run view:*), Bash(mkdir -p .transcripts/*), Bash(find .transcripts/run-*), Bash(ls -lh .transcripts/*), Bash(python3 skills/analyze-transcript/analyze-transcript.py:*)
 ---
 
 # Analyze Agent Transcript
@@ -17,6 +18,26 @@ Download and analyze fullsend agent JSONL transcripts from GitHub Actions runs.
 - `gh` CLI authenticated with access to the target repository
 - Python 3.8+
 
+## Rules
+
+- **Never auto-dispatch subagents.** Try `search`, `errors`, or
+  `conversation --lines` first. Only _suggest_ a subagent if targeted
+  commands aren't enough — never spawn one silently.
+- **Always use relative paths.** Pass `.transcripts/run-<id>/...` to the
+  script, not absolute paths. Absolute paths trigger permission prompts.
+- **No shell variables.** Never assign paths to variables or export them.
+  No `DLDIR=...`, `TRANSCRIPT=...`, `SANDBOX_LOG=...`, `BASE_DIR=...`,
+  `export ...`. Inline the literal path in every command. This applies to
+  the download dir, transcript paths, sandbox log paths, and the script
+  path. Variables cause commands to drift from the allowed-tools patterns
+  and trigger unnecessary permission prompts.
+- **Limit output.** Use `| head -N`, `| tail -N`, or `--lines` to keep
+  transcript output short. Never dump a full conversation into the main
+  context.
+- **Plain `find` only.** Never use `-exec`, `-ls`, or `-printf` with
+  `find`. Use `find ... -print` (the default). If you need file sizes,
+  run `ls -lh` on the directory instead.
+
 ## Script location
 
 The analyzer script lives alongside this skill:
@@ -25,8 +46,23 @@ The analyzer script lives alongside this skill:
 skills/analyze-transcript/analyze-transcript.py
 ```
 
-Resolve the absolute path from the skill's base directory. If this skill was
-loaded from a base directory, the script is at `<base-dir>/analyze-transcript.py`.
+Resolve the path from the skill's base directory. If this skill was loaded
+from a base directory, the script is at `<base-dir>/analyze-transcript.py`.
+
+## Question routing
+
+Route the user's question to the right subcommand before reaching for full
+conversation output:
+
+| User asks about | Start with |
+|---|---|
+| network / POST / REST / blocked / denied | `network`, `netsearch` |
+| error / failed / broke / crash | `errors` |
+| why / decided / reasoning | `search "<keyword>"`, then `conversation --lines` around hits |
+| what changed / commit / diff | `search "git diff"`, `search "git commit"` |
+| how long / duration / timeout | `summary` |
+| token / cost | `summary` |
+| everything / full picture | `audit` |
 
 ## Workflow
 
@@ -50,9 +86,8 @@ If still running, tell the user and offer to watch it.
 ### 3. Download artifacts
 
 ```bash
-DLDIR=".transcripts/run-<run-id>"
-mkdir -p "$DLDIR"
-gh run download <run-id> --repo OWNER/REPO --dir "$DLDIR"
+mkdir -p .transcripts/run-<run-id>
+gh run download <run-id> --repo OWNER/REPO --dir .transcripts/run-<run-id>
 ```
 
 The `.transcripts/` directory is gitignored. Using the working directory avoids
@@ -63,7 +98,7 @@ permission prompts for `/tmp` writes.
 Downloaded artifacts have this structure:
 
 ```
-<DLDIR>/fullsend-<agent>/
+.transcripts/run-<run-id>/fullsend-<agent>/
   agent-<type>-<id>/
     logs/
       openshell-sandbox.log    # OCSF network/process/sandbox events
@@ -77,23 +112,50 @@ Downloaded artifacts have this structure:
 Find transcripts and logs:
 
 ```bash
-find "$DLDIR" -name "*.jsonl" -type f
-find "$DLDIR" -name "openshell-sandbox.log" -type f
+find .transcripts/run-<run-id> -name "*.jsonl" -type f -print
+find .transcripts/run-<run-id> -name "openshell-sandbox.log" -type f -print
 ```
 
-List files with sizes. Each JSONL file is one agent session (main agent or
-subagent). The sandbox log contains all OCSF network events for the run.
+Each JSONL file is one agent session (main agent or subagent). The sandbox
+log contains all OCSF network events for the run. If you need file sizes,
+use `ls -lh` on the directory.
 
-### 5. Run summary on each transcript
+### 5. No transcript found?
 
+If `find` returns no `.jsonl` transcript files, the run likely failed before
+the agent started (security scan, infra failure, OPA denial). Fall back to:
+
+1. Check for non-transcript files in the artifact dir:
+   - `run-summary.json` — structured run metadata
+   - `run-telemetry.jsonl` — OTLP telemetry (not a Claude transcript)
+2. Check sandbox logs for early failures:
+   ```bash
+   python3 <base-dir>/analyze-transcript.py netsearch "DENIED" <sandbox-log>
+   ```
+3. Pull GitHub Actions logs directly:
+   ```bash
+   gh run view <run-id> --repo OWNER/REPO --log-failed
+   ```
+
+**Do not confuse `run-telemetry.jsonl` with Claude transcripts.** Telemetry
+files contain OTLP spans, not conversation messages. The script will detect
+this and warn you.
+
+### 6. Run analysis
+
+**Quick audit (summary + errors + tools in one shot):**
+```bash
+python3 <base-dir>/analyze-transcript.py audit <path-to-jsonl>
+```
+
+**Summary only:**
 ```bash
 python3 <base-dir>/analyze-transcript.py summary <path-to-jsonl>
 ```
-
-This gives: agent type, model, duration, message count, token usage, tool call
+Shows: agent type, model, duration, message count, token usage, tool call
 breakdown, and stop reasons.
 
-### 6. Deeper analysis based on user questions
+### 7. Deeper analysis based on user questions
 
 Use the appropriate subcommand:
 
@@ -105,10 +167,9 @@ Shows assistant text, tool calls, and results with line numbers. Use
 `| head -N` for the start or `| tail -N` for the end of large transcripts.
 Use `--max-width 0` for full untruncated output.
 
-**Context window caution:** Transcript output can be very large. When analyzing
-transcripts from within an agent session, dispatch a subagent to run analysis
-commands and summarize findings rather than running them in your main context.
-Use `| head -N` or `--lines` to limit output when running directly.
+**Note:** System prompts and pre-conversation context are not included in
+`conversation` output. If the user asks "why did the agent do X", search for
+decision-relevant keywords first, then show surrounding conversation lines.
 
 **Tool usage breakdown:**
 ```bash
@@ -137,7 +198,7 @@ python3 <base-dir>/analyze-transcript.py conversation <path> --lines 50-100
 python3 <base-dir>/analyze-transcript.py summary <path> --json
 ```
 
-### 7. Sandbox network analysis
+### 8. Sandbox network analysis
 
 The `openshell-sandbox.log` contains OCSF events for all network connections,
 HTTP requests, process launches, and policy decisions made inside the sandbox.
@@ -155,6 +216,14 @@ python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http
 ```
 Appends a chronological list of every HTTP request with relative timestamps.
 
+**Filter HTTP requests by method or host:**
+```bash
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --method POST
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --method POST,PUT,PATCH,DELETE
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --host github.com
+python3 <base-dir>/analyze-transcript.py network <sandbox-log> --http --method POST,PUT,PATCH --host github.com
+```
+
 **Search network logs:**
 ```bash
 python3 <base-dir>/analyze-transcript.py network-search "DENIED" <sandbox-log>
@@ -162,6 +231,15 @@ python3 <base-dir>/analyze-transcript.py netsearch "github" <sandbox-log>
 ```
 Regex search across all OCSF event lines. Matches against raw log text,
 destination hosts, and HTTP URLs.
+
+## Full audit workflow
+
+When the user wants the full picture, run this sequence:
+
+1. `audit <transcript>` — summary + errors + tools in one pass
+2. `network <sandbox-log>` — denied connections, hosts, policies
+3. `conversation <transcript> | head -80` — how the run started
+4. `conversation <transcript> | tail -50` — how the run ended
 
 ## Common analysis patterns
 
@@ -185,6 +263,8 @@ destination hosts, and HTTP URLs.
   by frequency. Add `--http` for the full request log.
 - **Which OPA policy allowed/denied traffic?** `network` shows policy hit
   counts. `netsearch "policy:<name>"` filters to a specific policy.
+- **Did the agent make write requests to GitHub?** Filter POST/PUT/PATCH to
+  github.com: `network <sandbox-log> --http --method POST,PUT,PATCH --host github.com`
 
 ## Notes
 

--- a/skills/analyze-transcript/analyze-transcript.py
+++ b/skills/analyze-transcript/analyze-transcript.py
@@ -9,6 +9,7 @@ import sys
 from collections import Counter
 from datetime import datetime
 from typing import TypedDict
+from urllib.parse import urlsplit
 
 # Prevent BrokenPipeError when output is piped through head/tail.
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
@@ -19,7 +20,7 @@ def parse_lines(path, line_range=None):
     if path == "-":
         yield from _parse_source(sys.stdin, line_range)
     else:
-        with open(path) as f:
+        with open(path, errors="replace") as f:
             yield from _parse_source(f, line_range)
 
 
@@ -35,9 +36,12 @@ def _parse_source(source, line_range):
         if not raw:
             continue
         try:
-            yield i, json.loads(raw)
+            obj = json.loads(raw)
         except json.JSONDecodeError:
             continue
+        if not isinstance(obj, dict):
+            continue
+        yield i, obj
 
 
 def parse_line_range(spec):
@@ -89,6 +93,38 @@ def get_tool_result_text(block):
     return ""
 
 
+def detect_file_type(path):
+    """Check first few lines to detect file type. Returns None if it looks like
+    a valid transcript, or a warning string if it's something else."""
+    if path == "-":
+        return None
+    try:
+        with open(path) as f:
+            for _ in range(5):
+                line = f.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if "resourceSpans" in obj or "scopeSpans" in obj:
+                    return (
+                        "This looks like OTLP telemetry data, not a Claude transcript. "
+                        "Look for a file named <agent>-<session-id>.jsonl instead."
+                    )
+                if obj.get("type") in ("assistant", "user", "agent-setting"):
+                    return None
+    except (OSError, UnicodeDecodeError):
+        pass
+    return None
+
+
 def iter_messages(path, line_range=None):
     """Yield (line_num, role, msg_obj, raw_obj) for message-type lines."""
     for i, obj in parse_lines(path, line_range):
@@ -108,7 +144,15 @@ def iter_messages(path, line_range=None):
 # --- Subcommands ---
 
 
-def cmd_summary(args):
+def _check_file_type(path):
+    warning = detect_file_type(path)
+    if warning:
+        print(f"Warning: {warning}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _accumulate_stats(path, line_range=None, messages=None):
+    """Single-pass accumulation of model/session/token/duration/tool/stop-reason stats."""
     models = set()
     session_ids = set()
     timestamps = []
@@ -121,7 +165,8 @@ def cmd_summary(args):
     stop_reasons = Counter()
     agent_setting = None
 
-    for _i, role, msg, raw in iter_messages(args.file, args.line_range):
+    source = messages if messages is not None else iter_messages(path, line_range)
+    for _i, role, msg, raw in source:
         if role == "meta":
             if raw.get("type") == "agent-setting":
                 agent_setting = raw.get("agentSetting")
@@ -153,9 +198,9 @@ def cmd_summary(args):
             if sr:
                 stop_reasons[sr] += 1
 
-            for btype, block in extract_content_blocks(msg):
-                if btype == "tool_use":
-                    tool_counts[block.get("name", "unknown")] += 1
+        for btype, block in extract_content_blocks(msg):
+            if role == "assistant" and btype == "tool_use":
+                tool_counts[block.get("name", "unknown")] += 1
 
     duration = None
     if len(timestamps) >= 2:
@@ -167,11 +212,11 @@ def cmd_summary(args):
         except (ValueError, TypeError):
             pass
 
-    result = {
+    return {
         "agent": agent_setting,
         "session_ids": sorted(session_ids),
         "models": sorted(models),
-        "messages": dict(msg_counts),
+        "messages": msg_counts,
         "tokens": {
             "input": total_input_tokens,
             "output": total_output_tokens,
@@ -179,38 +224,58 @@ def cmd_summary(args):
             "cache_create": total_cache_create,
         },
         "duration_seconds": duration,
-        "tool_calls": dict(tool_counts.most_common()),
-        "stop_reasons": dict(stop_reasons),
+        "tool_calls": tool_counts,
+        "stop_reasons": stop_reasons,
     }
 
-    if args.json_output:
-        print(json.dumps(result, indent=2))
-        return
 
-    print(f"Agent:      {agent_setting or 'unknown'}")
-    print(f"Session:    {', '.join(session_ids) or 'unknown'}")
-    print(f"Model:      {', '.join(models) or 'unknown'}")
+def _print_stats(s):
+    """Print the shared summary section from an _accumulate_stats result."""
+    print(f"Agent:      {s['agent'] or 'unknown'}")
+    print(f"Session:    {', '.join(s['session_ids']) or 'unknown'}")
+    print(f"Model:      {', '.join(s['models']) or 'unknown'}")
+    duration = s["duration_seconds"]
     if duration is not None:
         mins, secs = divmod(duration, 60)
         print(f"Duration:   {int(mins)}m {secs:.1f}s")
+    msg_counts = s["messages"]
     msg_parts = ", ".join(f"{v} {k}" for k, v in msg_counts.items())
     print(f"Messages:   {sum(msg_counts.values())} ({msg_parts})")
+    t = s["tokens"]
     print(
-        f"Tokens:     {total_input_tokens} in / "
-        f"{total_output_tokens} out / "
-        f"{total_cache_read} cache-read / "
-        f"{total_cache_create} cache-create"
+        f"Tokens:     {t['input']} in / "
+        f"{t['output']} out / "
+        f"{t['cache_read']} cache-read / "
+        f"{t['cache_create']} cache-create"
     )
-    print()
+    tool_counts = s["tool_calls"]
     if tool_counts:
+        print()
         print("Tool calls:")
         for name, count in tool_counts.most_common():
             print(f"  {name:30s} {count}")
+    stop_reasons = s["stop_reasons"]
     if stop_reasons:
         print(f"\nStop reasons: {', '.join(f'{k}={v}' for k, v in stop_reasons.items())}")
 
 
+def cmd_summary(args):
+    _check_file_type(args.file)
+    s = _accumulate_stats(args.file, args.line_range)
+
+    if args.json_output:
+        out = dict(s)
+        out["messages"] = dict(out["messages"])
+        out["tool_calls"] = dict(out["tool_calls"].most_common())
+        out["stop_reasons"] = dict(out["stop_reasons"])
+        print(json.dumps(out, indent=2))
+        return
+
+    _print_stats(s)
+
+
 def cmd_conversation(args):
+    _check_file_type(args.file)
     max_w = args.max_width
 
     for i, role, msg, _raw in iter_messages(args.file, args.line_range):
@@ -250,6 +315,7 @@ class ToolStats(TypedDict):
 
 
 def cmd_tools(args):
+    _check_file_type(args.file)
     tool_data: dict[str, ToolStats] = {}
 
     for i, role, msg, _raw in iter_messages(args.file, args.line_range):
@@ -281,33 +347,46 @@ def cmd_tools(args):
         print(f"{name:<30s} {data['count']:>5d}  {lines_str}")
 
 
-def cmd_errors(args):
-    max_w = args.max_width
+_ASSISTANT_ERROR_KEYWORDS = ["api error", "permission denied", "eacces", "fatal error"]
+
+
+def _check_block_error(role, btype, block, line, max_w, errors, mentions):
+    """Classify a single content block and append to errors/mentions if applicable."""
+    if btype == "tool_result":
+        if _is_error_result(block):
+            text = get_tool_result_text(block)
+            errors.append((line, truncate(text.strip(), max_w)))
+        else:
+            text = get_tool_result_text(block)
+            if _RESULT_ERROR_PATTERNS.search(text):
+                errors.append((line, truncate(text.strip(), max_w)))
+    elif role == "user" and btype == "text":
+        text = block if isinstance(block, str) else block.get("text", "")
+        if "<error>" in text:
+            errors.append((line, truncate(text.strip(), max_w)))
+    elif role == "assistant" and btype == "text":
+        text = block if isinstance(block, str) else block.get("text", "")
+        lower = text.lower()
+        if any(kw in lower for kw in _ASSISTANT_ERROR_KEYWORDS):
+            mentions.append((line, truncate(text.strip(), max_w)))
+
+
+def _collect_errors(file, max_w, line_range=None, messages=None):
+    """Shared error collection used by cmd_errors."""
     errors = []
     mentions = []
 
-    for i, role, msg, _raw in iter_messages(args.file, args.line_range):
+    source = messages if messages is not None else iter_messages(file, line_range)
+    for i, role, msg, _raw in source:
         for btype, block in extract_content_blocks(msg):
-            if btype == "tool_result":
-                if _is_error_result(block):
-                    text = get_tool_result_text(block)
-                    errors.append((i, truncate(text.strip(), max_w)))
-                else:
-                    text = get_tool_result_text(block)
-                    if _RESULT_ERROR_PATTERNS.search(text):
-                        errors.append((i, truncate(text.strip(), max_w)))
-            elif role == "user" and btype == "text":
-                text = block if isinstance(block, str) else block.get("text", "")
-                if "<error>" in text:
-                    errors.append((i, truncate(text.strip(), max_w)))
-            elif role == "assistant" and btype == "text":
-                text = block if isinstance(block, str) else block.get("text", "")
-                lower = text.lower()
-                if any(
-                    kw in lower
-                    for kw in ["api error", "permission denied", "eacces", "fatal error"]
-                ):
-                    mentions.append((i, truncate(text.strip(), max_w)))
+            _check_block_error(role, btype, block, i, max_w, errors, mentions)
+
+    return errors, mentions
+
+
+def cmd_errors(args):
+    _check_file_type(args.file)
+    errors, mentions = _collect_errors(args.file, args.max_width, args.line_range)
 
     if not errors and not mentions:
         print("No errors found.")
@@ -341,7 +420,32 @@ _RESULT_ERROR_PATTERNS = re.compile(
 )
 
 
+def cmd_audit(args):
+    """Combined summary + errors + tool breakdown."""
+    _check_file_type(args.file)
+
+    messages = list(iter_messages(args.file))
+    s = _accumulate_stats(args.file, messages=messages)
+    _print_stats(s)
+
+    errors, mentions = _collect_errors(args.file, args.max_width, messages=messages)
+    if errors or mentions:
+        print()
+        print(f"Errors ({len(errors)}):")
+        for line, text in errors:
+            print(f"  L{line}: {text}")
+        if mentions:
+            print()
+            print(f"Mentions ({len(mentions)}):")
+            for line, text in mentions:
+                print(f"  L{line}: {text}")
+    else:
+        print()
+        print("Errors: none")
+
+
 def cmd_search(args):
+    _check_file_type(args.file)
     pattern = re.compile(args.pattern, re.IGNORECASE)
     max_w = args.max_width
     found = False
@@ -426,6 +530,27 @@ def parse_sandbox_log(path):
             yield entry
 
 
+def _host_matches(candidate, filter_val):
+    """Check if candidate host matches filter_val (exact or parent-domain)."""
+    if not candidate:
+        return False
+    candidate = candidate.lower()
+    return candidate == filter_val or candidate.endswith("." + filter_val)
+
+
+def _match_network_entry(e, method_filter, host_filter):
+    """Return True if an HTTP entry passes the method/host filters."""
+    if not e.get("http_method"):
+        return False
+    if method_filter and e["http_method"].upper() not in method_filter:
+        return False
+    if host_filter and not _host_matches(e.get("host"), host_filter):
+        url_host = urlsplit(e.get("http_url", "")).hostname or ""
+        if not _host_matches(url_host, host_filter):
+            return False
+    return True
+
+
 def cmd_network(args):
     entries = list(parse_sandbox_log(args.file))
 
@@ -433,16 +558,23 @@ def cmd_network(args):
         print("No OCSF events found.")
         return
 
+    method_filter = (
+        {m.strip().upper() for m in args.method.split(",")}
+        if hasattr(args, "method") and args.method
+        else None
+    )
+    host_filter = args.host.lower() if hasattr(args, "host") and args.host else None
+
     if args.json_output:
+        if method_filter or host_filter:
+            entries = [e for e in entries if _match_network_entry(e, method_filter, host_filter)]
         print(json.dumps(entries, indent=2))
         return
 
-    # Compute time span.
     t0 = entries[0]["ts"]
     t1 = entries[-1]["ts"]
     duration = t1 - t0
 
-    # Collect stats.
     event_counts = Counter(e["event"] for e in entries)
     host_counts = Counter()
     denied = []
@@ -455,7 +587,7 @@ def cmd_network(args):
             host_counts[h] += 1
         if e.get("verdict") == "DENIED":
             denied.append(e)
-        if e.get("http_method"):
+        if _match_network_entry(e, method_filter, host_filter):
             http_requests.append(e)
         p = e.get("policy")
         if p and p != "-":
@@ -495,13 +627,21 @@ def cmd_network(args):
         print(f"  {event:20s} {count:>4d}")
 
     if args.http:
+        filter_desc = ""
+        if method_filter:
+            filter_desc += f" [{','.join(sorted(method_filter))}]"
+        if host_filter:
+            filter_desc += f" [host={host_filter}]"
         print()
-        print("HTTP requests:")
+        print(f"HTTP requests{filter_desc}:")
+        if not http_requests:
+            print("  (none matching filters)")
         for e in http_requests:
             ts_rel = e["ts"] - t0
             method = e.get("http_method", "?")
+            host = e.get("host", "?")
             url = e.get("http_url", "?")
-            print(f"  +{ts_rel:7.1f}s  {method:6s} {url}")
+            print(f"  +{ts_rel:7.1f}s  {method:6s} {host}  {url}")
 
 
 def cmd_network_search(args):
@@ -561,6 +701,10 @@ def main():
     p_errors.add_argument("--max-width", type=int, default=400, help=width_help)
     p_errors.add_argument("--lines", dest="line_range_spec", help=lines_help)
 
+    p_audit = sub.add_parser("audit", help="summary + errors + tools in one pass")
+    p_audit.add_argument("file", help="path to .jsonl file (or - for stdin)")
+    p_audit.add_argument("--max-width", type=int, default=400, help=width_help)
+
     p_search = sub.add_parser("search", help="search tool results and text for pattern")
     p_search.add_argument("pattern", help="regex pattern to search for")
     p_search.add_argument("file", help="path to .jsonl file (or - for stdin)")
@@ -571,6 +715,12 @@ def main():
     p_network.add_argument("file", help="path to sandbox .log file")
     p_network.add_argument("--json", dest="json_output", action="store_true", help=json_help)
     p_network.add_argument("--http", action="store_true", help="list individual HTTP requests")
+    p_network.add_argument(
+        "--method", help="filter HTTP requests by method (e.g. POST or POST,PUT,PATCH)"
+    )
+    p_network.add_argument(
+        "--host", help="filter HTTP requests by host (exact or parent domain match)"
+    )
 
     p_netsearch = sub.add_parser(
         "network-search", aliases=["netsearch"], help="search sandbox network logs"
@@ -599,6 +749,7 @@ def main():
         "conv": cmd_conversation,
         "tools": cmd_tools,
         "errors": cmd_errors,
+        "audit": cmd_audit,
         "search": cmd_search,
         "network": cmd_network,
         "net": cmd_network,

--- a/skills/analyze-transcript/analyze-transcript.py
+++ b/skills/analyze-transcript/analyze-transcript.py
@@ -9,6 +9,7 @@ import sys
 from collections import Counter
 from datetime import datetime
 from typing import TypedDict
+from urllib.parse import urlsplit
 
 # Prevent BrokenPipeError when output is piped through head/tail.
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
@@ -19,7 +20,7 @@ def parse_lines(path, line_range=None):
     if path == "-":
         yield from _parse_source(sys.stdin, line_range)
     else:
-        with open(path) as f:
+        with open(path, errors="replace") as f:
             yield from _parse_source(f, line_range)
 
 
@@ -35,9 +36,12 @@ def _parse_source(source, line_range):
         if not raw:
             continue
         try:
-            yield i, json.loads(raw)
+            obj = json.loads(raw)
         except json.JSONDecodeError:
             continue
+        if not isinstance(obj, dict):
+            continue
+        yield i, obj
 
 
 def parse_line_range(spec):
@@ -89,10 +93,56 @@ def get_tool_result_text(block):
     return ""
 
 
+TRANSCRIPT_TYPES = ("assistant", "user", "agent-setting", "queue-operation", "last-prompt")
+
+
+def detect_file_type(path):
+    """Check first few lines to detect file type. Returns None if it looks like
+    a valid transcript, or a warning string if it's something else."""
+    if path == "-":
+        return None
+    examined = 0
+    has_transcript_line = False
+    try:
+        with open(path, errors="replace") as f:
+            while examined < 5:
+                line = f.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    examined += 1
+                    continue
+                examined += 1
+                if not isinstance(obj, dict):
+                    continue
+                if "resourceSpans" in obj or "scopeSpans" in obj:
+                    return (
+                        "This looks like OTLP telemetry data, not a Claude transcript. "
+                        "Look for a file named <agent>-<session-id>.jsonl instead."
+                    )
+                if obj.get("type") in TRANSCRIPT_TYPES:
+                    has_transcript_line = True
+    except OSError as e:
+        return f"Cannot read file: {e}"
+    if not has_transcript_line:
+        return (
+            "No recognizable transcript lines found in the first few lines. "
+            "Expected JSONL with a recognized transcript type."
+        )
+    return None
+
+
 def iter_messages(path, line_range=None):
     """Yield (line_num, role, msg_obj, raw_obj) for message-type lines."""
     for i, obj in parse_lines(path, line_range):
         obj_type = obj.get("type", "")
+        if obj_type not in TRANSCRIPT_TYPES:
+            continue
         if obj_type in ("assistant", "user"):
             msg = obj.get("message", {})
             role = msg.get("role", obj_type)
@@ -108,7 +158,15 @@ def iter_messages(path, line_range=None):
 # --- Subcommands ---
 
 
-def cmd_summary(args):
+def _check_file_type(path):
+    warning = detect_file_type(path)
+    if warning:
+        print(f"Warning: {warning}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _accumulate_stats(path, line_range=None, messages=None):
+    """Single-pass accumulation of model/session/token/duration/tool/stop-reason stats."""
     models = set()
     session_ids = set()
     timestamps = []
@@ -121,7 +179,8 @@ def cmd_summary(args):
     stop_reasons = Counter()
     agent_setting = None
 
-    for _i, role, msg, raw in iter_messages(args.file, args.line_range):
+    source = messages if messages is not None else iter_messages(path, line_range)
+    for _i, role, msg, raw in source:
         if role == "meta":
             if raw.get("type") == "agent-setting":
                 agent_setting = raw.get("agentSetting")
@@ -153,9 +212,9 @@ def cmd_summary(args):
             if sr:
                 stop_reasons[sr] += 1
 
-            for btype, block in extract_content_blocks(msg):
-                if btype == "tool_use":
-                    tool_counts[block.get("name", "unknown")] += 1
+        for btype, block in extract_content_blocks(msg):
+            if role == "assistant" and btype == "tool_use":
+                tool_counts[block.get("name", "unknown")] += 1
 
     duration = None
     if len(timestamps) >= 2:
@@ -167,11 +226,11 @@ def cmd_summary(args):
         except (ValueError, TypeError):
             pass
 
-    result = {
+    return {
         "agent": agent_setting,
         "session_ids": sorted(session_ids),
         "models": sorted(models),
-        "messages": dict(msg_counts),
+        "messages": msg_counts,
         "tokens": {
             "input": total_input_tokens,
             "output": total_output_tokens,
@@ -179,38 +238,59 @@ def cmd_summary(args):
             "cache_create": total_cache_create,
         },
         "duration_seconds": duration,
-        "tool_calls": dict(tool_counts.most_common()),
-        "stop_reasons": dict(stop_reasons),
+        "tool_calls": tool_counts,
+        "stop_reasons": stop_reasons,
     }
 
-    if args.json_output:
-        print(json.dumps(result, indent=2))
-        return
 
-    print(f"Agent:      {agent_setting or 'unknown'}")
-    print(f"Session:    {', '.join(session_ids) or 'unknown'}")
-    print(f"Model:      {', '.join(models) or 'unknown'}")
+def _print_stats(s, skip_tools=False):
+    """Print the shared summary section from an _accumulate_stats result."""
+    print(f"Agent:      {s['agent'] or 'unknown'}")
+    print(f"Session:    {', '.join(s['session_ids']) or 'unknown'}")
+    print(f"Model:      {', '.join(s['models']) or 'unknown'}")
+    duration = s["duration_seconds"]
     if duration is not None:
         mins, secs = divmod(duration, 60)
         print(f"Duration:   {int(mins)}m {secs:.1f}s")
+    msg_counts = s["messages"]
     msg_parts = ", ".join(f"{v} {k}" for k, v in msg_counts.items())
     print(f"Messages:   {sum(msg_counts.values())} ({msg_parts})")
+    t = s["tokens"]
     print(
-        f"Tokens:     {total_input_tokens} in / "
-        f"{total_output_tokens} out / "
-        f"{total_cache_read} cache-read / "
-        f"{total_cache_create} cache-create"
+        f"Tokens:     {t['input']} in / "
+        f"{t['output']} out / "
+        f"{t['cache_read']} cache-read / "
+        f"{t['cache_create']} cache-create"
     )
-    print()
-    if tool_counts:
-        print("Tool calls:")
-        for name, count in tool_counts.most_common():
-            print(f"  {name:30s} {count}")
+    if not skip_tools:
+        tool_counts = s["tool_calls"]
+        if tool_counts:
+            print()
+            print("Tool calls:")
+            for name, count in tool_counts.most_common():
+                print(f"  {name:30s} {count}")
+    stop_reasons = s["stop_reasons"]
     if stop_reasons:
         print(f"\nStop reasons: {', '.join(f'{k}={v}' for k, v in stop_reasons.items())}")
 
 
+def cmd_summary(args):
+    _check_file_type(args.file)
+    s = _accumulate_stats(args.file, args.line_range)
+
+    if args.json_output:
+        out = dict(s)
+        out["messages"] = dict(out["messages"])
+        out["tool_calls"] = dict(out["tool_calls"].most_common())
+        out["stop_reasons"] = dict(out["stop_reasons"])
+        print(json.dumps(out, indent=2))
+        return
+
+    _print_stats(s)
+
+
 def cmd_conversation(args):
+    _check_file_type(args.file)
     max_w = args.max_width
 
     for i, role, msg, _raw in iter_messages(args.file, args.line_range):
@@ -250,6 +330,7 @@ class ToolStats(TypedDict):
 
 
 def cmd_tools(args):
+    _check_file_type(args.file)
     tool_data: dict[str, ToolStats] = {}
 
     for i, role, msg, _raw in iter_messages(args.file, args.line_range):
@@ -281,33 +362,46 @@ def cmd_tools(args):
         print(f"{name:<30s} {data['count']:>5d}  {lines_str}")
 
 
-def cmd_errors(args):
-    max_w = args.max_width
+_ASSISTANT_ERROR_KEYWORDS = ["api error", "permission denied", "eacces", "fatal error"]
+
+
+def _check_block_error(role, btype, block, line, max_w, errors, mentions):
+    """Classify a single content block and append to errors/mentions if applicable."""
+    if btype == "tool_result":
+        if _is_error_result(block):
+            text = get_tool_result_text(block)
+            errors.append((line, truncate(text.strip(), max_w)))
+        else:
+            text = get_tool_result_text(block)
+            if _RESULT_ERROR_PATTERNS.search(text):
+                errors.append((line, truncate(text.strip(), max_w)))
+    elif role == "user" and btype == "text":
+        text = block if isinstance(block, str) else block.get("text", "")
+        if "<error>" in text:
+            errors.append((line, truncate(text.strip(), max_w)))
+    elif role == "assistant" and btype == "text":
+        text = block if isinstance(block, str) else block.get("text", "")
+        lower = text.lower()
+        if any(kw in lower for kw in _ASSISTANT_ERROR_KEYWORDS):
+            mentions.append((line, truncate(text.strip(), max_w)))
+
+
+def _collect_errors(file, max_w, line_range=None, messages=None):
+    """Shared error collection used by cmd_errors."""
     errors = []
     mentions = []
 
-    for i, role, msg, _raw in iter_messages(args.file, args.line_range):
+    source = messages if messages is not None else iter_messages(file, line_range)
+    for i, role, msg, _raw in source:
         for btype, block in extract_content_blocks(msg):
-            if btype == "tool_result":
-                if _is_error_result(block):
-                    text = get_tool_result_text(block)
-                    errors.append((i, truncate(text.strip(), max_w)))
-                else:
-                    text = get_tool_result_text(block)
-                    if _RESULT_ERROR_PATTERNS.search(text):
-                        errors.append((i, truncate(text.strip(), max_w)))
-            elif role == "user" and btype == "text":
-                text = block if isinstance(block, str) else block.get("text", "")
-                if "<error>" in text:
-                    errors.append((i, truncate(text.strip(), max_w)))
-            elif role == "assistant" and btype == "text":
-                text = block if isinstance(block, str) else block.get("text", "")
-                lower = text.lower()
-                if any(
-                    kw in lower
-                    for kw in ["api error", "permission denied", "eacces", "fatal error"]
-                ):
-                    mentions.append((i, truncate(text.strip(), max_w)))
+            _check_block_error(role, btype, block, i, max_w, errors, mentions)
+
+    return errors, mentions
+
+
+def cmd_errors(args):
+    _check_file_type(args.file)
+    errors, mentions = _collect_errors(args.file, args.max_width, args.line_range)
 
     if not errors and not mentions:
         print("No errors found.")
@@ -341,7 +435,56 @@ _RESULT_ERROR_PATTERNS = re.compile(
 )
 
 
+def cmd_audit(args):
+    """Combined summary + errors + tool breakdown with per-call line numbers."""
+    _check_file_type(args.file)
+
+    messages = list(iter_messages(args.file, args.line_range))
+    s = _accumulate_stats(args.file, messages=messages)
+    _print_stats(s, skip_tools=True)
+
+    tool_data: dict[str, ToolStats] = {}
+    for i, role, msg, _raw in messages:
+        if role != "assistant":
+            continue
+        for btype, block in extract_content_blocks(msg):
+            if btype == "tool_use":
+                name = block.get("name", "unknown")
+                if name not in tool_data:
+                    tool_data[name] = {"count": 0, "lines": []}
+                tool_data[name]["count"] += 1
+                tool_data[name]["lines"].append(i)
+
+    if tool_data:
+        print()
+        sorted_tools = sorted(tool_data.items(), key=lambda x: -x[1]["count"])
+        print(f"{'Tool':<30s} {'Count':>5s}  Lines")
+        print("-" * 70)
+        for name, data in sorted_tools:
+            lines_str = ", ".join(str(ln) for ln in data["lines"][:10])
+            if len(data["lines"]) > 10:
+                lines_str += f" ... (+{len(data['lines']) - 10} more)"
+            print(f"{name:<30s} {data['count']:>5d}  {lines_str}")
+
+    errors, mentions = _collect_errors(args.file, args.max_width, messages=messages)
+    if errors or mentions:
+        if errors:
+            print()
+            print(f"Errors ({len(errors)}):")
+            for line, text in errors:
+                print(f"  L{line}: {text}")
+        if mentions:
+            print()
+            print(f"Mentions ({len(mentions)}):")
+            for line, text in mentions:
+                print(f"  L{line}: {text}")
+    else:
+        print()
+        print("Errors: none")
+
+
 def cmd_search(args):
+    _check_file_type(args.file)
     pattern = re.compile(args.pattern, re.IGNORECASE)
     max_w = args.max_width
     found = False
@@ -426,6 +569,33 @@ def parse_sandbox_log(path):
             yield entry
 
 
+def _host_matches(candidate, filter_val):
+    """Check if candidate host matches filter_val (exact or parent-domain)."""
+    if not candidate:
+        return False
+    candidate = candidate.lower()
+    return candidate == filter_val or candidate.endswith("." + filter_val)
+
+
+def _match_host(e, host_filter):
+    """Return True if the entry's host matches the filter (exact or parent-domain)."""
+    if not host_filter:
+        return True
+    if _host_matches(e.get("host", ""), host_filter):
+        return True
+    url_host = urlsplit(e.get("http_url", "")).hostname or ""
+    return _host_matches(url_host, host_filter)
+
+
+def _match_http_entry(e, method_filter, host_filter):
+    """Return True if an HTTP entry passes the method/host filters."""
+    if not e.get("http_method"):
+        return False
+    if method_filter and e["http_method"].upper() not in method_filter:
+        return False
+    return _match_host(e, host_filter)
+
+
 def cmd_network(args):
     entries = list(parse_sandbox_log(args.file))
 
@@ -433,16 +603,34 @@ def cmd_network(args):
         print("No OCSF events found.")
         return
 
+    method_filter = {m.strip().upper() for m in args.method.split(",")} if args.method else None
+    host_filter = args.host.lower() if args.host else None
+
+    explicit_http = args.http
+
+    if method_filter or host_filter:
+        args.http = True
+
     if args.json_output:
+        if method_filter or explicit_http or host_filter:
+            filtered = []
+            for e in entries:
+                if e.get("verdict") == "DENIED":
+                    if _match_host(e, host_filter):
+                        filtered.append(e)
+                elif e.get("http_method"):
+                    if _match_http_entry(e, method_filter, host_filter):
+                        filtered.append(e)
+                elif not explicit_http and not method_filter and _match_host(e, host_filter):
+                    filtered.append(e)
+            entries = filtered
         print(json.dumps(entries, indent=2))
         return
 
-    # Compute time span.
     t0 = entries[0]["ts"]
     t1 = entries[-1]["ts"]
     duration = t1 - t0
 
-    # Collect stats.
     event_counts = Counter(e["event"] for e in entries)
     host_counts = Counter()
     denied = []
@@ -455,7 +643,7 @@ def cmd_network(args):
             host_counts[h] += 1
         if e.get("verdict") == "DENIED":
             denied.append(e)
-        if e.get("http_method"):
+        if _match_http_entry(e, method_filter, host_filter):
             http_requests.append(e)
         p = e.get("policy")
         if p and p != "-":
@@ -495,13 +683,21 @@ def cmd_network(args):
         print(f"  {event:20s} {count:>4d}")
 
     if args.http:
+        filter_desc = ""
+        if method_filter:
+            filter_desc += f" [{','.join(sorted(method_filter))}]"
+        if host_filter:
+            filter_desc += f" [host={host_filter}]"
         print()
-        print("HTTP requests:")
+        print(f"HTTP requests{filter_desc}:")
+        if not http_requests:
+            print("  (none matching filters)")
         for e in http_requests:
             ts_rel = e["ts"] - t0
             method = e.get("http_method", "?")
+            host = e.get("host", "?")
             url = e.get("http_url", "?")
-            print(f"  +{ts_rel:7.1f}s  {method:6s} {url}")
+            print(f"  +{ts_rel:7.1f}s  {method:6s} {host}  {url}")
 
 
 def cmd_network_search(args):
@@ -561,6 +757,11 @@ def main():
     p_errors.add_argument("--max-width", type=int, default=400, help=width_help)
     p_errors.add_argument("--lines", dest="line_range_spec", help=lines_help)
 
+    p_audit = sub.add_parser("audit", help="summary + errors + tools in one pass")
+    p_audit.add_argument("file", help="path to .jsonl file (or - for stdin)")
+    p_audit.add_argument("--max-width", type=int, default=400, help=width_help)
+    p_audit.add_argument("--lines", dest="line_range_spec", help=lines_help)
+
     p_search = sub.add_parser("search", help="search tool results and text for pattern")
     p_search.add_argument("pattern", help="regex pattern to search for")
     p_search.add_argument("file", help="path to .jsonl file (or - for stdin)")
@@ -571,6 +772,12 @@ def main():
     p_network.add_argument("file", help="path to sandbox .log file")
     p_network.add_argument("--json", dest="json_output", action="store_true", help=json_help)
     p_network.add_argument("--http", action="store_true", help="list individual HTTP requests")
+    p_network.add_argument(
+        "--method", help="filter HTTP requests by method (e.g. POST or POST,PUT,PATCH)"
+    )
+    p_network.add_argument(
+        "--host", help="filter HTTP requests by host (exact or parent domain match)"
+    )
 
     p_netsearch = sub.add_parser(
         "network-search", aliases=["netsearch"], help="search sandbox network logs"
@@ -599,6 +806,7 @@ def main():
         "conv": cmd_conversation,
         "tools": cmd_tools,
         "errors": cmd_errors,
+        "audit": cmd_audit,
         "search": cmd_search,
         "network": cmd_network,
         "net": cmd_network,


### PR DESCRIPTION
## Summary

Closes #5161.

- Add `audit` subcommand combining summary + errors + tool breakdown in one pass
- Detect OTLP telemetry files early and exit with a clear warning instead of producing confusing output
- Add `--method` and `--host` filters to `network --http` for targeted HTTP request analysis
- Harden SKILL.md: `allowed-tools` patterns, no-shell-variables rule, question routing table, missing-transcript troubleshooting, full audit workflow docs

## Test plan

- [ ] Run `audit` against a real agent transcript JSONL and verify it outputs summary, tool counts, and errors in one pass
- [ ] Pass a `run-telemetry.jsonl` file to `summary` and verify it exits with a telemetry warning
- [ ] Run `network <sandbox-log> --http --method POST --host github.com` and verify filtering works
- [ ] Invoke the skill via `/analyze-transcript` and confirm no permission prompts for standard commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)