### PR TITLE
ci: skip site build when no site files changed

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -2,8 +2,34 @@ name: Build Site
 
 on:
   pull_request:
+    paths:
+      - "web/**"
+      - "website/**"
+      - "docs/**"
+      - "cloudflare_site/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.ts"
+      - "experiments"
+      - "experiments/**"
+      - ".gitmodules"
+      - ".github/workflows/site-build.yml"
+      - ".github/workflows/site-deploy.yml"
   push:
     branches: [main]
+    paths:
+      - "web/**"
+      - "website/**"
+      - "docs/**"
+      - "cloudflare_site/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.ts"
+      - "experiments"
+      - "experiments/**"
+      - ".gitmodules"
+      - ".github/workflows/site-build.yml"
+      - ".github/workflows/site-deploy.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `paths:` filters to Build Site so it only runs when site-related inputs change (web SPA, VitePress docs, Cloudflare worker, root JS deps, experiments submodule, workflow YAML)
- Deploy Site already chains via `workflow_run`, so it skips automatically when Build Site does not run

Closes #813

## Filtered paths

| Glob | Reason |
|------|--------|
| `web/**` | Vite SPA sources and static HTML |
| `website/**` | VitePress config and deps |
| `docs/**` | Documentation markdown content |
| `cloudflare_site/**` | Worker + static assets in deploy bundle |
| `package.json`, `package-lock.json`, `vite.config.ts` | Root SPA build inputs |
| `experiments`, `experiments/**`, `.gitmodules` | Docs submodule (gitlink + content) |
| `.github/workflows/site-build.yml`, `site-deploy.yml` | Workflow self-updates |

## Test plan
- [ ] This PR touches `site-build.yml` → Build Site should **trigger**
- [ ] A future PR modifying only Go/`internal/**` → Build Site should be **skipped**
- [ ] A future PR modifying `docs/` or `web/` → Build Site should **trigger**


Made with [Cursor](https://cursor.com)