### PR TITLE
ci(e2e): raise behaviour job timeout from 30m to 45m

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -189,7 +189,7 @@ jobs:
       !cancelled() &&
       (github.event_name != 'pull_request_target' || needs.gate.outputs.authorized == 'true')
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ e2e-test:
 	go test -tags e2e -v -count=1 -timeout 30m ./e2e/admin/
 
 behaviour-test:
-	go test -tags behaviour -v -count=1 -timeout 30m ./e2e/behaviour/
+	go test -tags behaviour -v -count=1 -timeout 45m ./e2e/behaviour/
 
 # Functional agent evals — run agents against ephemeral GitHub repos and judge results.
 # Required env: EVAL_ORG (GitHub org for ephemeral repos), plus GCP creds for Vertex AI.


### PR DESCRIPTION
## Summary

- Raise the `behaviour` job `timeout-minutes` from 30 → 45 in `.github/workflows/e2e.yml`
- Raise `make behaviour-test` `go test -timeout` from 30m → 45m in `Makefile`
- Leaves the `e2e` job timeout at 30m unchanged

## Why

The behaviour suite already takes ~29 minutes on a good day on `main`, leaving ~1 minute of margin. Pool latency and non-fast-forward commit retries push runs past 30m with **no assertion failures** — GitHub Actions cancels the job mid-scenario (`The operation was canceled.`).

### Evidence

- Successful main run completing in **1731s (~28.9m)** for 12 scenarios: [actions/runs/29912680247](https://github.com/fullsend-ai/fullsend/actions/runs/29912680247) (`TestBehaviourSuite (1731.65s)`)
- PR #5428 cancelled 4× at ~30m15s with no failed Gherkin steps, e.g. [job 89065249479](https://github.com/fullsend-ai/fullsend/actions/runs/29962082991/job/89065249479)

This blocks #5428: its config encapsulation changes correctly trigger behaviour, but `pull_request_target` loads the workflow from **main**, so a timeout bump on that PR branch cannot take effect until this lands.

## Test plan

- [x] Diff is only the two timeout lines (behaviour job + Makefile)
- [ ] Human approve (`.github/` protected path)
- [ ] After merge, re-run behaviour on #5428