### PR TITLE
fix(dispatch): pass pr-head-sha to action.yml in harness-run job

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1642,3 +1642,4 @@ jobs:
           status-repo: ${{ matrix.status_repo }}
           status-number: ${{ matrix.status_number }}
           mint-url: ${{ inputs.mint_url }}
+          pr-head-sha: ${{ fromJSON(matrix.event_payload).pull_request.head.sha || '' }}

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -614,6 +614,24 @@ func TestReusableDispatchPRHeadSHAPassthrough(t *testing.T) {
 				"%s agent pr-head-sha must be populated from event_payload", stage)
 		})
 	}
+
+	t.Run("harness-run", func(t *testing.T) {
+		marker := "Run harness agent"
+		idx := strings.Index(s, marker)
+		require.NotEqual(t, -1, idx,
+			"workflow must contain %q step", marker)
+		section := s[idx:]
+		nextStep := strings.Index(section, "\n      - name:")
+		if nextStep > 0 {
+			section = section[:nextStep]
+		}
+		assert.Contains(t, section, "pr-head-sha:",
+			"harness-run agent step must pass pr-head-sha to action.yml")
+		assert.Contains(t, section, ".pull_request.head.sha",
+			"harness-run pr-head-sha must be populated from event_payload")
+		assert.Contains(t, section, "matrix.event_payload",
+			"harness-run must use matrix.event_payload, not needs.route.outputs")
+	})
 }
 
 // TestRoleCheckCaseBranches validates the role-check step's case mapping and


### PR DESCRIPTION
## Summary

- Thread `pr-head-sha` from `matrix.event_payload` through to `action.yml` in the `harness-run` job, mirroring the fix #5274 applied to the five stage jobs (triage, code, review, fix, retro)
- Without this, comment-triggered custom harness agents fall through to `GITHUB_SHA` and operate on the wrong commit
- Extend `TestReusableDispatchPRHeadSHAPassthrough` to cover `harness-run` alongside the five stage jobs

## Root cause

`harness-run`'s "Run harness agent" step was omitted from #5274. It passes neither the explicit `pr-head-sha` input nor a wrapped `event_payload` to `action.yml`, so the SHA resolution falls through to tier 3 (`GITHUB_SHA`) — the config-repo checkout SHA instead of the PR's actual head.

## The fix

The Go `harnessdispatch` package already populates `matrix.event_payload` with the correct SHA via a real API lookup (`opts.Forge.GetPullRequestInfo`). This PR simply extracts it and passes it through:

```yaml
pr-head-sha: ${{ fromJSON(matrix.event_payload).pull_request.head.sha || '' }}
```

## Test plan

- [x] `TestReusableDispatchPRHeadSHAPassthrough` now includes `harness-run` subtest — passes
- [x] Full `internal/scaffold` test suite passes
- [x] `make lint` clean
- [ ] Verify in a live comment-triggered harness-run that the agent sees the correct PR head SHA

Closes #5329