### PR TITLE
docs(agents): prefer go run for fullsend CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Fullsend is a platform for fully autonomous agentic development for Git-hosted o
 - Keep core problem documents organization-agnostic. Organization-specific details belong in `docs/problems/applied/<org-name>/`.
 - The target audience for problem documents is any contributor community considering autonomous agents — keep language accessible and avoid presuming solutions.
 - Always stage your changes before running `make lint` and fix any failures. Pre-commit only checks staged files — without staging first, it stashes your work and finds nothing to lint.
+- When invoking the fullsend CLI from this checkout, **prefer** `go run ./cmd/fullsend …` from the repo root. Do **not** use a `fullsend` binary from mise, `$PATH`, `go install`, or another checkout — those often lag this tree. A stale CLI once rewrote hosted-mint `ALLOWED_ROLES` during enrollment (dropping `e2e`/`fix`) and broke e2e. Details: [Go Code](docs/contributing/go-code.md#running-the-fullsend-cli).
 - You **must** read and follow [COMMITS.md](COMMITS.md) when writing or reviewing commit messages and PR titles. Getting the prefix right is not optional — GoReleaser uses PR titles to build release notes. Breaking changes **must** carry the `!` suffix in both commit messages and PR titles; a missing `!` is an important-severity review finding.
 - This repository requires a [Developer Certificate of Origin (DCO)](https://developercertificate.org/). Human-proposed commits **must** be signed off: use `git commit -s` (or add `Signed-off-by: Your Name <email>` as a trailer). Human-driven agent sessions (e.g., using Claude Code locally) should also sign off — the human directing the session is the one certifying the DCO. **Autonomous agent commits are exempt** and must never supply the DCO with `-s` or with `Signed-off-by`. These agents commit using the GitHub App's bot identity, which the [Probot DCO app](https://github.com/apps/dco) auto-skips.
 - Never commit secrets (tokens, API keys, PEM keys, gcloud credentials) or sensitive data (GCP project names, service account identifiers, Model Armor template names, internal hostnames). Use environment variables with no defaults for sensitive values.
@@ -22,7 +23,7 @@ Detailed guidance lives in `docs/contributing/` and topic-specific guides under 
 
 | File | When to read |
 |------|-------------|
-| [Go Code](docs/contributing/go-code.md) | Changing Go code under `cmd/` or `internal/` — covers mint sync, coverage, vet, e2e tests, concurrency testing, and suite-timeout policy |
+| [Go Code](docs/contributing/go-code.md) | Changing Go code under `cmd/` or `internal/` — covers mint sync, coverage, vet, e2e tests, concurrency testing, suite-timeout policy, and preferring `go run` for the CLI |
 | [Behaviour Testing](docs/guides/dev/behaviour-testing.md) | Modifying behaviour test repo provisioning, fork handling, or workflow dispatch — covers forge API constraints (`auto_init`, fork name derivation, Actions readiness, CI timeout budgeting) |
 | [Shell Scripting](docs/contributing/shell-scripting.md) | Writing or reviewing shell scripts — covers `gh api --paginate` pitfalls and jq patterns |
 | [Forge Abstraction](docs/contributing/forge-abstraction.md) | Adding forge operations — covers `forge.Client` interface rules |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,10 @@ make go-build
 
 The binary is written to `./bin/fullsend`. To run agents locally with the built binary, see [Running agents locally](docs/guides/user/running-agents-locally.md).
 
+When working from this checkout (especially mint-mutating commands), prefer
+`go run ./cmd/fullsend …` over a preinstalled binary so the CLI matches the
+branch under edit. See [Running the fullsend CLI](docs/contributing/go-code.md#running-the-fullsend-cli). End-user and operator guides continue to document the released `fullsend` binary.
+
 ## Issues
 
 When in doubt about whether something warrants a PR, start with an issue. Issues are low-friction and can graduate into PRs, problem docs, or ADRs later.

--- a/docs/contributing/go-code.md
+++ b/docs/contributing/go-code.md
@@ -79,7 +79,13 @@ Stubs that implement an interface with no-ops or stateless pass-throughs hold no
 
 ## Running the fullsend CLI
 
-When agents (or humans working from this checkout) need the fullsend CLI, invoke it from the **repo root** with:
+**Audience:** contributors and agents working from a **repo checkout**. Do not
+change end-user or operator guides under `docs/guides/getting-started/`,
+`docs/guides/user/`, or `docs/guides/infrastructure/` to require `go run` —
+those audiences install a released `fullsend` binary.
+
+When agents (or humans working from this checkout) need the fullsend CLI,
+invoke it from the **repo root** with:
 
 ```bash
 go run ./cmd/fullsend <subcommand> …

--- a/docs/contributing/go-code.md
+++ b/docs/contributing/go-code.md
@@ -77,6 +77,20 @@ Convention: use 12 goroutines. This is high enough to trigger races reliably but
 
 Stubs that implement an interface with no-ops or stateless pass-throughs hold no mutable state, so the race detector has nothing to detect. Even stubs that use `atomic.Int64` counters are invisible to `-race` because atomics are correctly synchronized by definition. The point of a race test is to exercise the **real type's fields** — only a real constructor backed by a thread-safe fake can trigger the detector on unsynchronized production code.
 
+## Running the fullsend CLI
+
+When agents (or humans working from this checkout) need the fullsend CLI, invoke it from the **repo root** with:
+
+```bash
+go run ./cmd/fullsend <subcommand> …
+```
+
+**Do not** use a preinstalled `fullsend` from mise, `$PATH`, `GOBIN`, `go install`, or another clone. Those binaries often lag the branch you are on. Enrollment and other mint-mutating commands rewrite Cloud Run env vars; a stale CLI can apply obsolete merge logic against the hosted mint.
+
+This already happened: an enrollment for `crc-org/crc` used a June-era mise `fullsend` that still wrote org-scoped `ROLE_APP_IDS` keys and re-derived `ALLOWED_ROLES` from slash-keyed entries only. Shared role-only keys such as `e2e` and `fix` were ignored, so the mint dropped those roles from `ALLOWED_ROLES` and e2e broke until the mint was restored. Current tree enroll is safer, but the durable fix for agents is to always run the CLI from source.
+
+`make go-build` / `bin/fullsend` is fine when you intentionally build **this** checkout first. Prefer `go run` unless you have a reason to keep a built binary.
+
 ## Running e2e tests
 
 The e2e tests mint short-lived GitHub App installation tokens via the central token mint. Pool-org admin operations use mint/OIDC in CI and do not require a dedicated mint URL secret.

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -91,10 +91,10 @@ One-time enrollment for all pool orgs (idempotent). Enroll the singular admin `t
 ```bash
 export GCP_PROJECT=it-gcp-konflux-dev-fullsend
 for i in $(seq -w 1 12); do
-  fullsend mint enroll "halfsend-${i}/test-repo" \
+  go run ./cmd/fullsend mint enroll "halfsend-${i}/test-repo" \
     --project="$GCP_PROJECT" --region=us-central1
   for j in $(seq -w 1 12); do
-    fullsend mint enroll "halfsend-${i}/test-repo-${j}" \
+    go run ./cmd/fullsend mint enroll "halfsend-${i}/test-repo-${j}" \
       --project="$GCP_PROJECT" --region=us-central1
   done
 done
@@ -121,14 +121,14 @@ MINT_PROJECT=... MINT_FUNCTION=... hack/setup-new-e2e-org.sh 07
 Verify foreign authorization:
 
 ```bash
-fullsend admin foreign list --org halfsend-01
+go run ./cmd/fullsend admin foreign list --org halfsend-01
 # expect e2e → fullsend-ai/fullsend
 ```
 
 Existing pool orgs (`halfsend-01` … `halfsend-12`) need a one-time operator pass: install the e2e app (if missing) and run:
 
 ```bash
-fullsend admin foreign allow --org halfsend-NN --role e2e --caller fullsend-ai/fullsend
+go run ./cmd/fullsend admin foreign allow --org halfsend-NN --role e2e --caller fullsend-ai/fullsend
 ```
 
 ## CI authorization

--- a/docs/guides/dev/testing-workflows.md
+++ b/docs/guides/dev/testing-workflows.md
@@ -24,7 +24,7 @@ definitions, and the CLI binary from your local checkout into the config repo or
 `.fullsend/` directory:
 
 ```bash
-fullsend admin install "$ORG" \
+go run ./cmd/fullsend admin install "$ORG" \
   --vendor \
   --fullsend-source "$PWD" \
   --skip-app-setup \
@@ -34,8 +34,8 @@ fullsend admin install "$ORG" \
 ```
 
 After changing reusable workflows or agent content, re-run install (or
-`fullsend github setup`) with `--vendor` to refresh vendored files.
-`fullsend github sync-scaffold` updates thin caller templates and auto-detects
+`go run ./cmd/fullsend github setup`) with `--vendor` to refresh vendored files.
+`go run ./cmd/fullsend github sync-scaffold` updates thin caller templates and auto-detects
 vendored vs layered mode from `.defaults/action.yml` presence.
 
 Runtime skips the upstream sparse checkout when `.defaults/action.yml` is

--- a/skills/mint-enroll/SKILL.md
+++ b/skills/mint-enroll/SKILL.md
@@ -15,16 +15,27 @@ triggers:
 
 # Mint Service Enrollment
 
-Enroll a new GitHub org or per-repo into the fullsend token mint using the
-`fullsend mint` CLI. The mint is a stateless service (deployed on GCP Cloud
-Function or Cloudflare Worker) that exchanges GitHub OIDC JWTs for scoped
-GitHub App installation tokens.
+Enroll a new GitHub org or per-repo into the fullsend token mint using
+`go run ./cmd/fullsend mint` from this checkout. The mint is a stateless
+service (deployed on GCP Cloud Function or Cloudflare Worker) that exchanges
+GitHub OIDC JWTs for scoped GitHub App installation tokens.
 
 Follow these steps in order. Do not skip steps.
 
 **Always ask the operator for the GCP project ID.** Do not infer it from
 `gcloud config get-value project` — the local config may point at the
 wrong project.
+
+**Always run the CLI from this checkout via `go run`.** From the repo root:
+
+```bash
+go run ./cmd/fullsend <subcommand> …
+```
+
+Do **not** use a `fullsend` binary from mise, `$PATH`, `go install`, or
+another checkout. A stale CLI can rewrite hosted-mint env vars with obsolete
+merge logic (this previously dropped `e2e`/`fix` from `ALLOWED_ROLES` and
+broke e2e). See [Running the fullsend CLI](../../docs/contributing/go-code.md#running-the-fullsend-cli).
 
 ## Setup
 
@@ -47,11 +58,11 @@ for initial PEM bootstrap (`mint deploy --pem-dir`), not for enrollment.
 Per-repo enrollment additionally requires Project IAM Admin (to grant
 `roles/aiplatform.user` to the repo WIF principal).
 
-Verify credentials and that the fullsend CLI is available:
+Verify credentials and that this checkout's CLI builds:
 
 ```bash
 gcloud auth list --filter=status:ACTIVE --format="value(account)"
-fullsend --version
+go run ./cmd/fullsend --version
 ```
 
 ## Constraints
@@ -83,12 +94,12 @@ PEM keys and app IDs are tied to the role, not the org. Secrets use role-only na
 (`fullsend-{role}-app-pem`) — one secret per role, shared across orgs on the
 mint. `ROLE_APP_IDS` uses the same model: one GitHub App ID per role (e.g.,
 `coder` → `123456`), shared by all enrolled orgs. PEMs and app IDs must already
-exist (from `mint deploy --pem-dir` or `fullsend admin install`); enrollment
+exist (from `mint deploy --pem-dir` or `go run ./cmd/fullsend admin install`); enrollment
 does not create, copy, or modify PEM secrets or app ID mappings.
 
 Apps must be installed on the target org before the mint can produce tokens.
 An org admin installs via `https://github.com/apps/{slug}/installations/new`
-or by running `fullsend admin install`.
+or by running `go run ./cmd/fullsend admin install`.
 
 ## Enrollment Steps
 
@@ -113,13 +124,13 @@ Run `mint status` to see the current mint state, enrolled orgs, Cloud Run
 revision info, and PEM health:
 
 ```bash
-fullsend mint status --project="$GCP_PROJECT" --region="$MINT_REGION"
+go run ./cmd/fullsend mint status --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
 If the mint is not deployed yet, deploy it first:
 
 ```bash
-fullsend mint deploy --project="$GCP_PROJECT" --region="$MINT_REGION"
+go run ./cmd/fullsend mint deploy --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
 Check the status output for:
@@ -135,7 +146,7 @@ For per-org drill-down into PEM status (accepts org name only, not
 `owner/repo` — for per-repo enrollment, use just the org portion):
 
 ```bash
-fullsend mint status "<github-org>" --project="$GCP_PROJECT" --region="$MINT_REGION"
+go run ./cmd/fullsend mint status "<github-org>" --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
 **STOP — show the status output to the operator.** Confirm the mint is
@@ -146,7 +157,7 @@ healthy and the enrollment target is correct before proceeding.
 Preview the enrollment first with `--dry-run`:
 
 ```bash
-fullsend mint enroll "$TARGET" \
+go run ./cmd/fullsend mint enroll "$TARGET" \
   --project="$GCP_PROJECT" \
   --region="$MINT_REGION" \
   --dry-run
@@ -159,7 +170,7 @@ If the preview looks correct and the operator confirms, run the actual
 enrollment:
 
 ```bash
-fullsend mint enroll "$TARGET" \
+go run ./cmd/fullsend mint enroll "$TARGET" \
   --project="$GCP_PROJECT" \
   --region="$MINT_REGION"
 ```
@@ -185,7 +196,7 @@ If the CLI reports "Post-write verification FAILED", run `mint status` to
 diagnose:
 
 ```bash
-fullsend mint status --project="$GCP_PROJECT" --region="$MINT_REGION"
+go run ./cmd/fullsend mint status --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
 Common causes of verification failure:
@@ -193,7 +204,7 @@ Common causes of verification failure:
 - **Template/traffic divergence** — traffic routing step didn't complete.
   Re-run enrollment to trigger a new revision cycle.
 - **Missing shared app IDs** — the mint has no role-keyed `ROLE_APP_IDS` entries.
-  Run `mint deploy --pem-dir` or `fullsend admin install` on the mint project first.
+  Run `mint deploy --pem-dir` or `go run ./cmd/fullsend admin install` on the mint project first.
 
 ### 5. Handoff to repo admin
 
@@ -201,7 +212,7 @@ The mint SRE does not configure target repos. Inform the repo admin that
 mint-side enrollment is complete and provide:
 
 - **Mint URL**: shown in `mint status` output
-- GitHub Actions org variable `FULLSEND_MINT_URL` (set by `fullsend admin install` or manually)
+- GitHub Actions org variable `FULLSEND_MINT_URL` (set by `go run ./cmd/fullsend admin install` or manually)
 - `.github/workflows/fullsend.yaml` shim workflow in the target repo
 
 For per-repo enrollments, also provide:
@@ -211,7 +222,7 @@ For per-repo enrollments, also provide:
 
 For per-org, the `repo-maintenance` workflow in `.fullsend` handles shim
 deployment. For per-repo, the admin runs
-`fullsend admin install <owner/repo>` or configures manually.
+`go run ./cmd/fullsend admin install <owner/repo>` or configures manually.
 
 Verify that all required GitHub Apps are installed on the target org
 before the admin triggers a workflow.
@@ -226,11 +237,11 @@ Use the CLI to unenroll:
 
 ```bash
 # Dry-run first
-fullsend mint unenroll "$TARGET" \
+go run ./cmd/fullsend mint unenroll "$TARGET" \
   --project="$GCP_PROJECT" --region="$MINT_REGION" --dry-run
 
 # Actual unenroll (after operator confirms dry-run output)
-fullsend mint unenroll "$TARGET" \
+go run ./cmd/fullsend mint unenroll "$TARGET" \
   --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
@@ -247,11 +258,11 @@ add `--delete-provider` to the unenroll command:
 
 ```bash
 # Preview permanent WIF provider deletion first (repo-scoped only)
-fullsend mint unenroll "$TARGET" \
+go run ./cmd/fullsend mint unenroll "$TARGET" \
   --project="$GCP_PROJECT" --region="$MINT_REGION" --delete-provider --dry-run
 
 # Permanently delete WIF provider (repo-scoped only, after dry-run confirms)
-fullsend mint unenroll "$TARGET" \
+go run ./cmd/fullsend mint unenroll "$TARGET" \
   --project="$GCP_PROJECT" --region="$MINT_REGION" --delete-provider
 ```
 
@@ -280,7 +291,7 @@ gcloud run services update "$MINT_SERVICE" \
 # gcloud run services update "$MINT_SERVICE" --set-env-vars="KEY=value"
 ```
 
-Prefer `fullsend mint enroll` over manual `gcloud` env var edits — the
+Prefer `go run ./cmd/fullsend mint enroll` over manual `gcloud` env var edits — the
 CLI handles read-merge-write with REVISION-pinned traffic routing.
 
 Set these variables for the commands below:

--- a/skills/mint-enroll/SKILL.md
+++ b/skills/mint-enroll/SKILL.md
@@ -2,8 +2,9 @@
 name: mint-enroll
 description: >
   SRE runbook for enrolling new GitHub orgs or repos into the fullsend token
-  mint service using the fullsend CLI. Use when onboarding a new org, adding a
-  per-repo WIF provider, or re-enrolling after infrastructure changes.
+  mint service using `go run ./cmd/fullsend` from this checkout. Use when
+  onboarding a new org, adding a per-repo WIF provider, or re-enrolling after
+  infrastructure changes.
 allowed-tools: Bash
 triggers:
   - mint enroll


### PR DESCRIPTION
## Summary

- Instruct agents to invoke the fullsend CLI via `go run ./cmd/fullsend …` from this checkout, not via mise, `$PATH`, `go install`, or another clone.
- Document the rationale in `docs/contributing/go-code.md` and update the mint-enroll skill so enrollment commands match.

**Why:** A simple `crc-org/crc` mint enrollment used a stale mise `fullsend` (June-era binary that still wrote org-scoped `ROLE_APP_IDS` and re-derived `ALLOWED_ROLES` from slash-keyed entries only). Shared role-only keys such as `e2e` and `fix` were ignored, so the hosted mint dropped those roles from `ALLOWED_ROLES` and e2e broke until the mint was restored. Preferring `go run` keeps the CLI matched to the branch under edit.

## Test plan

- [ ] Skim `AGENTS.md` / go-code section / mint-enroll skill for clarity
- [ ] Confirm markdown link to `#running-the-fullsend-cli` resolves
- [ ] Optional: `go run ./cmd/fullsend --version` from repo root


Made with [Cursor](https://cursor.com)