### PR TITLE
ci(#5509): add harness-eval static analysis for agent configurations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,12 @@ jobs:
 
       - run: make lint-all
 
+      - name: Lint agent configurations (harness-eval)
+        run: |
+          pip install -q harness-eval==6.1.1
+          harness-eval lint . --preset recommended --fail-on-error
+          harness-eval lint internal/scaffold/fullsend-repo --preset recommended --fail-on-error
+
       - name: Run Go tests with coverage
         run: go test -race -coverprofile=coverage.out ./...
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,3 +143,28 @@ jobs:
 
       - name: Run svelte-check
         run: npm run check
+
+  harness-eval:
+    # Lint agent configurations with harness-eval (advisory, not required for merge).
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install harness-eval
+        run: pip install -q "harness-eval==7.12.0"
+
+      # harness-gate runs only the validated gating-tier rules (>=97% precision,
+      # zero corpus false positives) and never loads LLM extras. The root baseline
+      # suppresses one pre-existing true positive so the job runs clean today and
+      # flags only new drift; the scaffold is clean and needs no baseline.
+      - name: Gate repo root
+        run: harness-eval harness-gate . --baseline .harness-eval-baseline.json
+
+      - name: Gate scaffold
+        if: always()
+        run: harness-eval harness-gate internal/scaffold/fullsend-repo

--- a/.harness-eval-baseline.json
+++ b/.harness-eval-baseline.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "findings": [
+    {
+      "rule_id": "frontmatter/format-valid",
+      "file": "skills/filing-issues/SKILL.md",
+      "message_hash": "df3375eb05be64c3"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an advisory `harness-eval` CI job that lints agent configuration files using [harness-eval](https://github.com/redhat-community-ai-tools/harness-eval) static analysis.

### What it does

- Adds a `harness-eval` job to the existing `lint.yml` workflow. It is not part of the required `test` job, so findings do not block merge (advisory until the team trusts it).
- Runs `harness-eval harness-gate` against both the repo root (with a baseline) and the scaffold (`internal/scaffold/fullsend-repo`, no baseline).
- `harness-gate` runs only the six validated gating-tier rules (>=97% precision on >=50 re-derived findings, zero corpus false positives) and never loads LLM extras. This is deliberately **not** the 97-rule `recommended` preset: most of those rules are heuristic (judgments about prose) and advisory by design, and they were the source of the earlier false positives that a broad suppression list had to paper over.
- Exits non-zero only on new gating findings beyond the baseline.

Pinned to the tagged PyPI release `harness-eval==7.12.0` (this release also fixes security rules leaking onto generic text files such as CI workflows and shell scripts).

### Baseline

A checked-in `.harness-eval-baseline.json` records known findings so the job runs clean on day one and flags only new drift. Against the gate it contains a single entry, a genuine pre-existing true positive:

- `frontmatter/format-valid` on `skills/filing-issues/SKILL.md` (frontmatter `name` `Filing GitHub Issues` does not match directory `filing-issues`).

The scaffold scan is clean and runs without a baseline. There is no `--exclude` suppression.

### What it does NOT do

- No SARIF upload or inline PR annotations
- No PR comment posting
- Not a required status check
- No LLM / rubric calls (`harness-gate` is pure static analysis, deterministic and offline)

## Related Issue

Closes #5509

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are signed off (DCO)