### PR TITLE
chore(deps): bump google.golang.org/grpc to v1.82.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

- Bumps `google.golang.org/grpc` from v1.81.1 to v1.82.1 (transitive dependency)
- Fixes [Dependabot alert #45](https://github.com/fullsend-ai/fullsend/security/dependabot/45) — three vulnerabilities:
  - **xDS RBAC Authorization Bypass** (CVSS 8.2) — fail-open on unsupported matchers
  - **HTTP/2 Rapid Reset DoS Bypass** (CVSS 7.5) — bypasses earlier mitigations
  - **xDS RBAC Engine Panic** (CVSS 5.9) — crash on `NOT` rules with unsupported fields

## Test plan

- [x] `go build ./...` passes
- [x] Test suite passes (one pre-existing failure in `internal/scaffold` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)