### PR TITLE
fix(#5188): re-trigger review via label after fix-agent push

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-fix-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix-test.sh
@@ -157,6 +157,276 @@ run_precommit_retry_test "precommit-passes-with-unstaged" \
 run_precommit_retry_test "precommit-retry-passes-but-left-unstaged" \
   "1" "yes" "0" "blocked:retry-left-unstaged" "yes"
 
+# ---------------------------------------------------------------------------
+# Test helper — reimplements the label re-trigger logic from post-fix.sh
+# section 5 (#5188), exercising the actual remove-then-add call sequence
+# against a stubbed `gh` so failures in either call are tolerated exactly as
+# post-fix.sh tolerates them: a failed --remove-label logs a non-fatal
+# ::notice:: (sanitized against :: injection) since it may just mean the
+# label wasn't present, and a failed --add-label warns — neither may ever
+# make the script exit nonzero, since a re-dispatch miss is not worth
+# failing an otherwise-successful fix push over.
+# ---------------------------------------------------------------------------
+perform_relabel_retrigger() {
+  local pr_number="$1" repo="$2"
+  local remove_err
+  remove_err="$(mktemp)"
+  if ! gh pr edit "${pr_number}" --repo "${repo}" \
+       --remove-label "ready-for-review" 2>"${remove_err}"; then
+    local sanitized_err
+    sanitized_err="$(tr -d '\r' < "${remove_err}" | tr '\n' ' ' | sed 's/::/: /g')"
+    sanitized_err="${sanitized_err//%0A/ }"
+    sanitized_err="${sanitized_err//%0a/ }"
+    sanitized_err="${sanitized_err//%0D/ }"
+    sanitized_err="${sanitized_err//%0d/ }"
+    echo "::notice::Could not remove ready-for-review label from PR #${pr_number} (may not have been present): ${sanitized_err}"
+  fi
+  rm -f "${remove_err}"
+  gh pr edit "${pr_number}" --repo "${repo}" \
+    --add-label "ready-for-review" 2>/dev/null || \
+    echo "::warning::Failed to re-apply ready-for-review label to PR #${pr_number} — review will not be re-dispatched"
+}
+
+run_relabel_test() {
+  local test_name="$1" fail_call="$2" expect_warning="$3" expect_notice="${4:-no}"
+
+  # Stub gh: fail whichever call fail_call names, succeed otherwise. Records
+  # the exact invocation (not just substring presence) so a bug in argument
+  # order/values (e.g. pr_number and repo swapped) fails this test, and
+  # emits a poison stderr message on the remove call to verify sanitization.
+  local gh_call_log
+  gh_call_log="$(mktemp)"
+  gh() {
+    echo "$*" >> "${gh_call_log}"
+    if [[ "$*" == *"--remove-label"* ]]; then
+      if [[ "${fail_call}" == "remove" || "${fail_call}" == "both" ]]; then
+        echo "HTTP 500::internal error
+with a newline" >&2
+        return 1
+      fi
+      return 0
+    elif [[ "$*" == *"--add-label"* ]]; then
+      [[ "${fail_call}" == "add" || "${fail_call}" == "both" ]] && return 1
+      return 0
+    fi
+    return 0
+  }
+
+  local output rc
+  output="$(perform_relabel_retrigger "123" "org/repo")"
+  rc=$?
+  unset -f gh
+
+  if [ "${rc}" -ne 0 ]; then
+    echo "FAIL: ${test_name} (exited ${rc} — re-trigger must never hard-fail)"
+    FAILURES=$((FAILURES + 1))
+    rm -f "${gh_call_log}"
+    return
+  fi
+
+  local expected_calls actual_calls
+  expected_calls=$'pr edit 123 --repo org/repo --remove-label ready-for-review\npr edit 123 --repo org/repo --add-label ready-for-review'
+  actual_calls="$(cat "${gh_call_log}")"
+  rm -f "${gh_call_log}"
+  if [ "${actual_calls}" != "${expected_calls}" ]; then
+    echo "FAIL: ${test_name} (unexpected gh invocation)"
+    echo "  expected: ${expected_calls}"
+    echo "  actual:   ${actual_calls}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  local has_warning="no"
+  echo "${output}" | grep -q "::warning::Failed to re-apply" && has_warning="yes"
+  if [ "${has_warning}" != "${expect_warning}" ]; then
+    echo "FAIL: ${test_name}"
+    echo "  expected warning: '${expect_warning}', got: '${has_warning}'"
+    echo "  output: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  local has_notice="no"
+  echo "${output}" | grep -q "::notice::Could not remove ready-for-review label" && has_notice="yes"
+  if [ "${has_notice}" != "${expect_notice}" ]; then
+    echo "FAIL: ${test_name}"
+    echo "  expected notice: '${expect_notice}', got: '${has_notice}'"
+    echo "  output: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  # When the notice fires, the injected "HTTP 500::internal error" plus a
+  # real newline must be sanitized — no bare "::" beyond the recognized
+  # ::notice:: prefix, and no embedded line breaks, since this text is
+  # embedded in a GHA workflow command.
+  if [ "${has_notice}" = "yes" ]; then
+    local notice_line notice_body
+    notice_line="$(echo "${output}" | grep "::notice::Could not remove")"
+    notice_body="${notice_line#*::notice::}"
+    if [[ "${notice_body}" == *"::"* ]]; then
+      echo "FAIL: ${test_name} (unsanitized :: sequence leaked into notice)"
+      echo "  output: ${output}"
+      FAILURES=$((FAILURES + 1))
+      return
+    fi
+
+    # An unsanitized embedded newline would split the injected stderr across
+    # an extra raw output line with no :: prefix. Expect exactly one line
+    # for the notice, plus one more if the add-label warning also fired.
+    local expected_lines=1
+    [ "${expect_warning}" = "yes" ] && expected_lines=2
+    local actual_lines
+    actual_lines="$(echo "${output}" | wc -l)"
+    if [ "${actual_lines}" -ne "${expected_lines}" ]; then
+      echo "FAIL: ${test_name} (embedded newline leaked into notice — expected ${expected_lines} output line(s), got ${actual_lines})"
+      echo "  output: ${output}"
+      FAILURES=$((FAILURES + 1))
+      return
+    fi
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+# --- Label re-trigger test cases ---
+
+# Both calls succeed → no warning, no notice.
+run_relabel_test "relabel-both-succeed" "none" "no" "no"
+
+# Remove fails (e.g. label wasn't present — first fix run on a PR whose
+# label was never applied, or a transient API error) — non-fatal notice,
+# add still runs and succeeds, no warning.
+run_relabel_test "relabel-remove-fails-add-succeeds" "remove" "no" "yes"
+
+# Add fails (e.g. API error, label deleted from repo) — warns, does not fail.
+run_relabel_test "relabel-add-fails" "add" "yes" "no"
+
+# Both fail — notice for the remove, warning for the add, never a hard failure.
+run_relabel_test "relabel-both-fail" "both" "yes" "yes"
+
+# ---------------------------------------------------------------------------
+# Remove-call stderr containing percent-encoded newline/CR escapes (%0A/%0a/
+# %0D/%0d) and a bare CR must be scrubbed just like literal "::" and "\n" —
+# matching the sanitization already used by post-retro.sh,
+# install-precommit-tools.sh, and extract-transcript-error.sh for the same
+# GHA workflow-command injection class.
+# ---------------------------------------------------------------------------
+run_relabel_percent_encoded_sanitization_test() {
+  local test_name="relabel-percent-encoded-and-cr-sanitized"
+
+  gh() {
+    if [[ "$*" == *"--remove-label"* ]]; then
+      printf '%s\r\n' 'HTTP 500%0A::error::spoofed%0D' >&2
+      return 1
+    fi
+    return 0
+  }
+
+  local output
+  output="$(perform_relabel_retrigger "123" "org/repo")"
+  unset -f gh
+
+  local notice_line notice_body
+  notice_line="$(echo "${output}" | grep "::notice::Could not remove")"
+  if [ -z "${notice_line}" ]; then
+    echo "FAIL: ${test_name} (expected a notice, got none)"
+    echo "  output: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  notice_body="${notice_line#*::notice::}"
+
+  if [[ "${notice_body}" == *"::"* ]] || [[ "${notice_body}" == *"%0A"* ]] \
+     || [[ "${notice_body}" == *"%0a"* ]] || [[ "${notice_body}" == *"%0D"* ]] \
+     || [[ "${notice_body}" == *"%0d"* ]]; then
+    echo "FAIL: ${test_name} (unsanitized :: or percent-encoded newline/CR leaked into notice)"
+    echo "  notice: ${notice_body}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if [ "$(echo "${output}" | wc -l)" -ne 1 ]; then
+    echo "FAIL: ${test_name} (embedded bare CR/newline leaked an extra output line)"
+    echo "  output: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+run_relabel_percent_encoded_sanitization_test
+
+# ---------------------------------------------------------------------------
+# Execution-based GH_TOKEN test — the relabel step's gh calls must actually
+# see GH_TOKEN=PUSH_TOKEN at runtime, not merely appear after the export by
+# line position. A prior version of this test only checked line numbers via
+# grep, which stayed green under two confirmed-reproducible mutations that
+# silently break the real fix: commenting out the export, or wrapping it in
+# a `( ... )` subshell (export doesn't propagate out of a subshell, but the
+# line position is unchanged either way). This version extracts the real
+# GH_TOKEN-export-through-relabel region from post-fix.sh and actually runs
+# it in a subprocess with a stubbed `gh` that records what GH_TOKEN was set
+# to at call time — both mutations above change that recorded value (to
+# unset/empty) or make the region fail to extract at all, either of which
+# fails this test.
+# ---------------------------------------------------------------------------
+run_gh_token_execution_test() {
+  local test_name="gh-token-execution"
+  local script_dir post_fix_sh
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  post_fix_sh="${script_dir}/post-fix.sh"
+
+  local snippet
+  snippet="$(sed -n '/^export GH_TOKEN="\${PUSH_TOKEN}"$/,/^# 6\. Process structured output/p' "${post_fix_sh}")"
+
+  if [ -z "${snippet}" ]; then
+    echo "FAIL: ${test_name} (could not extract the GH_TOKEN-export-through-relabel region from post-fix.sh — the export line may have been removed, commented out, or reindented)"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  local harness gh_calls_file
+  harness="$(mktemp)"
+  gh_calls_file="$(mktemp)"
+
+  {
+    echo 'set -euo pipefail'
+    echo 'PR_NUMBER="123"'
+    echo 'REPO_FULL_NAME="org/repo"'
+    echo 'PUSH_TOKEN="sentinel-token-xyz"'
+    echo 'NO_PUSH="false"'
+    echo "gh() { echo \"\${GH_TOKEN:-<unset>}\" >> '${gh_calls_file}'; return 0; }"
+    echo "${snippet}"
+  } > "${harness}"
+
+  bash "${harness}" >/dev/null 2>&1 || true
+  rm -f "${harness}"
+
+  local seen
+  seen="$(cat "${gh_calls_file}")"
+  rm -f "${gh_calls_file}"
+
+  if [ -z "${seen}" ]; then
+    echo "FAIL: ${test_name} (the extracted region never invoked gh — extraction is likely broken)"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  while IFS= read -r token_seen; do
+    if [ "${token_seen}" != "sentinel-token-xyz" ]; then
+      echo "FAIL: ${test_name} (a gh call ran with GH_TOKEN='${token_seen}', expected the exported PUSH_TOKEN — the export is missing, commented out, or scoped to a subshell that doesn't propagate to the relabel calls)"
+      FAILURES=$((FAILURES + 1))
+      return
+    fi
+  done <<< "${seen}"
+
+  echo "PASS: ${test_name}"
+}
+
+run_gh_token_execution_test
+
 # --- Summary ---
 
 echo ""

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -22,9 +22,10 @@
 #   2. Auto-install pre-commit tool deps (from .pre-commit-tools.yaml)
 #   3. Authoritative pre-commit check
 #   4. Push branch
-#   5. Process structured output
-#   6. Iteration-cap warning label
-#   7. Summary
+#   5. Re-trigger review via ready-for-review label
+#   6. Process structured output
+#   7. Iteration-cap warning label
+#   8. Summary
 #
 # After pushing, this script processes fix-result.json to:
 #   - Post a summary comment on the PR documenting fixes and disagreements
@@ -335,10 +336,65 @@ if [ "${NO_PUSH}" = "false" ]; then
   echo "Branch ${BRANCH} pushed successfully"
 fi
 
-# ---------------------------------------------------------------------------
-# 5. Process structured output (fix-result.json)
-# ---------------------------------------------------------------------------
+# GH_TOKEN must be set before any `gh` call in this script — including the
+# relabel step below, not just the fix-result processing that historically
+# needed it. PUSH_TOKEN is a GitHub App installation token (PUSH_TOKEN_SOURCE
+# is "github-app"), not the runner's default GITHUB_TOKEN, so it is exempt
+# from Actions' loop-prevention restriction on triggering new workflow runs.
 export GH_TOKEN="${PUSH_TOKEN}"
+
+# ---------------------------------------------------------------------------
+# 5. Re-trigger review via ready-for-review label (only if we pushed)
+#
+# pull_request_target.synchronize also fires on this push, but its
+# actor-identity check is gated on PR_USER_LOGIN — the PR's original author,
+# which is the code agent's bot account regardless of who triggered this fix
+# run — and GitHub App bots have no collaborator role, so that check always
+# fails closed (#5188). Re-triggering via the label path sidesteps the
+# identity question entirely: label application itself requires write
+# access, so the labeled-event dispatch has no separate actor-authorization
+# gate (see post-code.sh's identical rationale for the PR-open case).
+#
+# GitHub does not fire a new `labeled` webhook event when a label already
+# present is re-added — only a genuine absent-to-present transition fires
+# one — so the label must be removed first to force that transition. This
+# specific remove-then-add sequence (as opposed to post-code.sh's simpler
+# add-when-absent case, which never needed to force a transition) has not
+# been empirically confirmed against a live fix-agent run; watch for the
+# review agent actually re-dispatching after the first production use of
+# this path before considering the fix fully verified.
+#
+# Concurrency note: reusable-fix.yml's fix-agent concurrency group uses
+# cancel-in-progress: true. If a second fix run is dispatched for the same
+# PR while this block is between the remove and add calls, cancellation
+# could leave the label removed with nothing to re-add it. No unlabeled
+# handler exists to recover automatically; the next successful fix push
+# re-adds the label and self-heals. This is a narrow, accepted window, not
+# engineered around here.
+# ---------------------------------------------------------------------------
+if [ "${NO_PUSH}" = "false" ]; then
+  REMOVE_LABEL_ERR="$(mktemp)"
+  if ! gh pr edit "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" \
+       --remove-label "ready-for-review" 2>"${REMOVE_LABEL_ERR}"; then
+    # Expected when the label wasn't present (e.g. a human-authored PR that
+    # never went through post-code.sh); still worth a breadcrumb since an
+    # unexpected API/permission failure looks identical from here.
+    SANITIZED_ERR="$(tr -d '\r' < "${REMOVE_LABEL_ERR}" | tr '\n' ' ' | sed 's/::/: /g')"
+    SANITIZED_ERR="${SANITIZED_ERR//%0A/ }"
+    SANITIZED_ERR="${SANITIZED_ERR//%0a/ }"
+    SANITIZED_ERR="${SANITIZED_ERR//%0D/ }"
+    SANITIZED_ERR="${SANITIZED_ERR//%0d/ }"
+    echo "::notice::Could not remove ready-for-review label from PR #${PR_NUMBER} (may not have been present): ${SANITIZED_ERR}"
+  fi
+  rm -f "${REMOVE_LABEL_ERR}"
+  gh pr edit "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" \
+    --add-label "ready-for-review" 2>/dev/null || \
+    echo "::warning::Failed to re-apply ready-for-review label to PR #${PR_NUMBER} — review will not be re-dispatched"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Process structured output (fix-result.json)
+# ---------------------------------------------------------------------------
 
 # Locate process-fix-result.py relative to this script, with workspace fallback.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -398,7 +454,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Iteration-cap warning label
+# 7. Iteration-cap warning label
 # ---------------------------------------------------------------------------
 ITERATION="${FIX_ITERATION:-1}"
 BOT_CAP="${ITERATION_CAP:-5}"
@@ -417,7 +473,7 @@ if [ "${ITERATION}" -ge "${WARN_THRESHOLD}" ] && is_bot_user "${TRIGGER_SOURCE}"
 fi
 
 # ---------------------------------------------------------------------------
-# 7. Summary
+# 8. Summary
 # ---------------------------------------------------------------------------
 echo ""
 echo "Fix post-script complete:"


### PR DESCRIPTION
## What this fixes

After the fix agent pushes a commit to a PR, the review agent is never re-dispatched (#5188). `pull_request_target.synchronize` fires on that push, but the dispatch routing's actor-identity check is gated on `PR_USER_LOGIN` — the PR's *original* author, which for agent-authored PRs is always the code agent's bot account, regardless of who actually triggered this fix run. GitHub App bots have no collaborator role, so that check always fails closed.

## The fix

`post-fix.sh` now removes then re-adds the `ready-for-review` label after a successful push, forcing a fresh `labeled` webhook event. That path has no actor-authorization gate at all — applying a label already requires write access, so no separate identity check is needed — mirroring `post-code.sh`'s existing handling of the PR-open case. GitHub does not fire a new `labeled` event when a label already present is simply re-added, hence the remove-then-add sequence.

## Why this approach, not identity recognition

This supersedes #5415, which attempted the same fix by extending an actor-identity-recognition function (`is_org_bot()`) across several dispatch-authorization gates. @ifireball closed that approach out during review: it reintroduced a design — recognizing bots by name for dispatch authorization — that issue #2669 had already evaluated and explicitly rejected in favor of label-based gating ("actors can be spoofed and the approach is fragile across workflow changes"). PR #2679 already implemented that decision and shipped it for the retro→triage handoff, closing #2636.

The label-based fix here has some concrete advantages the identity-based approach didn't:
- **No change needed to the CEL-based dispatch path** (`internal/harnessdispatch`) — its `IsAuthorized()` already trusts `label-added` events unconditionally, so this fix is already consistent there with zero Go changes.
- **No forge-specific bot-identity logic** — labels work identically on GitHub and GitLab; GitHub's `[bot]`-suffixed App-login convention has no GitLab equivalent at all, so an identity-matching approach would need an entirely separate mechanism per forge.
- **No new spoofing surface** — nothing here depends on trusting a login string.

#2636 needs no further work — it's already fixed by #2679.

## What's not in this PR

A separate, unrelated bug that #5415 also touched — the fix agent's own review-body content-attribution lookups (in `reusable-fix.yml`, `reusable-dispatch.yml`, and `pre-fetch-prior-review.sh`) missing the shared `fullsend-ai-review[bot]` identity — is tracked independently as #5550 (found by @waynesun09 during #5415's review). It's a content-attribution question ("whose review text do I trust"), not dispatch authorization, so it's unaffected by the labels-vs-identity discussion here and doesn't belong in this PR.

`#5463` and `#5480` (identity-hardening follow-ups filed during #5415's review) are no longer relevant to dispatch authorization now that this PR doesn't use `is_org_bot()` for that purpose; they may still be relevant once #5550 is addressed.

## Test plan

- [x] `bash internal/scaffold/fullsend-repo/scripts/post-fix-test.sh` — new test cases cover the remove/add label sequence tolerating either call failing without the script exiting nonzero.
- [x] `go build ./...` and `go test ./internal/scaffold/...` — no regressions.

Fixes #5188. References #2636, #2669, #2679, #5463, #5480, #5550. Supersedes #5415.

cc @ifireball @waynesun09 — this replaces #5415 per the discussion there; see the closing comment on that PR for the full rationale.