### PR TITLE
test(#5707): fix missing harness agent fixtures and timeout diagnostics

### DIFF
--- a/pkg/behaviourtest/drivers/ci/githubactions/githubactions.go
+++ b/pkg/behaviourtest/drivers/ci/githubactions/githubactions.go
@@ -16,8 +16,6 @@ import (
 
 const (
 	pollInterval   = 15 * time.Second
-	dispatchWait   = 12 * time.Minute
-	dispatchPoll   = 5 * time.Second
 	dispatchMaxTry = 48
 
 	artifactRunPoll = 5 * time.Second
@@ -27,6 +25,12 @@ const (
 
 	assertNoWorkflowChecks = 3
 	assertNoWorkflowDelay  = 10 * time.Second
+)
+
+// Overridable in tests so timeout / fail-fast paths do not burn wall clock.
+var (
+	dispatchWait = 12 * time.Minute
+	dispatchPoll = 5 * time.Second
 )
 
 // Driver implements ci.Driver against GitHub Actions.
@@ -432,6 +436,12 @@ func readLimited(r io.Reader, limit int64) ([]byte, error) {
 }
 
 // WaitForHarnessAgent waits for a successful harness-run workflow and artifact for agent.
+//
+// When the harness fails before uploading an artifact (for example missing
+// agent files after scaffold deletion), polling artifacts alone yields an
+// opaque timeout. This method fail-fasts on completed non-success workflow
+// runs after the trigger time and includes recent-run diagnostics on
+// timeout so flakes self-explain (#5707).
 func (d *Driver) WaitForHarnessAgent(ctx context.Context, owner, repo, agent string, after time.Time) (*forge.WorkflowRun, error) {
 	artifactName := "fullsend-" + agent
 	deadline := time.Now().Add(dispatchWait)
@@ -446,22 +456,86 @@ func (d *Driver) WaitForHarnessAgent(ctx context.Context, owner, repo, agent str
 			continue
 		}
 		art := selectRepositoryArtifactAfter(arts, artifactName, after)
-		if art == nil {
-			continue
+		if art != nil {
+			run, err := d.Client.GetWorkflowRun(ctx, owner, repo, art.WorkflowRunID)
+			if err != nil {
+				continue
+			}
+			if run.Status != "completed" {
+				continue
+			}
+			if run.Conclusion != "success" {
+				return nil, fmt.Errorf("harness run for %q concluded with %q%s", agent, run.Conclusion, formatWorkflowRunRef(run))
+			}
+			return run, nil
 		}
-		run, err := d.Client.GetWorkflowRun(ctx, owner, repo, art.WorkflowRunID)
-		if err != nil {
-			continue
+		if failed := selectFailedWorkflowRunAfter(d.listRecentRuns(ctx, owner, repo), after); failed != nil {
+			return nil, fmt.Errorf("harness agent %q did not complete successfully: workflow run %d concluded with %q%s%s",
+				agent, failed.ID, failed.Conclusion, formatWorkflowRunRef(failed), formatRecentRunsDiag(d.listRecentRuns(ctx, owner, repo), after))
 		}
-		if run.Status != "completed" {
-			continue
-		}
-		if run.Conclusion != "success" {
-			return nil, fmt.Errorf("harness run for %q concluded with %q", agent, run.Conclusion)
-		}
-		return run, nil
 	}
-	return nil, fmt.Errorf("harness agent %q did not complete successfully", agent)
+	return nil, fmt.Errorf("harness agent %q did not complete successfully%s",
+		agent, formatRecentRunsDiag(d.listRecentRuns(ctx, owner, repo), after))
+}
+
+func (d *Driver) listRecentRuns(ctx context.Context, owner, repo string) []forge.WorkflowRun {
+	runs, err := d.Client.ListRecentWorkflowRuns(ctx, owner, repo, 30)
+	if err != nil {
+		return nil
+	}
+	return runs
+}
+
+// selectFailedWorkflowRunAfter returns the newest completed non-success
+// workflow run created at or after after. Cancelled / failure / timed_out
+// conclusions all count — they explain a missing success artifact.
+func selectFailedWorkflowRunAfter(runs []forge.WorkflowRun, after time.Time) *forge.WorkflowRun {
+	var best *forge.WorkflowRun
+	for i := range runs {
+		run := &runs[i]
+		if run.Status != "completed" || run.Conclusion == "" || run.Conclusion == "success" {
+			continue
+		}
+		runTime, parseErr := time.Parse(time.RFC3339, run.CreatedAt)
+		if parseErr != nil || runTime.Before(after) {
+			continue
+		}
+		if best == nil || run.ID > best.ID {
+			best = run
+		}
+	}
+	return best
+}
+
+func formatWorkflowRunRef(run *forge.WorkflowRun) string {
+	if run == nil {
+		return ""
+	}
+	if run.HTMLURL != "" {
+		return fmt.Sprintf(" (%s)", run.HTMLURL)
+	}
+	return ""
+}
+
+// formatRecentRunsDiag lists recent workflow runs after after for timeout
+// / fail-fast error messages.
+func formatRecentRunsDiag(runs []forge.WorkflowRun, after time.Time) string {
+	var parts []string
+	for _, run := range runs {
+		runTime, parseErr := time.Parse(time.RFC3339, run.CreatedAt)
+		if parseErr != nil || runTime.Before(after) {
+			continue
+		}
+		ref := fmt.Sprintf("id=%d name=%q status=%s conclusion=%q", run.ID, run.Name, run.Status, run.Conclusion)
+		if run.HTMLURL != "" {
+			ref += " url=" + run.HTMLURL
+		}
+		parts = append(parts, ref)
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("; no workflow runs after %s", after.Format(time.RFC3339))
+	}
+	return "; recent runs after " + after.Format(time.RFC3339) + ": " + strings.Join(parts, "; ")
 }
 
 // CountHarnessDispatches returns the number of fullsend-{agent} artifacts

--- a/pkg/behaviourtest/drivers/ci/githubactions/githubactions.go
+++ b/pkg/behaviourtest/drivers/ci/githubactions/githubactions.go
@@ -487,13 +487,18 @@ func (d *Driver) listRecentRuns(ctx context.Context, owner, repo string) []forge
 }
 
 // selectFailedWorkflowRunAfter returns the newest completed non-success
-// workflow run created at or after after. Cancelled / failure / timed_out
-// conclusions all count — they explain a missing success artifact.
+// workflow run created at or after after that indicates a real harness
+// failure.
+//
+// "skipped" is intentionally ignored: GitHub concurrency cancel-in-progress
+// and path-filter skips produce skipped conclusions while a newer run is
+// still in progress. Treating skipped as terminal caused false fail-fasts
+// during behaviour tests (#5707).
 func selectFailedWorkflowRunAfter(runs []forge.WorkflowRun, after time.Time) *forge.WorkflowRun {
 	var best *forge.WorkflowRun
 	for i := range runs {
 		run := &runs[i]
-		if run.Status != "completed" || run.Conclusion == "" || run.Conclusion == "success" {
+		if run.Status != "completed" || !isHarnessFailureConclusion(run.Conclusion) {
 			continue
 		}
 		runTime, parseErr := time.Parse(time.RFC3339, run.CreatedAt)
@@ -505,6 +510,17 @@ func selectFailedWorkflowRunAfter(runs []forge.WorkflowRun, after time.Time) *fo
 		}
 	}
 	return best
+}
+
+func isHarnessFailureConclusion(conclusion string) bool {
+	switch conclusion {
+	case "failure", "timed_out", "startup_failure":
+		return true
+	default:
+		// skipped/cancelled often come from concurrency cancel-in-progress
+		// while a newer run is still active — do not fail-fast on those.
+		return false
+	}
 }
 
 func formatWorkflowRunRef(run *forge.WorkflowRun) string {

--- a/pkg/behaviourtest/drivers/ci/githubactions/githubactions_test.go
+++ b/pkg/behaviourtest/drivers/ci/githubactions/githubactions_test.go
@@ -271,3 +271,98 @@ func TestWaitForHarnessAgent_FromRepositoryArtifact(t *testing.T) {
 	require.NotNil(t, run)
 	assert.Equal(t, 99, run.ID)
 }
+
+func TestWaitForHarnessAgent_FailFastOnFailedRun(t *testing.T) {
+	// Mutates package-level dispatchWait/dispatchPoll — not parallel-safe.
+	prevWait, prevPoll := dispatchWait, dispatchPoll
+	dispatchWait = 2 * time.Second
+	dispatchPoll = 10 * time.Millisecond
+	t.Cleanup(func() {
+		dispatchWait, dispatchPoll = prevWait, prevPoll
+	})
+
+	after := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	client := forge.NewFakeClient()
+	client.RepositoryArtifacts = map[string][]forge.RepositoryArtifact{
+		"org/repo": {},
+	}
+	client.RecentWorkflowRuns = map[string][]forge.WorkflowRun{
+		"org/repo": {
+			{
+				ID:         42,
+				Name:       "Dispatch",
+				Status:     "completed",
+				Conclusion: "failure",
+				HTMLURL:    "https://github.com/org/repo/actions/runs/42",
+				CreatedAt:  "2026-01-02T00:00:00Z",
+			},
+		},
+	}
+
+	d := &Driver{Client: client}
+	_, err := d.WaitForHarnessAgent(context.Background(), "org", "repo", "fork-pr-sync", after)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `workflow run 42 concluded with "failure"`)
+	assert.Contains(t, err.Error(), "https://github.com/org/repo/actions/runs/42")
+	assert.Contains(t, err.Error(), "recent runs after")
+}
+
+func TestWaitForHarnessAgent_TimeoutIncludesRecentRunsDiag(t *testing.T) {
+	// Mutates package-level dispatchWait/dispatchPoll — not parallel-safe.
+	prevWait, prevPoll := dispatchWait, dispatchPoll
+	dispatchWait = 50 * time.Millisecond
+	dispatchPoll = 10 * time.Millisecond
+	t.Cleanup(func() {
+		dispatchWait, dispatchPoll = prevWait, prevPoll
+	})
+
+	after := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	client := forge.NewFakeClient()
+	client.RepositoryArtifacts = map[string][]forge.RepositoryArtifact{
+		"org/repo": {},
+	}
+	client.RecentWorkflowRuns = map[string][]forge.WorkflowRun{
+		"org/repo": {
+			{
+				ID:         7,
+				Name:       "Dispatch",
+				Status:     "in_progress",
+				Conclusion: "",
+				HTMLURL:    "https://github.com/org/repo/actions/runs/7",
+				CreatedAt:  "2026-01-02T00:00:00Z",
+			},
+		},
+	}
+
+	d := &Driver{Client: client}
+	_, err := d.WaitForHarnessAgent(context.Background(), "org", "repo", "issue-ping", after)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `harness agent "issue-ping" did not complete successfully`)
+	assert.Contains(t, err.Error(), "id=7")
+	assert.Contains(t, err.Error(), "status=in_progress")
+}
+
+func TestSelectFailedWorkflowRunAfter(t *testing.T) {
+	t.Parallel()
+
+	after := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	runs := []forge.WorkflowRun{
+		{ID: 1, Status: "completed", Conclusion: "failure", CreatedAt: "2025-12-31T00:00:00Z"},
+		{ID: 2, Status: "completed", Conclusion: "success", CreatedAt: "2026-01-02T00:00:00Z"},
+		{ID: 3, Status: "completed", Conclusion: "failure", CreatedAt: "2026-01-02T01:00:00Z"},
+		{ID: 4, Status: "completed", Conclusion: "cancelled", CreatedAt: "2026-01-02T02:00:00Z"},
+		{ID: 5, Status: "in_progress", Conclusion: "", CreatedAt: "2026-01-02T03:00:00Z"},
+	}
+	got := selectFailedWorkflowRunAfter(runs, after)
+	require.NotNil(t, got)
+	assert.Equal(t, 4, got.ID)
+	assert.Equal(t, "cancelled", got.Conclusion)
+}
+
+func TestFormatRecentRunsDiag_NoRuns(t *testing.T) {
+	t.Parallel()
+
+	after := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	got := formatRecentRunsDiag(nil, after)
+	assert.Contains(t, got, "no workflow runs after")
+}

--- a/pkg/behaviourtest/drivers/ci/githubactions/githubactions_test.go
+++ b/pkg/behaviourtest/drivers/ci/githubactions/githubactions_test.go
@@ -350,13 +350,25 @@ func TestSelectFailedWorkflowRunAfter(t *testing.T) {
 		{ID: 1, Status: "completed", Conclusion: "failure", CreatedAt: "2025-12-31T00:00:00Z"},
 		{ID: 2, Status: "completed", Conclusion: "success", CreatedAt: "2026-01-02T00:00:00Z"},
 		{ID: 3, Status: "completed", Conclusion: "failure", CreatedAt: "2026-01-02T01:00:00Z"},
-		{ID: 4, Status: "completed", Conclusion: "cancelled", CreatedAt: "2026-01-02T02:00:00Z"},
-		{ID: 5, Status: "in_progress", Conclusion: "", CreatedAt: "2026-01-02T03:00:00Z"},
+		{ID: 4, Status: "completed", Conclusion: "skipped", CreatedAt: "2026-01-02T02:00:00Z"},
+		{ID: 5, Status: "completed", Conclusion: "cancelled", CreatedAt: "2026-01-02T02:30:00Z"},
+		{ID: 6, Status: "in_progress", Conclusion: "", CreatedAt: "2026-01-02T03:00:00Z"},
 	}
 	got := selectFailedWorkflowRunAfter(runs, after)
 	require.NotNil(t, got)
-	assert.Equal(t, 4, got.ID)
-	assert.Equal(t, "cancelled", got.Conclusion)
+	assert.Equal(t, 3, got.ID)
+	assert.Equal(t, "failure", got.Conclusion)
+}
+
+func TestSelectFailedWorkflowRunAfter_IgnoresSkipped(t *testing.T) {
+	t.Parallel()
+
+	after := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	runs := []forge.WorkflowRun{
+		{ID: 1, Status: "completed", Conclusion: "skipped", CreatedAt: "2026-01-02T00:00:00Z"},
+		{ID: 2, Status: "in_progress", Conclusion: "", CreatedAt: "2026-01-02T01:00:00Z"},
+	}
+	assert.Nil(t, selectFailedWorkflowRunAfter(runs, after))
 }
 
 func TestFormatRecentRunsDiag_NoRuns(t *testing.T) {

--- a/pkg/behaviourtest/steps/dispatch.go
+++ b/pkg/behaviourtest/steps/dispatch.go
@@ -91,13 +91,26 @@ func givenCustomHarness(w *world.World, name, doc string) error {
 	}
 	w.DispatchAgent = name
 
+	ctx := context.Background()
+	cfgOwner := w.Install.ConfigOwner()
+	cfgRepo := w.Install.ConfigRepo()
+
 	harnessPath := filepath.Join(".fullsend", "harness", name+".yaml")
-	if err := w.SCM.CommitFile(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), harnessPath, fmt.Sprintf("behaviour: add harness %s", name), []byte(doc)); err != nil {
+	if err := w.SCM.CommitFile(ctx, cfgOwner, cfgRepo, harnessPath, fmt.Sprintf("behaviour: add harness %s", name), []byte(doc)); err != nil {
 		return fmt.Errorf("committing harness: %w", err)
 	}
 
+	// Scaffold agent files were removed in #5552. Local harnesses still
+	// reference relative paths like agents/triage.md, which resolve under
+	// .fullsend/ at runtime. Commit minimal fixtures so clean pool repos
+	// do not fail with "stat .../.fullsend/agents/triage.md: no such file".
+	prefix := w.Install.ConfigPathPrefix()
+	if _, err := commitRelativeResources(ctx, w, cfgOwner, cfgRepo, name, doc, prefix); err != nil {
+		return fmt.Errorf("committing harness relative resources: %w", err)
+	}
+
 	cfgPath := filepath.Join(".fullsend", "config.yaml")
-	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath)
+	cfgData, err := w.SCM.GetFileContent(ctx, cfgOwner, cfgRepo, cfgPath)
 	if err != nil {
 		return fmt.Errorf("reading config: %w", err)
 	}
@@ -123,7 +136,7 @@ func givenCustomHarness(w *world.World, name, doc string) error {
 	if err != nil {
 		return err
 	}
-	if err := w.SCM.CommitFile(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath, fmt.Sprintf("behaviour: register harness %s", name), merged); err != nil {
+	if err := w.SCM.CommitFile(ctx, cfgOwner, cfgRepo, cfgPath, fmt.Sprintf("behaviour: register harness %s", name), merged); err != nil {
 		return fmt.Errorf("updating config: %w", err)
 	}
 	return nil

--- a/pkg/behaviourtest/steps/dispatch_test.go
+++ b/pkg/behaviourtest/steps/dispatch_test.go
@@ -17,6 +17,21 @@ func TestGivenCustomHarness_Validation(t *testing.T) {
 	require.Error(t, givenCustomHarness(w, "agent", ""))
 }
 
+func TestGivenCustomHarness_CommitsAgentFixture(t *testing.T) {
+	scm := &fakeURLSCM{files: map[string][]byte{
+		"test-org/test-repo/.fullsend/config.yaml": []byte("version: \"1\"\nagents: []\n"),
+	}}
+	w := &world.World{
+		Install: &fakeURLInstall{owner: "test-org", repo: "test-repo"},
+		SCM:     scm,
+	}
+	err := givenCustomHarness(w, "issue-ping", "agent: agents/triage.md\nrole: triage\nslug: issue-ping")
+	require.NoError(t, err)
+	assert.Equal(t, "issue-ping", w.DispatchAgent)
+	assert.Equal(t, minimalAgentContent, string(scm.files["test-org/test-repo/.fullsend/agents/triage.md"]))
+	assert.Contains(t, string(scm.files["test-org/test-repo/.fullsend/harness/issue-ping.yaml"]), "agent: agents/triage.md")
+}
+
 func TestDispatchSteps_RequireScenarioStart(t *testing.T) {
 	w := &world.World{}
 	require.Error(t, thenHarnessWorkflowCompletes(w, "agent"))

--- a/pkg/behaviourtest/steps/url_dispatch.go
+++ b/pkg/behaviourtest/steps/url_dispatch.go
@@ -131,7 +131,7 @@ func givenURLSourcedCustomHarness(w *world.World, name, doc string, opts urlHarn
 	// repo URL directory. Commit any relative resources so the runtime can
 	// fetch them. Without this, LoadWithBase fails because the agent file
 	// does not exist at the resolved URL.
-	relativePaths, err := commitRelativeResources(ctx, w, hostOwner, hostRepo, name, doc)
+	relativePaths, err := commitRelativeResources(ctx, w, hostOwner, hostRepo, name, doc, "")
 	if err != nil {
 		return fmt.Errorf("committing relative resources to hosting repo: %w", err)
 	}
@@ -236,18 +236,26 @@ func givenURLSourcedCustomHarness(w *world.World, name, doc string, opts urlHarn
 	return nil
 }
 
-// minimalAgentContent is a stub agent definition committed to the hosting
-// repo so that URL-sourced harness resource resolution succeeds at runtime.
-// The behaviour tests override the agent with a dummy script, so the content
-// only needs to be fetchable — not a complete agent specification.
-const minimalAgentContent = "# URL Test Agent\n\nMinimal agent fixture for URL-sourced harness behaviour tests.\n"
+// minimalAgentContent is a stub agent definition committed so harness
+// resource resolution succeeds at runtime. Behaviour tests override the
+// agent with a dummy script, so the content only needs to be present —
+// not a complete agent specification.
+//
+// Used for both URL-sourced harness hosting repos and local custom
+// harnesses under .fullsend/ (scaffold agents were removed in #5552).
+const minimalAgentContent = "# Behaviour Test Agent\n\nMinimal agent fixture for harness behaviour tests.\n"
 
 // commitRelativeResources parses the harness YAML doc and commits any
-// relative resource files (agent, policy) to the hosting repo. This is
-// required by ADR-0045: when SourceURL is set, resolveBaseResources
-// fetches relative paths from the hosting repo URL directory.
-// Returns the list of committed relative paths for subsequent verification.
-func commitRelativeResources(ctx context.Context, w *world.World, owner, repo, harnessName, doc string) ([]string, error) {
+// relative resource files (agent, policy).
+//
+// destPrefix is prepended to relative paths when committing (for example
+// ".fullsend" for local custom harnesses that resolve against the
+// per-repo config directory). Pass "" for URL-sourced hosting repos,
+// where paths are rooted at the hosting repository.
+//
+// Returns the list of committed paths (including destPrefix) for
+// subsequent verification.
+func commitRelativeResources(ctx context.Context, w *world.World, owner, repo, harnessName, doc, destPrefix string) ([]string, error) {
 	// Parse just the resource fields we need from the harness YAML.
 	var h struct {
 		Agent  string `yaml:"agent"`
@@ -259,25 +267,34 @@ func commitRelativeResources(ctx context.Context, w *world.World, owner, repo, h
 
 	var committed []string
 
+	joinDest := func(rel string) string {
+		if destPrefix == "" {
+			return rel
+		}
+		return path.Join(destPrefix, rel)
+	}
+
 	// Commit relative agent file if specified.
 	if h.Agent != "" && !strings.HasPrefix(h.Agent, "/") && !strings.HasPrefix(h.Agent, "https://") {
-		if err := w.SCM.CommitFile(ctx, owner, repo, h.Agent,
+		dest := joinDest(h.Agent)
+		if err := w.SCM.CommitFile(ctx, owner, repo, dest,
 			fmt.Sprintf("behaviour: add agent resource for %s", harnessName),
 			[]byte(minimalAgentContent)); err != nil {
-			return nil, fmt.Errorf("committing agent resource %s: %w", h.Agent, err)
+			return nil, fmt.Errorf("committing agent resource %s: %w", dest, err)
 		}
-		committed = append(committed, h.Agent)
+		committed = append(committed, dest)
 	}
 
 	// Commit relative policy file if specified.
 	if h.Policy != "" && !strings.HasPrefix(h.Policy, "/") && !strings.HasPrefix(h.Policy, "https://") {
+		dest := joinDest(h.Policy)
 		minimalPolicy := fmt.Sprintf("# Minimal policy for %s\n", harnessName)
-		if err := w.SCM.CommitFile(ctx, owner, repo, h.Policy,
+		if err := w.SCM.CommitFile(ctx, owner, repo, dest,
 			fmt.Sprintf("behaviour: add policy resource for %s", harnessName),
 			[]byte(minimalPolicy)); err != nil {
-			return nil, fmt.Errorf("committing policy resource %s: %w", h.Policy, err)
+			return nil, fmt.Errorf("committing policy resource %s: %w", dest, err)
 		}
-		committed = append(committed, h.Policy)
+		committed = append(committed, dest)
 	}
 
 	return committed, nil

--- a/pkg/behaviourtest/steps/url_dispatch_test.go
+++ b/pkg/behaviourtest/steps/url_dispatch_test.go
@@ -586,17 +586,27 @@ func TestCommitRelativeResources_CommitsAgentFile(t *testing.T) {
 	scm := &fakeURLSCM{files: map[string][]byte{}}
 	w := &world.World{SCM: scm}
 	paths, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"agent: agents/triage.md\nrole: triage")
+		"agent: agents/triage.md\nrole: triage", "")
 	require.NoError(t, err)
 	assert.Equal(t, minimalAgentContent, string(scm.files["org/repo/agents/triage.md"]))
 	assert.Equal(t, []string{"agents/triage.md"}, paths)
+}
+
+func TestCommitRelativeResources_WithDestPrefix(t *testing.T) {
+	scm := &fakeURLSCM{files: map[string][]byte{}}
+	w := &world.World{SCM: scm}
+	paths, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
+		"agent: agents/triage.md\nrole: triage", ".fullsend")
+	require.NoError(t, err)
+	assert.Equal(t, minimalAgentContent, string(scm.files["org/repo/.fullsend/agents/triage.md"]))
+	assert.Equal(t, []string{".fullsend/agents/triage.md"}, paths)
 }
 
 func TestCommitRelativeResources_SkipsAbsoluteAgentPath(t *testing.T) {
 	scm := &fakeURLSCM{files: map[string][]byte{}}
 	w := &world.World{SCM: scm}
 	paths, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"agent: /absolute/agents/triage.md\nrole: triage")
+		"agent: /absolute/agents/triage.md\nrole: triage", "")
 	require.NoError(t, err)
 	assert.Empty(t, paths, "absolute paths should not be committed")
 }
@@ -605,7 +615,7 @@ func TestCommitRelativeResources_SkipsURLAgentPath(t *testing.T) {
 	scm := &fakeURLSCM{files: map[string][]byte{}}
 	w := &world.World{SCM: scm}
 	paths, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"agent: https://example.com/agents/triage.md\nrole: triage")
+		"agent: https://example.com/agents/triage.md\nrole: triage", "")
 	require.NoError(t, err)
 	assert.Empty(t, paths, "URL paths should not be committed")
 }
@@ -614,7 +624,7 @@ func TestCommitRelativeResources_NoAgentField(t *testing.T) {
 	scm := &fakeURLSCM{files: map[string][]byte{}}
 	w := &world.World{SCM: scm}
 	paths, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"role: triage\nslug: test")
+		"role: triage\nslug: test", "")
 	require.NoError(t, err)
 	assert.Empty(t, paths, "no files should be committed without agent field")
 }
@@ -623,7 +633,7 @@ func TestCommitRelativeResources_CommitsPolicyFile(t *testing.T) {
 	scm := &fakeURLSCM{files: map[string][]byte{}}
 	w := &world.World{SCM: scm}
 	paths, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"agent: agents/triage.md\npolicy: policies/base.yaml\nrole: triage")
+		"agent: agents/triage.md\npolicy: policies/base.yaml\nrole: triage", "")
 	require.NoError(t, err)
 	assert.Equal(t, minimalAgentContent, string(scm.files["org/repo/agents/triage.md"]))
 	assert.Contains(t, string(scm.files["org/repo/policies/base.yaml"]), "Minimal policy")
@@ -638,7 +648,7 @@ func TestCommitRelativeResources_AgentCommitError(t *testing.T) {
 	}
 	w := &world.World{SCM: scm}
 	_, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"agent: agents/triage.md\nrole: triage")
+		"agent: agents/triage.md\nrole: triage", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "committing agent resource")
 }
@@ -647,7 +657,7 @@ func TestCommitRelativeResources_PolicyCommitError(t *testing.T) {
 	scm := &fakeURLSCM{files: map[string][]byte{}}
 	w := &world.World{SCM: &policyFailSCM{fakeURLSCM: scm}}
 	_, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"agent: agents/triage.md\npolicy: policies/base.yaml\nrole: triage")
+		"agent: agents/triage.md\npolicy: policies/base.yaml\nrole: triage", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "committing policy resource")
 }
@@ -656,7 +666,7 @@ func TestCommitRelativeResources_InvalidYAML(t *testing.T) {
 	scm := &fakeURLSCM{files: map[string][]byte{}}
 	w := &world.World{SCM: scm}
 	_, err := commitRelativeResources(context.Background(), w, "org", "repo", "test",
-		"invalid: [yaml: content")
+		"invalid: [yaml: content", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing harness YAML")
 }


### PR DESCRIPTION
## Summary
- Behaviour custom harnesses reference `agent: agents/triage.md`, but scaffold agents were removed in #5552. Clean pool repos fail at runtime with `stat .../.fullsend/agents/triage.md: no such file`, upload no artifact, then `WaitForHarnessAgent` times out opaquely after ~12 minutes.
- Commit a minimal agent (and policy) fixture under `.fullsend/` when registering a custom harness via `givenCustomHarness` (same helper already used for URL-sourced harnesses).
- Improve `WaitForHarnessAgent`: fail fast when a completed non-success workflow run exists after `ScenarioStart` without a success artifact, and include recent run id/conclusion/URL diagnostics on timeout.

## Hypothesis (from main run forensics)
Run https://github.com/fullsend-ai/fullsend/actions/runs/30408887762 leased `halfsend-01/test-repo-09`. Harness did run (https://github.com/halfsend-01/test-repo-09/actions/runs/30408975596) and failed on missing `triage.md`; no artifact → opaque behaviour timeout. Most pool repos still have stale leftover agents, so failures are intermittent.

## What behaviour CI should confirm
- Dispatch / fork / URL-local harness scenarios no longer time out on clean repos for missing `agents/triage.md`.
- If a harness still fails for another reason, the step error should cite the failed workflow run conclusion/URL instead of only `did not complete successfully`.

Fixes #5707

## Test plan
- [x] `go test ./pkg/behaviourtest/steps/ ./pkg/behaviourtest/drivers/ci/githubactions/`
- [x] staged `make lint`
- [ ] Behaviour job on this draft PR (needs `ok-to-test` for fork PRs)


Made with [Cursor](https://cursor.com)