### PR TITLE
ci(e2e): raise behaviour job timeout to 45m

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,7 +182,7 @@ jobs:
       !cancelled() &&
       (github.event_name != 'pull_request_target' || needs.gate.outputs.authorized == 'true')
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ e2e-test:
 	go test -tags e2e -v -count=1 -timeout 30m ./e2e/admin/
 
 behaviour-test:
-	go test -tags behaviour -v -count=1 -timeout 30m ./e2e/behaviour/
+	go test -tags behaviour -v -count=1 -timeout 45m ./e2e/behaviour/
 
 # Functional agent evals — run agents against ephemeral GitHub repos and judge results.
 # Required env: EVAL_ORG (GitHub org for ephemeral repos), plus GCP creds for Vertex AI.


### PR DESCRIPTION
## Summary
- Raises the `behaviour` job `timeout-minutes` (and matching `make behaviour-test` go test timeout) from 30m to 45m on **main**.
- Needed so PRs that add longer behaviour suites (e.g. fullsend-ai/fullsend#5407 URL-dispatch scenarios) can finish under `pull_request_target`, which always uses the workflow definition from `main`.

## Test plan
- [ ] Confirm `e2e` job remains at 30m
- [ ] After merge, re-run ok-to-test on fullsend-ai/fullsend#5407 and confirm behaviour is not killed at 30m


Made with [Cursor](https://cursor.com)