### PR TITLE
feat(review): add confidence annotation to review verdicts (#5514)

### DIFF
--- a/internal/scaffold/fullsend-repo/schemas/review-result.schema.json
+++ b/internal/scaffold/fullsend-repo/schemas/review-result.schema.json
@@ -26,6 +26,11 @@
     },
     "label_actions": {
       "$ref": "#/$defs/label_actions"
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"],
+      "description": "How confident the review agent is in its verdict. Derived from sub-agent agreement, challenger removals, and verdict threshold proximity."
     }
   },
   "allOf": [

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -777,6 +777,32 @@ challenger-adjudicated finding set and evaluate:
   Use `reject` only when no amount of code-level iteration will make
   the PR mergeable.
 
+#### 6g. Determine confidence level
+
+After the verdict is set, derive a confidence level based on the signals
+available from the sub-agent and challenger passes. Confidence does not
+change the verdict or any routing behavior. It is an informational
+annotation for humans reviewing the agent's output.
+
+**Confidence levels:**
+
+- **high:** all sub-agents agreed on severity for every finding, the
+  challenger removed zero or one findings, and the verdict was not close
+  to a threshold boundary (e.g., no medium findings when the verdict is
+  approve)
+- **medium:** the challenger removed more than one finding (initial
+  disagreement that was resolved), OR sub-agents flagged the same code
+  with different severities, OR the verdict is one finding away from
+  flipping (e.g., one medium finding on an approve verdict)
+- **low:** significant sub-agent disagreement (same code flagged at
+  severities two or more levels apart), OR the challenger failed and
+  the pre-challenger set was used, OR the change scope is ambiguous
+  (e.g., large refactoring PR where correctness is hard to verify)
+
+Include the confidence level in the review result JSON as a top-level
+`confidence` field. This field is optional in the schema; omitting it
+is acceptable if you cannot determine it.
+
 ### 7. Produce the review result
 
 Compose the review comment using this structure:


### PR DESCRIPTION
## Summary

Adds a confidence level (`high`/`medium`/`low`) to the review agent's structured output. This is the minimal first step toward graduated approval, emitting the data without changing any routing or auto-merge behavior.

### What changes

- **pr-review skill (step 6g):** new step after verdict determination that derives confidence from sub-agent agreement, challenger removal rate, and verdict threshold proximity
- **review-result schema:** adds an optional `confidence` field (`high`/`medium`/`low`)

### Confidence derivation

| Level | When |
|-------|------|
| high | all sub-agents agreed, challenger removed 0-1 findings, verdict not near threshold |
| medium | challenger removed >1 finding, OR sub-agents disagreed on severity, OR verdict is one finding from flipping |
| low | severe sub-agent disagreement, OR challenger failed (fallback set used), OR ambiguous change scope |

### What does NOT change

- Dispatch logic, label behavior, verdict thresholds, auto-merge rules
- The field is optional in the schema; omitting it is valid

## Related Issue

Closes #5514

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are signed off (DCO)