### PR TITLE
ci(e2e): raise behaviour job timeout to 45m

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,7 +182,7 @@ jobs:
       !cancelled() &&
       (github.event_name != 'pull_request_target' || needs.gate.outputs.authorized == 'true')
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ e2e-test:
 	go test -tags e2e -v -count=1 -timeout 30m ./e2e/admin/
 
 behaviour-test:
-	go test -tags behaviour -v -count=1 -timeout 30m ./e2e/behaviour/
+	go test -tags behaviour -v -count=1 -timeout 45m ./e2e/behaviour/
 
 # Functional agent evals — run agents against ephemeral GitHub repos and judge results.
 # Required env: EVAL_ORG (GitHub org for ephemeral repos), plus GCP creds for Vertex AI.


### PR DESCRIPTION
## Summary
- Bump E2E Tests `behaviour` job `timeout-minutes` from 30 → 45.
- Align `make behaviour-test` Go `-timeout` to 45m.

## Why
`pull_request_target` workflows load YAML from **base/main**, so a timeout bump inside PR #5498 cannot take effect until it lands on main. Behaviour on #5498 was cancelled at exactly ~30m15s (`timeout-minutes: 30` on main) while still running triage scenarios. Healthy suites already take ~24–29m; headroom is needed after dispatch-window increases (#5506).

## Related
- Unblocks babysit of https://github.com/fullsend-ai/fullsend/pull/5498
- Timeout commit already present on that PR branch; this lands it on main first so CI can use it.

## Test plan
- [ ] Confirm `behaviour` job shows `timeout-minutes: 45` on main after merge
- [ ] Re-run behaviour on #5498 after rebase onto this commit

Made with [Cursor](https://cursor.com)