### PR TITLE
feat(#4718): add pre-script output protocol to fullsend run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,19 @@ inputs:
       wrapper. Takes precedence over GITHUB_EVENT_PATH extraction.
     default: ""
 
+outputs:
+  skipped:
+    description: >-
+      "true" when the harness pre-script requested a skip via the
+      FULLSEND_PRESCRIPT_OUTPUT protocol, so the agent did not run.
+      "false" when the run proceeded. Empty when the CLI predates the
+      protocol, or when the run failed before the skip decision — check
+      the step outcome before reading empty as a version signal.
+    value: ${{ steps.run.outputs.skipped }}
+  skip-reason:
+    description: Human-readable reason accompanying a skip, if the pre-script gave one.
+    value: ${{ steps.run.outputs.reason }}
+
 runs:
   using: composite
   steps:
@@ -301,6 +314,7 @@ runs:
         cache: false
 
     - name: Run fullsend
+      id: run
       if: inputs.agent != '__install_only__'
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ outputs:
   skipped:
     description: >-
       "true" when the harness pre-script requested a skip via the
-      FULLSEND_PRESCRIPT_OUTPUT protocol, so the agent did not run.
+      pre-script output protocol, so the agent did not run.
       "false" when the run proceeded. Empty when the CLI predates the
       protocol, or when the run failed before the skip decision — check
       the step outcome before reading empty as a version signal.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -562,6 +562,7 @@ event ──► DISPATCHER
           ║                                                       ║
           ║ Runs pre-script on host:                              ║
           ║   validate inputs, prefetch data                      ║
+          ║   may request skip, exiting before sandbox creation   ║
           ║                                                       ║
           ║ ┌───────────────────────────────────────────────────┐ ║
           ║ │ SANDBOX (ephemeral, per-run)                      │ ║

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -405,7 +405,8 @@ Vendoring commit messages use title + body (upload and stale delete). `github st
 │  └──────┬───────────┘                                           │
 │         ▼                                                       │
 │  ┌──────────────────┐                                           │
-│  │ Pre-script        │ Run harness.pre_script (host-side)       │
+│  │ Pre-script        │ Run harness.pre_script (host-side).      │
+│  │                   │ skipped=true exits 0 here (#4718)        │
 │  └──────┬───────────┘                                           │
 │         ▼                                                       │
 │  ┌──────────────────┐                                           │

--- a/docs/guides/user/building-custom-agents.md
+++ b/docs/guides/user/building-custom-agents.md
@@ -314,6 +314,30 @@ echo "Pre-script complete."
 
 The pre-script has full credentials on the trusted runner. It fetches data from external systems and writes it to files that the harness copies into the sandbox. Credentials never enter the sandbox.
 
+#### Skipping the run from the pre-script
+
+A pre-script can tell `fullsend run` not to start the agent at all — useful when
+an open PR already addresses the issue, or when the work is otherwise
+redundant. `fullsend run` exports `FULLSEND_PRESCRIPT_OUTPUT` (a file path); the
+script appends `skipped=true` to it and the run reports a ⏭️ skipped status and
+exits 0 **before the sandbox is created**.
+
+```bash
+if [[ -n "${FULLSEND_PRESCRIPT_OUTPUT:-}" ]]; then
+  {
+    echo "skipped=true"
+    echo "reason=PR #${EXISTING_PR} already addresses this issue"
+  } >> "${FULLSEND_PRESCRIPT_OUTPUT}"
+  exit 0
+fi
+```
+
+Always guard on the variable being set — older `fullsend` versions do not export
+it, and appending to an empty path would fail the script. Malformed content is a
+hard error rather than a silent proceed, so a mistyped skip cannot turn into a
+duplicate agent run. See the [pre-script output v1 contract](../../normative/prescript-output/v1/README.md)
+for the full grammar, error semantics, and CI relay behavior.
+
 ### Post-script (action execution)
 
 `.fullsend/customized/scripts/post-my-agent.sh`:

--- a/docs/normative/prescript-output/v1/README.md
+++ b/docs/normative/prescript-output/v1/README.md
@@ -1,0 +1,163 @@
+# Pre-script output v1
+
+Contract between `fullsend run` and a harness `pre_script` ([issue #4718](https://github.com/fullsend-ai/fullsend/issues/4718)).
+
+A pre-script uses this contract to tell `fullsend run` **not to run the agent** —
+for example when an open PR already addresses the issue. The decision lives in
+the CLI rather than in workflow YAML, so every forge inherits it: GitLab and
+Forgejo scaffolds invoke `fullsend run` directly and get the same gating with no
+CI-side reimplementation.
+
+This document is normative. The Go implementation lives in
+[`internal/prescript`](../../../../internal/prescript/prescript.go).
+
+## Contract
+
+`fullsend run` creates an empty file inside the run directory and exports its
+absolute path to the pre-script:
+
+```
+FULLSEND_PRESCRIPT_OUTPUT=/path/to/run-dir/prescript-1234567890.out
+```
+
+The script **appends** `key=value` lines to that file. After the script exits
+successfully, `fullsend run` parses the file:
+
+| `skipped` | Behavior |
+|-----------|----------|
+| `true` | Report a `skipped` status (⏭️), relay outputs, exit 0 **before sandbox creation**. |
+| `false`, absent, or empty file | Proceed with the run — today's behavior. |
+
+A non-zero script exit remains a hard failure, unchanged by this protocol.
+
+### Reserved keys
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `skipped` | no | `true` or `false`. Any other value — including an empty one — is an error. |
+| `reason` | no | Short human-readable explanation, shown in the run log and in the status comment. |
+
+Reserved keys are **lowercase**. A key differing only in case (`SKIPPED=true`)
+is a hard error rather than an unrelated output — see [Error semantics](#error-semantics).
+
+### Other keys
+
+Any other valid key is parsed, logged, and relayed. Reserved-key names are
+owned by the protocol; a future CLI may interpret additional lowercase
+single-word keys, so scripts should prefix their own outputs (`myagent_pr=123`)
+to avoid colliding with a future directive.
+
+## Grammar
+
+Line-based. One assignment per line:
+
+```
+skipped=true
+reason=an open PR already addresses this issue
+# comments and blank lines are ignored
+myagent_existing_pr=123
+```
+
+- **Keys** match `^[a-zA-Z_][a-zA-Z0-9_-]*$` (hyphens allowed).
+- **Values** are single-line and may not contain control characters
+  (`U+0000`–`U+001F`, `U+007F`). This includes `\r` and `\n`.
+- **Whitespace** surrounding the key and the value is insignificant:
+  `skipped = true` is equivalent to `skipped=true`.
+- **Comments** are lines whose first non-whitespace character is `#`. A value
+  may contain `#`; only a leading `#` starts a comment.
+- **`=` in values** is preserved — only the first `=` splits the line.
+- **Repeated keys**: the last assignment wins.
+- **Maximum file size** is 1 MiB.
+
+### Not supported
+
+The format resembles `GITHUB_OUTPUT` but is **not compatible with it**:
+
+- No `key<<DELIMITER` heredoc form. Multiline values are not expressible;
+  a heredoc line is a hard error with a message naming this limitation.
+- No quoting. `skipped="true"` is an error, not `true`.
+
+## Error semantics
+
+These are **hard errors** — the run fails rather than proceeding:
+
+| Condition | Rationale |
+|-----------|-----------|
+| A line that is not `key=value` | A typo like `skipped true` silently ignored would start the duplicate agent run the pre-check exists to prevent. |
+| A key that fails the key pattern | Same. |
+| A key differing from a reserved key only by case | `SKIPPED=true` would otherwise be stored as an unrelated output and the run would proceed silently. |
+| A value containing a control character | A bare `\r` is a line terminator to the GitHub Actions runner, so such a value could smuggle extra output entries — including overriding `skipped`. |
+| `skipped` set to anything but `true`/`false` | Same silent-proceed risk. |
+| `skipped` present but empty (`skipped=`) | `skipped=${SKIP}` with `SKIP` unset is a plausible script bug, and an intended skip must not degrade into a duplicate run. An *absent* `skipped` key means proceed; a present-but-empty one does not. |
+| The output file missing after the script ran | `fullsend run` created it beforehand, so its absence means the script removed it. |
+| File larger than 1 MiB | Bounded read. |
+
+Failing closed is deliberate: an unparseable skip request must not degrade into
+a duplicate agent run.
+
+## CI relay
+
+When running under GitHub Actions (`GITHUB_ACTIONS=true` **and** `GITHUB_OUTPUT`
+set), `fullsend run` appends the outputs to `$GITHUB_OUTPUT` on every path it
+reaches the skip decision on — skip, proceed, and harnesses that define no
+`pre_script` at all — with `skipped` normalized to `true`/`false`. The composite
+action re-exports them as the `skipped` and `skip-reason` action outputs.
+
+A consumer can therefore distinguish three states:
+
+| `steps.<id>.outputs.skipped` | Meaning |
+|------------------------------|---------|
+| `true` | The pre-script requested a skip. |
+| `false` | The skip decision was made and was "proceed" — either the pre-script declined to skip, or the harness has no `pre_script`. |
+| *(empty)* | The CLI predates this protocol, **or** the run failed before reaching the skip decision. |
+
+The empty case is ambiguous by construction: a relay only happens once the
+decision exists, so a run that fails earlier (harness load, pre-script failure,
+malformed output) writes nothing. Check the step's `outcome` before treating an
+empty `skipped` as a version signal.
+
+If a relay target exists but writing fails, the run fails — a workflow gate
+that disagrees with the CLI's decision is the failure mode this protocol is
+meant to remove.
+
+Other CI systems get the outputs in the run log only. GitLab `dotenv` report
+artifacts are the natural equivalent and are not implemented in v1; GitLab
+still gets the skip itself and the ⏭️ status comment, since both flow through
+`fullsend run` and `forge.Client`.
+
+## Version skew
+
+Same class of concern as [ADR 0062](../../../ADRs/0062-dispatch-version-skew.md).
+The two directions are handled asymmetrically, deliberately:
+
+| Direction | Behavior |
+|-----------|----------|
+| Old script, new CLI | The script never writes to the file. Empty file → proceed. Fails **safe**. |
+| New script, old CLI | `FULLSEND_PRESCRIPT_OUTPUT` is unset, so the script cannot signal a skip and the agent runs anyway. Fails **open** — a duplicate run. |
+
+Scripts must therefore guard on the variable, the same pattern as the existing
+`GITHUB_OUTPUT` guard in the scaffold scripts:
+
+```sh
+if [ -n "${FULLSEND_PRESCRIPT_OUTPUT:-}" ]; then
+  {
+    echo "skipped=true"
+    echo "reason=an open PR already addresses this issue"
+  } >> "${FULLSEND_PRESCRIPT_OUTPUT}"
+fi
+```
+
+Without the guard, `>>` to an empty path fails the script and therefore the run.
+
+## Versioning
+
+Breaking changes require `docs/normative/prescript-output/v2/`.
+
+| Change | v1 impact |
+|--------|-----------|
+| **Breaking** (requires v2): rename or remove a reserved key, change the meaning of a reserved value, tighten the grammar so previously valid files are rejected | Pre-scripts must migrate |
+| **Non-breaking** (allowed in v1): add a reserved key, relax the grammar, clarify documentation | Existing pre-scripts keep working |
+
+Adding a reserved key is non-breaking for the CLI but fails open on older CLIs,
+which ignore it. Direct a script that depends on a newly added key at a CLI
+version that understands it.

--- a/docs/normative/prescript-output/v1/README.md
+++ b/docs/normative/prescript-output/v1/README.md
@@ -1,8 +1,9 @@
 # Pre-script output v1
 
-Contract between `fullsend run` and a harness `pre_script` ([issue #4718](https://github.com/fullsend-ai/fullsend/issues/4718)).
+The **pre-script output protocol** — the contract between `fullsend run` and a
+harness `pre_script` ([issue #4718](https://github.com/fullsend-ai/fullsend/issues/4718)).
 
-A pre-script uses this contract to tell `fullsend run` **not to run the agent** —
+A pre-script uses this protocol to tell `fullsend run` **not to run the agent** —
 for example when an open PR already addresses the issue. The decision lives in
 the CLI rather than in workflow YAML, so every forge inherits it: GitLab and
 Forgejo scaffolds invoke `fullsend run` directly and get the same gating with no
@@ -11,7 +12,7 @@ CI-side reimplementation.
 This document is normative. The Go implementation lives in
 [`internal/prescript`](../../../../internal/prescript/prescript.go).
 
-## Contract
+## Protocol
 
 `fullsend run` creates an empty file inside the run directory and exports its
 absolute path to the pre-script:

--- a/internal/cli/prescript_run_test.go
+++ b/internal/cli/prescript_run_test.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/harness"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+// writePreScript creates an executable script for runPreScript tests.
+func writePreScript(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("pre-script tests require a POSIX shell")
+	}
+	path := filepath.Join(t.TempDir(), "pre-test.sh")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/bash\nset -euo pipefail\n"+body), 0o755))
+	return path
+}
+
+func TestRunPreScript_NoOutput_Proceeds(t *testing.T) {
+	printer := ui.New(io.Discard)
+	h := &harness.Harness{PreScript: writePreScript(t, "true\n")}
+
+	res, err := runPreScript(h, t.TempDir(), "", printer)
+	require.NoError(t, err)
+	assert.False(t, res.Skipped)
+}
+
+func TestRunPreScript_SkipRequested(t *testing.T) {
+	printer := ui.New(io.Discard)
+	h := &harness.Harness{PreScript: writePreScript(t,
+		`echo "skipped=true" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n"+
+			`echo "reason=open PR exists" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n")}
+
+	res, err := runPreScript(h, t.TempDir(), "", printer)
+	require.NoError(t, err)
+	assert.True(t, res.Skipped)
+	assert.Equal(t, "open PR exists", res.Reason)
+}
+
+func TestRunPreScript_RunnerEnvVisible(t *testing.T) {
+	printer := ui.New(io.Discard)
+	h := &harness.Harness{
+		PreScript: writePreScript(t,
+			`[ "${MY_RUNNER_VAR}" = "on" ] || exit 7`+"\n"+
+				`echo "skipped=true" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n"),
+		RunnerEnv: map[string]string{"MY_RUNNER_VAR": "on"},
+	}
+
+	res, err := runPreScript(h, t.TempDir(), "", printer)
+	require.NoError(t, err)
+	assert.True(t, res.Skipped)
+}
+
+func TestRunPreScript_ScriptFailureIsHardError(t *testing.T) {
+	printer := ui.New(io.Discard)
+	h := &harness.Harness{PreScript: writePreScript(t, "exit 3\n")}
+
+	_, err := runPreScript(h, t.TempDir(), "", printer)
+	require.ErrorContains(t, err, "running pre-script")
+}
+
+func TestRunPreScript_MalformedOutputIsHardError(t *testing.T) {
+	printer := ui.New(io.Discard)
+	h := &harness.Harness{PreScript: writePreScript(t,
+		`echo "skipped true" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n")}
+
+	_, err := runPreScript(h, t.TempDir(), "", printer)
+	require.ErrorContains(t, err, "parsing pre-script output")
+}
+
+// The headline claim of issue #4718: a skip exits before the sandbox is
+// ever created. usePreScriptStub makes sandbox creation fail loudly, so a
+// nil error here proves runAgent returned first. If the pre-script block
+// is ever moved below sandbox creation, this fails with "creating
+// sandbox" — the error its paired no-skip test asserts on.
+func TestRunAgent_PreScriptSkip_ReturnsBeforeSandboxCreation(t *testing.T) {
+	usePreScriptStub(t)
+	dir := newSkipHarnessDir(t, `echo "skipped=true" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n"+
+		`echo "reason=open PR exists" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n")
+
+	rFlags := resolveFlags{maxDepth: 10, maxResources: 50}
+	err := runAgent(context.Background(), "code", dir, "", t.TempDir(), "", nil, false, "", "", rFlags,
+		statusOpts{}, ui.New(io.Discard), false)
+	require.NoError(t, err)
+}
+
+// Without a skip, the run must still reach sandbox creation — a guard
+// against the skip path swallowing every run — and skipped=false must be
+// relayed so an absent key means only "this CLI predates the protocol".
+// The two assertions share one run: reaching sandbox creation costs the
+// full create-retry backoff.
+func TestRunAgent_PreScriptNoSkip_ProceedsToSandboxAndRelaysFalse(t *testing.T) {
+	usePreScriptStub(t)
+	out := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", out)
+	dir := newSkipHarnessDir(t, "true\n")
+
+	rFlags := resolveFlags{maxDepth: 10, maxResources: 50}
+	err := runAgent(context.Background(), "code", dir, "", t.TempDir(), "", nil, false, "", "", rFlags,
+		statusOpts{}, ui.New(io.Discard), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating sandbox")
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, "skipped=false\n", string(data))
+}
+
+// A harness with no pre_script must still relay skipped=false, otherwise
+// an empty output would mean two different things and the documented
+// three-state contract would not hold.
+func TestRunAgent_NoPreScript_StillRelaysSkippedFalse(t *testing.T) {
+	usePreScriptStub(t)
+	out := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", out)
+	dir := newSkipHarnessDir(t, "")
+
+	rFlags := resolveFlags{maxDepth: 10, maxResources: 50}
+	err := runAgent(context.Background(), "code", dir, "", t.TempDir(), "", nil, false, "", "", rFlags,
+		statusOpts{}, ui.New(io.Discard), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating sandbox")
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, "skipped=false\n", string(data))
+}
+
+// The skip path relays skipped=true. Fast: it returns before sandbox
+// creation, so it does not pay the create-retry backoff.
+func TestRunAgent_PreScriptSkip_RelaysSkippedTrue(t *testing.T) {
+	usePreScriptStub(t)
+	out := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", out)
+	dir := newSkipHarnessDir(t, `echo "skipped=true" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n"+
+		`echo "reason=open PR exists" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n")
+
+	rFlags := resolveFlags{maxDepth: 10, maxResources: 50}
+	require.NoError(t, runAgent(context.Background(), "code", dir, "", t.TempDir(), "", nil, false, "", "",
+		rFlags, statusOpts{}, ui.New(io.Discard), false))
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, "skipped=true\nreason=open PR exists\n", string(data))
+}
+
+// A relay target that cannot be written must fail the run rather than
+// exiting 0 with a decision the workflow gate never sees.
+func TestRunAgent_PreScriptRelayFailureIsHardError(t *testing.T) {
+	usePreScriptStub(t)
+	t.Setenv("GITHUB_ACTIONS", "true")
+	// A directory can be opened but not written to.
+	t.Setenv("GITHUB_OUTPUT", t.TempDir())
+	dir := newSkipHarnessDir(t, `echo "skipped=true" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n")
+
+	rFlags := resolveFlags{maxDepth: 10, maxResources: 50}
+	err := runAgent(context.Background(), "code", dir, "", t.TempDir(), "", nil, false, "", "", rFlags,
+		statusOpts{}, ui.New(io.Discard), false)
+	require.ErrorContains(t, err, "relaying pre-script outputs")
+}
+
+func TestRunPreScript_OutputFileExistsAndIsWritable(t *testing.T) {
+	printer := ui.New(io.Discard)
+	h := &harness.Harness{PreScript: writePreScript(t,
+		`[ -f "${FULLSEND_PRESCRIPT_OUTPUT}" ] || exit 8`+"\n"+
+			`[ -w "${FULLSEND_PRESCRIPT_OUTPUT}" ] || exit 9`+"\n")}
+
+	res, err := runPreScript(h, t.TempDir(), "", printer)
+	require.NoError(t, err)
+	assert.False(t, res.Skipped)
+}
+
+// The output file is removed once parsed, so skips do not accumulate
+// files in the run directory.
+func TestRunPreScript_CleansUpOutputFile(t *testing.T) {
+	printer := ui.New(io.Discard)
+	runDir := t.TempDir()
+	h := &harness.Harness{PreScript: writePreScript(t,
+		`echo "skipped=true" >> "${FULLSEND_PRESCRIPT_OUTPUT}"`+"\n")}
+
+	_, err := runPreScript(h, runDir, "", printer)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(runDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// usePreScriptStub puts an openshell stub on PATH that passes the gateway
+// check but refuses sandbox creation, so a run that gets that far fails
+// recognizably.
+func usePreScriptStub(t *testing.T) {
+	t.Helper()
+	stubDir, err := filepath.Abs(filepath.Join("testdata", "prescript-stub"))
+	require.NoError(t, err)
+	t.Setenv("PATH", stubDir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+}
+
+// newSkipHarnessDir builds a minimal fullsend dir whose code harness runs
+// the given pre-script body.
+func newSkipHarnessDir(t *testing.T, preScriptBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "agents"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "agents", "code.md"),
+		[]byte("You are a coding agent."), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"),
+		[]byte("agents:\n  - harness/code.yaml\n"), 0o644))
+
+	harnessYAML := "agent: agents/code.md\nrole: test\n"
+	if preScriptBody != "" {
+		harnessYAML += "pre_script: " + writePreScript(t, preScriptBody) + "\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "harness", "code.yaml"),
+		[]byte(harnessYAML), 0o644))
+	return dir
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -916,8 +916,9 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	}()
 
 	// 4. Run pre-script on the host (if configured). The pre-script may
-	// request a skip via the FULLSEND_PRESCRIPT_OUTPUT protocol (issue
-	// #4718), in which case the run ends here — before sandbox creation.
+	// request a skip via the pre-script output protocol
+	// (FULLSEND_PRESCRIPT_OUTPUT, issue #4718), in which case the run
+	// ends here — before sandbox creation.
 	var preResult prescript.Result
 	if h.PreScript != "" {
 		preResult, err = runPreScript(h, runDir, traceparent, printer)
@@ -2309,9 +2310,9 @@ func resolveTraceIdentity(ctx context.Context, tracer trace.Tracer, inboundTP, i
 	}
 }
 
-// runPreScript executes the harness pre-script with the skip-protocol
-// output file (FULLSEND_PRESCRIPT_OUTPUT) in its environment and parses
-// the result. See internal/prescript for the contract (issue #4718).
+// runPreScript executes the harness pre-script with the pre-script output
+// protocol's file (FULLSEND_PRESCRIPT_OUTPUT) in its environment and parses
+// the result. See internal/prescript for the protocol (issue #4718).
 // A non-zero script exit remains a hard failure; a malformed output file
 // is also a hard failure so a mistyped skip cannot silently proceed.
 func runPreScript(h *harness.Harness, runDir, traceparent string, printer *ui.Printer) (prescript.Result, error) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/lock"
 	"github.com/fullsend-ai/fullsend/internal/mintclient"
 	"github.com/fullsend-ai/fullsend/internal/mintcore"
+	"github.com/fullsend-ai/fullsend/internal/prescript"
 	"github.com/fullsend-ai/fullsend/internal/resolve"
 	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
@@ -646,6 +647,12 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		}
 	}
 
+	// runSkipped records that the pre-script requested a skip (issue #4718);
+	// the status-notification defer below reports it as "skipped" rather
+	// than "success", with runSkipReason as the visible explanation.
+	var runSkipped bool
+	var runSkipReason string
+
 	// 1c. Set up status notifications (comments on the issue/PR).
 	// Lives in the CLI layer (not harness or post-script) so it wraps the
 	// entire run lifecycle including sandbox setup, validation loop, and
@@ -664,14 +671,18 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			}
 			defer func() {
 				status := "success"
+				detail := ""
 				if ctx.Err() != nil {
 					status = "cancelled"
 				} else if runErr != nil {
 					status = "failure"
+				} else if runSkipped {
+					status = "skipped"
+					detail = runSkipReason
 				}
 				dCtx, dCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 				defer dCancel()
-				if err := notifier.PostCompletion(dCtx, description, status); err != nil {
+				if err := notifier.PostCompletionWithDetail(dCtx, description, status, detail); err != nil {
 					printer.StepWarn("Failed to post completion status: " + err.Error())
 				}
 			}()
@@ -867,6 +878,17 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		rootSpan.SetAttributes(
 			attribute.Int("exit_code", exitCode),
 		)
+		// A pre-script skip exits 0 like a success, so without this a
+		// skipped run is indistinguishable from a completed one in traces
+		// — and skip rate is the metric issue #4718 exists to move. Only
+		// set for harnesses that actually have a pre-script, so an absent
+		// attribute means "nothing could have skipped this run".
+		if h != nil && h.PreScript != "" {
+			rootSpan.SetAttributes(attribute.Bool("fullsend.prescript.skipped", runSkipped))
+		}
+		if runSkipped && runSkipReason != "" {
+			rootSpan.SetAttributes(attribute.String("fullsend.prescript.skip_reason", runSkipReason))
+		}
 		if runCount > 0 {
 			rootSpan.SetAttributes(
 				attribute.String("gen_ai.request.model", aggMetrics.Model),
@@ -893,19 +915,49 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		tracingCleanup(flushCtx)
 	}()
 
-	// 4. Run pre-script on the host (if configured).
+	// 4. Run pre-script on the host (if configured). The pre-script may
+	// request a skip via the FULLSEND_PRESCRIPT_OUTPUT protocol (issue
+	// #4718), in which case the run ends here — before sandbox creation.
+	var preResult prescript.Result
 	if h.PreScript != "" {
-		preStart := time.Now()
-		printer.StepStart("Running pre-script: " + h.PreScript)
-		preCmd := exec.Command(h.PreScript)
-		preCmd.Env = childScriptEnv(h.RunnerEnv, traceparent)
-		preCmd.Stdout = os.Stdout
-		preCmd.Stderr = os.Stderr
-		if err := preCmd.Run(); err != nil {
-			printer.StepFail("Pre-script failed")
-			return fmt.Errorf("running pre-script: %w", err)
+		preResult, err = runPreScript(h, runDir, traceparent, printer)
+		if err != nil {
+			return err
 		}
-		printer.StepDone(fmt.Sprintf("Pre-script completed (%.1fs)", time.Since(preStart).Seconds()))
+		// Log the outputs so non-GitHub CIs and local runs still see what
+		// the pre-script reported.
+		if line := prescript.LogLine(preResult); line != "" {
+			printer.StepDone("Pre-script outputs: " + line)
+		}
+	}
+
+	// Relay on every path that reaches the skip decision — skip, proceed,
+	// and harnesses with no pre-script at all — so an absent skipped
+	// output narrows to two cases: a CLI predating this protocol, or a run
+	// that failed before deciding. See docs/normative/prescript-output/v1.
+	if relayed, relayErr := prescript.Relay(preResult); relayErr != nil {
+		// Fail closed: a relay target exists but we could not write to it,
+		// so workflow-level gating would disagree with the decision
+		// fullsend just made — exactly the duplicate-run failure this
+		// protocol exists to prevent.
+		printer.StepFail("Failed to relay skip decision")
+		return fmt.Errorf("relaying pre-script outputs: %w", relayErr)
+	} else if relayed && h.PreScript != "" {
+		// Only worth a line when a pre-script actually produced something;
+		// otherwise this fires on every CI run and names a script that
+		// does not exist.
+		printer.StepDone("Pre-script outputs relayed to GITHUB_OUTPUT")
+	}
+
+	if preResult.Skipped {
+		runSkipped = true
+		runSkipReason = preResult.Reason
+		reason := preResult.Reason
+		if reason == "" {
+			reason = "no reason given"
+		}
+		printer.StepDone("Run skipped by pre-script: " + reason)
+		return nil
 	}
 
 	// 4a. Create sandbox.
@@ -2255,6 +2307,37 @@ func resolveTraceIdentity(ctx context.Context, tracer trace.Tracer, inboundTP, i
 		Traceparent: traceparent,
 		SpanKind:    spanKind,
 	}
+}
+
+// runPreScript executes the harness pre-script with the skip-protocol
+// output file (FULLSEND_PRESCRIPT_OUTPUT) in its environment and parses
+// the result. See internal/prescript for the contract (issue #4718).
+// A non-zero script exit remains a hard failure; a malformed output file
+// is also a hard failure so a mistyped skip cannot silently proceed.
+func runPreScript(h *harness.Harness, runDir, traceparent string, printer *ui.Printer) (prescript.Result, error) {
+	preStart := time.Now()
+	printer.StepStart("Running pre-script: " + h.PreScript)
+	outPath, cleanup, err := prescript.Prepare(runDir)
+	if err != nil {
+		printer.StepFail("Pre-script setup failed")
+		return prescript.Result{}, fmt.Errorf("preparing pre-script output file: %w", err)
+	}
+	defer cleanup()
+	preCmd := exec.Command(h.PreScript)
+	preCmd.Env = append(childScriptEnv(h.RunnerEnv, traceparent), prescript.EnvVar+"="+outPath)
+	preCmd.Stdout = os.Stdout
+	preCmd.Stderr = os.Stderr
+	if err := preCmd.Run(); err != nil {
+		printer.StepFail("Pre-script failed")
+		return prescript.Result{}, fmt.Errorf("running pre-script: %w", err)
+	}
+	result, err := prescript.ParseFile(outPath)
+	if err != nil {
+		printer.StepFail("Pre-script output invalid")
+		return prescript.Result{}, fmt.Errorf("parsing pre-script output: %w", err)
+	}
+	printer.StepDone(fmt.Sprintf("Pre-script completed (%.1fs)", time.Since(preStart).Seconds()))
+	return result, nil
 }
 
 // childScriptEnv builds the environment for a host-side child script (pre- or

--- a/internal/cli/testdata/prescript-stub/openshell
+++ b/internal/cli/testdata/prescript-stub/openshell
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Fake openshell that passes CheckGateway but refuses sandbox creation.
+# Used by the pre-script skip tests to prove that a skip returns *before*
+# sandbox creation: a skipped run sees no error, while a proceeding run
+# fails here.
+#
+# `sandbox get` must fail too — createOnce falls back to it to decide
+# whether a failed create nonetheless left a sandbox behind, and a passing
+# `get` would send it into the ready-poll loop instead of returning.
+
+case "$1" in
+  gateway)
+    case "$2" in
+      list) echo "default-gateway"; exit 0 ;;
+    esac
+    ;;
+  settings)
+    exit 0
+    ;;
+  provider)
+    case "$2" in
+      profile|create|update) exit 0 ;;
+    esac
+    ;;
+  sandbox)
+    case "$2" in
+      create)
+        echo "prescript-stub: sandbox creation refused" >&2
+        exit 1
+        ;;
+      get)
+        exit 1
+        ;;
+      delete|ready|exec) exit 0 ;;
+    esac
+    ;;
+esac
+exit 0

--- a/internal/prescript/prescript.go
+++ b/internal/prescript/prescript.go
@@ -1,0 +1,312 @@
+// Package prescript implements the pre-script skip protocol (issue #4718).
+//
+// fullsend run hands the harness pre-script an output file path via the
+// FULLSEND_PRESCRIPT_OUTPUT environment variable. The script may append
+// key=value lines to that file — most notably "skipped=true" plus an
+// optional "reason=..." — which fullsend run reads back after the script
+// exits. When skipped=true, fullsend run reports a "skipped" status and
+// exits successfully before creating the sandbox.
+//
+// The normative contract lives in docs/normative/prescript-output/v1;
+// that document, not this comment, is what pre-script authors write
+// against. The summary below is a convenience for readers of this package.
+//
+// Version skew is the same class of concern as ADR 0062, and is handled
+// asymmetrically — deliberately, because the two directions have different
+// costs:
+//
+//   - Old script, new CLI: the script never writes to the file, which
+//     parses to a Result with Skipped false and no outputs — exactly
+//     today's behavior.
+//   - New script, old CLI: FULLSEND_PRESCRIPT_OUTPUT is unset, so the
+//     script cannot signal a skip and the agent runs anyway (a duplicate
+//     run — this direction fails open). Scripts must guard on the variable
+//     being unset, the same pattern as the existing GITHUB_OUTPUT guard in
+//     the scaffold scripts.
+//
+// Malformed content is a hard error, not a silent proceed: a typo like
+// "skipped true" silently ignored would let a duplicate agent run start —
+// the exact failure mode the pre-checks exist to prevent. Values that
+// case-insensitively match a reserved key but differ in case (SKIPPED=true)
+// are rejected for the same reason.
+//
+// Supported syntax (line-based):
+//
+//	skipped=true
+//	reason=an open PR already addresses this issue
+//	# comments and blank lines are ignored
+//
+// The format resembles GITHUB_OUTPUT but is not compatible with it: there
+// is no quoting, and the "key<<DELIMITER" heredoc form for multiline
+// values is not supported. Values are single-line and may not contain
+// control characters. Surrounding whitespace around both key and value is
+// not significant. Later assignments to the same key win.
+package prescript
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// EnvVar is the environment variable through which fullsend run passes the
+// output file path to the pre-script. Scripts must guard on it being unset
+// (older CLI versions do not export it).
+const EnvVar = "FULLSEND_PRESCRIPT_OUTPUT"
+
+const (
+	skippedKey = "skipped"
+	reasonKey  = "reason"
+
+	// maxOutputSize caps the output file read, mirroring internal/envfile.
+	maxOutputSize = 1 << 20 // 1 MB
+)
+
+// validKeyRe allows hyphens as well as underscores: GitHub Actions output
+// names conventionally use hyphens, and rejecting them would turn a
+// perfectly ordinary key into a hard run failure.
+var validKeyRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
+
+// heredocRe matches GITHUB_OUTPUT's "key<<DELIMITER" multiline form, which
+// this protocol does not support. Anchored at the key so it cannot fire on
+// a value that merely contains "<<".
+var heredocRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*<<`)
+
+// reservedKeys are the keys the protocol itself interprets. A key that
+// differs from one of these only by case is rejected rather than stored as
+// an unrelated output — see the package doc on silent-proceed failures.
+var reservedKeys = []string{skippedKey, reasonKey}
+
+// Result is the parsed pre-script output.
+type Result struct {
+	// Skipped is true when the pre-script wrote skipped=true, requesting
+	// that fullsend run stop before sandbox creation.
+	Skipped bool
+	// Reason is the optional human-readable reason accompanying a skip.
+	Reason string
+	// Outputs holds every key=value pair the script wrote, including
+	// skipped and reason, with later assignments overriding earlier ones.
+	Outputs map[string]string
+}
+
+// Prepare creates the file the pre-script writes its outputs to, inside
+// dir. Using the run directory rather than the system temp directory keeps
+// the file out of reach of tmp reapers during a long pre-script. The
+// cleanup func removes the file and never fails loudly.
+func Prepare(dir string) (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp(dir, "prescript-*.out")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating pre-script output file: %w", err)
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(name)
+		return "", nil, fmt.Errorf("closing pre-script output file: %w", err)
+	}
+	return name, func() { _ = os.Remove(name) }, nil
+}
+
+// ParseFile reads a pre-script output file. An empty file yields a Result
+// with Skipped false and no outputs (proceed). Malformed lines, invalid
+// keys, values containing control characters, and skipped values other
+// than "true"/"false" are hard errors.
+//
+// A missing file is also a hard error: Prepare creates the file before the
+// script runs, so its absence afterwards means something removed it, and
+// treating that as "proceed" is the silent-proceed failure this protocol
+// exists to prevent.
+func ParseFile(path string) (Result, error) {
+	res := Result{Outputs: map[string]string{}}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return res, fmt.Errorf("pre-script output file %s is missing — it was created before the "+
+				"pre-script ran, so the script must have removed it", filepath.Base(path))
+		}
+		return res, fmt.Errorf("opening pre-script output: %w", err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return res, fmt.Errorf("stat pre-script output: %w", err)
+	}
+	if info.Size() > maxOutputSize {
+		return res, fmt.Errorf("pre-script output %s exceeds maximum size (%d bytes)", path, maxOutputSize)
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(strings.TrimRight(scanner.Text(), "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Checked before the key=value split so a delimiter containing "="
+		// (reason<<E=OF) still gets the message naming the limitation.
+		// Anchored to the key position so an ordinary value containing
+		// "<<" (reason=shift left << 2) is unaffected.
+		if heredocRe.MatchString(line) {
+			return res, fmt.Errorf("pre-script output line %d: %q uses GITHUB_OUTPUT heredoc syntax, "+
+				"which this protocol does not support — values must be single-line key=value", lineNum, line)
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			return res, fmt.Errorf("pre-script output line %d: %q is not key=value", lineNum, line)
+		}
+		key = strings.TrimSpace(key)
+		if !validKeyRe.MatchString(key) {
+			return res, fmt.Errorf("pre-script output line %d: invalid key %q", lineNum, key)
+		}
+		if canonical, ok := miscasedReservedKey(key); ok {
+			return res, fmt.Errorf("pre-script output line %d: key %q differs only in case from the reserved "+
+				"key %q — reserved keys are lowercase", lineNum, key, canonical)
+		}
+		value = strings.TrimSpace(value)
+		if i := strings.IndexFunc(value, isControlChar); i >= 0 {
+			return res, fmt.Errorf("pre-script output line %d: value for %q contains a control character (%#U) "+
+				"at offset %d — values must be plain single-line text", lineNum, key, rune(value[i]), i)
+		}
+		res.Outputs[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return res, fmt.Errorf("reading pre-script output: %w", err)
+	}
+
+	// An absent skipped key means proceed. A key that is *present but
+	// empty* is a different, far more suspicious state — `skipped=${SKIP}`
+	// with SKIP unset — and treating it as "proceed" would be the silent
+	// duplicate run this protocol exists to prevent.
+	v, present := res.Outputs[skippedKey]
+	switch {
+	case !present:
+		res.Skipped = false
+	case v == "false":
+		res.Skipped = false
+	case v == "true":
+		res.Skipped = true
+	default:
+		return res, fmt.Errorf("pre-script output: skipped must be \"true\" or \"false\", got %q", v)
+	}
+	res.Reason = res.Outputs[reasonKey]
+	return res, nil
+}
+
+// miscasedReservedKey reports whether key matches a reserved key
+// case-insensitively without matching it exactly, returning the reserved
+// spelling the author probably meant.
+func miscasedReservedKey(key string) (string, bool) {
+	for _, reserved := range reservedKeys {
+		if key != reserved && strings.EqualFold(key, reserved) {
+			return reserved, true
+		}
+	}
+	return "", false
+}
+
+// isControlChar reports whether r is a C0 control character or DEL. These
+// are rejected in values because a bare \r or \n written into
+// GITHUB_OUTPUT would be read as a line terminator by the Actions runner,
+// letting a value smuggle in additional output entries — including an
+// override of skipped itself.
+func isControlChar(r rune) bool {
+	return r < 0x20 || r == 0x7f
+}
+
+// validateOutputs re-checks what ParseFile already enforces. Relay and
+// LogLine are exported and a hand-built Result must not be able to inject
+// extra GITHUB_OUTPUT entries — a newline in a *key* smuggles a line just
+// as effectively as one in a value, including an override of skipped.
+func validateOutputs(outputs map[string]string) error {
+	for k, v := range outputs {
+		if !validKeyRe.MatchString(k) {
+			return fmt.Errorf("refusing to relay invalid key %q", k)
+		}
+		if strings.IndexFunc(v, isControlChar) >= 0 {
+			return fmt.Errorf("refusing to relay value for %q: contains a control character", k)
+		}
+	}
+	return nil
+}
+
+// Relay surfaces the pre-script outputs to the surrounding CI system so
+// remaining workflow-level gating (if any) can consume them. Today only
+// GitHub Actions is detected; other CIs get the outputs in the run log
+// only (fullsend run logs them on every path). Returns whether a relay
+// target was found.
+//
+// Callers must invoke Relay on both the skip and proceed paths: the
+// skipped key is always written (normalized to "true"/"false") so
+// consumers can gate on its value, and an absent key means the CLI
+// predates this protocol rather than "not skipped".
+func Relay(res Result) (relayed bool, err error) {
+	target := os.Getenv("GITHUB_OUTPUT")
+	// Gate on GITHUB_ACTIONS as well as the file path, matching
+	// detectForgePlatform: a stray exported GITHUB_OUTPUT in a local shell
+	// must not cause fullsend to append to an unrelated file.
+	if target == "" || os.Getenv("GITHUB_ACTIONS") != "true" {
+		return false, nil
+	}
+
+	if err := validateOutputs(res.Outputs); err != nil {
+		return false, err
+	}
+
+	f, err := os.OpenFile(target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return false, fmt.Errorf("opening GITHUB_OUTPUT: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing GITHUB_OUTPUT: %w", cerr)
+			relayed = false
+		}
+	}()
+
+	keys := make([]string, 0, len(res.Outputs))
+	for k := range res.Outputs {
+		if k != skippedKey {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s=%t\n", skippedKey, res.Skipped)
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%s=%s\n", k, res.Outputs[k])
+	}
+	if _, err := f.WriteString(b.String()); err != nil {
+		return false, fmt.Errorf("writing GITHUB_OUTPUT: %w", err)
+	}
+	return true, nil
+}
+
+// LogLine renders the outputs as a single stable, sorted line for the run
+// log, so non-GitHub CIs (and local runs) can still see what the
+// pre-script reported. Returns "" when there is nothing to show, or when
+// an output would break the single-line rendering.
+func LogLine(res Result) string {
+	if err := validateOutputs(res.Outputs); err != nil {
+		return ""
+	}
+
+	keys := make([]string, 0, len(res.Outputs))
+	for k := range res.Outputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, res.Outputs[k]))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/prescript/prescript.go
+++ b/internal/prescript/prescript.go
@@ -1,4 +1,4 @@
-// Package prescript implements the pre-script skip protocol (issue #4718).
+// Package prescript implements the pre-script output protocol (issue #4718).
 //
 // fullsend run hands the harness pre-script an output file path via the
 // FULLSEND_PRESCRIPT_OUTPUT environment variable. The script may append
@@ -7,7 +7,7 @@
 // exits. When skipped=true, fullsend run reports a "skipped" status and
 // exits successfully before creating the sandbox.
 //
-// The normative contract lives in docs/normative/prescript-output/v1;
+// The protocol is specified normatively in docs/normative/prescript-output/v1;
 // that document, not this comment, is what pre-script authors write
 // against. The summary below is a convenience for readers of this package.
 //

--- a/internal/prescript/prescript_test.go
+++ b/internal/prescript/prescript_test.go
@@ -1,0 +1,338 @@
+package prescript
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepare_CreatesRemovableFileInDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path, cleanup, err := Prepare(dir)
+	require.NoError(t, err)
+	require.FileExists(t, path)
+	// The file lives in the run directory, not the system temp dir, so a
+	// tmp reaper cannot remove it during a long pre-script and it lands in
+	// the uploaded run artifacts.
+	assert.Equal(t, dir, filepath.Dir(path))
+
+	cleanup()
+	assert.NoFileExists(t, path)
+}
+
+func TestParseFile_MissingFileIsHardError(t *testing.T) {
+	t.Parallel()
+
+	// Prepare creates the file before the script runs, so absence
+	// afterwards means the script removed it — treating that as "proceed"
+	// is the silent-proceed failure this protocol prevents.
+	_, err := ParseFile(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.ErrorContains(t, err, "is missing")
+}
+
+func TestParseFile_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "")
+	res, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.False(t, res.Skipped)
+}
+
+func TestParseFile_Skip(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "skipped=true\nreason=an open PR already addresses this issue\n")
+	res, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.True(t, res.Skipped)
+	assert.Equal(t, "an open PR already addresses this issue", res.Reason)
+}
+
+func TestParseFile_ExplicitFalse(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "skipped=false\n")
+	res, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.False(t, res.Skipped)
+}
+
+func TestParseFile_CommentsBlanksAndCRLF(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "# comment\r\n\r\nskipped=true\r\n")
+	res, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.True(t, res.Skipped)
+}
+
+func TestParseFile_LastAssignmentWins(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "skipped=true\nskipped=false\n")
+	res, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.False(t, res.Skipped)
+}
+
+func TestParseFile_ExtraOutputs(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "skipped=true\nexisting_pr=123\n")
+	res, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "123", res.Outputs["existing_pr"])
+}
+
+func TestParseFile_ValuePreservesEqualsAndSpaces(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "reason=a=b c\n")
+	res, err := ParseFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "a=b c", res.Reason)
+}
+
+func TestParseFile_MalformedLine(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "skipped true\n")
+	_, err := ParseFile(path)
+	require.ErrorContains(t, err, "not key=value")
+}
+
+func TestParseFile_InvalidKey(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "bad key=1\n")
+	_, err := ParseFile(path)
+	require.ErrorContains(t, err, "invalid key")
+}
+
+func TestParseFile_InvalidSkippedValue(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "skipped=yes\n")
+	_, err := ParseFile(path)
+	require.ErrorContains(t, err, `skipped must be "true" or "false"`)
+}
+
+func TestParseFile_OversizeFile(t *testing.T) {
+	t.Parallel()
+
+	path := writeOutput(t, "# "+strings.Repeat("x", maxOutputSize)+"\n")
+	_, err := ParseFile(path)
+	require.ErrorContains(t, err, "exceeds maximum size")
+}
+
+func TestRelay_NoTarget(t *testing.T) {
+	// t.Setenv forbids t.Parallel.
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", "")
+
+	relayed, err := Relay(Result{Skipped: true})
+	require.NoError(t, err)
+	assert.False(t, relayed)
+}
+
+// A stray exported GITHUB_OUTPUT in a local shell must not make fullsend
+// append to an unrelated file — GITHUB_ACTIONS is the repo-wide signal.
+func TestRelay_RequiresGitHubActions(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_OUTPUT", out)
+	t.Setenv("GITHUB_ACTIONS", "")
+
+	relayed, err := Relay(Result{Skipped: true})
+	require.NoError(t, err)
+	assert.False(t, relayed)
+	assert.NoFileExists(t, out)
+}
+
+func TestRelay_RejectsControlCharactersInValues(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", out)
+
+	// Relay is exported, so a hand-built Result must not be able to smuggle
+	// entries past the parser's validation.
+	relayed, err := Relay(Result{
+		Skipped: true,
+		Outputs: map[string]string{"reason": "dup\rskipped=false"},
+	})
+	require.ErrorContains(t, err, "control character")
+	assert.False(t, relayed)
+	assert.NoFileExists(t, out)
+}
+
+func TestRelay_WritesSkippedAndOutputs(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", out)
+
+	res := Result{
+		Skipped: true,
+		Reason:  "duplicate",
+		Outputs: map[string]string{
+			"skipped": "true",
+			"reason":  "duplicate",
+			"pr":      "42",
+		},
+	}
+	relayed, err := Relay(res)
+	require.NoError(t, err)
+	assert.True(t, relayed)
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, "skipped=true\npr=42\nreason=duplicate\n", string(data))
+}
+
+func TestRelay_AppendsToExistingFile(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "github-output")
+	require.NoError(t, os.WriteFile(out, []byte("prior=1\n"), 0o600))
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", out)
+
+	relayed, err := Relay(Result{Skipped: false})
+	require.NoError(t, err)
+	assert.True(t, relayed)
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, "prior=1\nskipped=false\n", string(data))
+}
+
+func writeOutput(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prescript-output")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// An embedded CR is a line terminator to the GitHub Actions runner, so a
+// value carrying one could smuggle extra GITHUB_OUTPUT entries — including
+// an override of skipped itself. Rejecting it at parse time is what makes
+// the plain key=value relay safe.
+func TestParseFile_RejectsEmbeddedControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	for name, content := range map[string]string{
+		"carriage return in reason": "skipped=true\nreason=dup\rskipped=false\n",
+		"NUL in reason":             "reason=a\x00b\n",
+		"escape in extra output":    "pr=\x1b[31mred\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseFile(writeOutput(t, content))
+			require.ErrorContains(t, err, "control character")
+		})
+	}
+}
+
+// GitHub Actions output names conventionally use hyphens; rejecting them
+// would turn an ordinary key into a hard run failure.
+func TestParseFile_HyphenatedKeysAllowed(t *testing.T) {
+	t.Parallel()
+
+	res, err := ParseFile(writeOutput(t, "skipped=true\nexisting-pr=123\n"))
+	require.NoError(t, err)
+	assert.True(t, res.Skipped)
+	assert.Equal(t, "123", res.Outputs["existing-pr"])
+}
+
+// A mis-cased reserved key would otherwise be stored as an unrelated
+// output and the run would proceed silently — the exact failure the
+// hard-error policy exists to prevent.
+func TestParseFile_MiscasedReservedKeyIsHardError(t *testing.T) {
+	t.Parallel()
+
+	for _, line := range []string{"SKIPPED=true\n", "Skipped=true\n", "REASON=dup\n"} {
+		_, err := ParseFile(writeOutput(t, line))
+		require.ErrorContains(t, err, "differs only in case", "input %q", line)
+	}
+}
+
+func TestParseFile_HeredocSyntaxNamesTheLimitation(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseFile(writeOutput(t, "skipped=true\nreason<<EOF\nline one\nEOF\n"))
+	require.ErrorContains(t, err, "heredoc syntax")
+}
+
+// Whitespace around the value is insignificant, matching the key side —
+// "skipped = true" must not fail the run.
+func TestParseFile_ValueWhitespaceIsInsignificant(t *testing.T) {
+	t.Parallel()
+
+	res, err := ParseFile(writeOutput(t, "skipped = true\nreason=   padded   \n"))
+	require.NoError(t, err)
+	assert.True(t, res.Skipped)
+	assert.Equal(t, "padded", res.Reason)
+}
+
+func TestLogLine(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, LogLine(Result{}))
+	assert.Equal(t, "pr=42 reason=dup skipped=true", LogLine(Result{
+		Outputs: map[string]string{"skipped": "true", "reason": "dup", "pr": "42"},
+	}))
+}
+
+// `skipped=${SKIP}` with SKIP unset must not degrade into a duplicate run.
+// An *absent* skipped key still means proceed.
+func TestParseFile_EmptySkippedValueIsHardError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseFile(writeOutput(t, "skipped=\nreason=meant to skip\n"))
+	require.ErrorContains(t, err, `skipped must be "true" or "false"`)
+
+	res, err := ParseFile(writeOutput(t, "reason=no skip requested\n"))
+	require.NoError(t, err)
+	assert.False(t, res.Skipped)
+}
+
+// A newline in a key smuggles a GITHUB_OUTPUT line just as effectively as
+// one in a value — including an override of the skipped Relay just wrote.
+func TestRelay_RejectsInvalidKeys(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_OUTPUT", out)
+
+	relayed, err := Relay(Result{
+		Skipped: false,
+		Outputs: map[string]string{"a\nskipped": "true"},
+	})
+	require.ErrorContains(t, err, "invalid key")
+	assert.False(t, relayed)
+	assert.NoFileExists(t, out)
+}
+
+func TestLogLine_DropsInvalidOutputs(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, LogLine(Result{Outputs: map[string]string{"a\nskipped": "true"}}))
+	assert.Empty(t, LogLine(Result{Outputs: map[string]string{"ok": "a\rb"}}))
+}
+
+// The heredoc check is anchored at the key, so an ordinary value
+// containing "<<" is not mistaken for one.
+func TestParseFile_HeredocDetection(t *testing.T) {
+	t.Parallel()
+
+	// Delimiter containing "=" still names the limitation.
+	_, err := ParseFile(writeOutput(t, "reason<<E=OF\nbody\nE=OF\n"))
+	require.ErrorContains(t, err, "heredoc syntax")
+
+	res, err := ParseFile(writeOutput(t, "reason=shift left << 2\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "shift left << 2", res.Reason)
+}

--- a/internal/statuscomment/statuscomment.go
+++ b/internal/statuscomment/statuscomment.go
@@ -142,8 +142,18 @@ func (n *Notifier) PostStart(ctx context.Context, description string) error {
 	return nil
 }
 
-// PostCompletion posts or edits a completion comment.
-// status should be "success", "failure", or "cancelled".
+// PostCompletion posts or edits a completion comment with no extra
+// detail. See PostCompletionWithDetail.
+func (n *Notifier) PostCompletion(ctx context.Context, description, status string) error {
+	return n.PostCompletionWithDetail(ctx, description, status, "")
+}
+
+// PostCompletionWithDetail posts or edits a completion comment.
+// status should be "success", "failure", "cancelled", or "skipped".
+//
+// detail is an optional short explanation rendered after the status label
+// (e.g. the pre-script's skip reason). It may come from script output, so
+// it is sanitized before rendering — see sanitizeDetail.
 //
 // Placement follows three rules:
 //  1. If the agent posted output after the start comment (a bot-authored
@@ -155,7 +165,7 @@ func (n *Notifier) PostStart(ctx context.Context, description string) error {
 //  3. Otherwise (other activity pushed past the start, but no agent
 //     output), a new completion comment is posted so the user sees the
 //     result while reading forward.
-func (n *Notifier) PostCompletion(ctx context.Context, description, status string) error {
+func (n *Notifier) PostCompletionWithDetail(ctx context.Context, description, status, detail string) error {
 	completionTime := n.now().UTC()
 
 	if !commentEnabled(n.cfg.Comment.Completion) {
@@ -175,7 +185,7 @@ func (n *Notifier) PostCompletion(ctx context.Context, description, status strin
 		return err
 	}
 
-	body := n.buildCompletionBody(description, status, completionTime)
+	body := n.buildCompletionBody(description, status, detail, completionTime)
 
 	if n.startCommentID != 0 {
 		agentPosted, startIsLast, err := n.analyzeTimeline(ctx)
@@ -254,8 +264,11 @@ func (n *Notifier) buildStartBody(description string) string {
 	return b.String()
 }
 
-func (n *Notifier) buildCompletionBody(description, status string, completionTime time.Time) string {
+func (n *Notifier) buildCompletionBody(description, status, detail string, completionTime time.Time) string {
 	statusLabel := statusEmoji(status) + " " + capitalize(status)
+	if d := sanitizeDetail(detail); d != "" {
+		statusLabel += " (" + d + ")"
+	}
 
 	var b strings.Builder
 	b.WriteString(n.marker)
@@ -331,6 +344,63 @@ func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
+// maxDetailLen caps the rendered status detail so a verbose script cannot
+// turn the one-line status comment into a wall of text.
+const maxDetailLen = 200
+
+// sanitizeDetail makes a status detail safe to embed in the completion
+// comment. The detail can originate in script output (the pre-script skip
+// reason), which may in turn carry forge-sourced text, so it must not be
+// able to break out of the single status line, forge an HTML comment
+// marker (the `fullsend:agent-status` / `fullsend:status:terminal` tags
+// that ReconcileOrphaned depends on), or inject raw HTML.
+func sanitizeDetail(detail string) string {
+	if detail == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	lastSpace := false
+	for _, r := range detail {
+		switch {
+		case r < 0x20 || r == 0x7f:
+			// Control characters — including the newlines that would let a
+			// reason escape the status line — collapse to a single space.
+			if !lastSpace {
+				b.WriteRune(' ')
+				lastSpace = true
+			}
+		case r == ' ':
+			if !lastSpace {
+				b.WriteRune(' ')
+				lastSpace = true
+			}
+		case r == '<':
+			// Blocks `<!--`, so a reason cannot forge a status marker, and
+			// blocks raw HTML generally. GitHub renders the entity as `<`.
+			b.WriteString("&lt;")
+			lastSpace = false
+		case r == '[':
+			// Blocks `[text](url)`, so a reason cannot render a link whose
+			// visible text lies about its destination — the same concern
+			// isSafeURL guards for the run URL on the line below. Bare
+			// URLs still autolink under GFM, but those display their real
+			// target.
+			b.WriteString("&#91;")
+			lastSpace = false
+		default:
+			b.WriteRune(r)
+			lastSpace = false
+		}
+	}
+
+	out := strings.TrimSpace(b.String())
+	if runes := []rune(out); len(runes) > maxDetailLen {
+		out = strings.TrimSpace(string(runes[:maxDetailLen])) + "…"
+	}
+	return out
+}
+
 func buildMarker(runID string) (string, error) {
 	if !validRunID.MatchString(runID) {
 		return "", fmt.Errorf("invalid run ID %q: must match [a-zA-Z0-9_-]+", runID)
@@ -352,6 +422,8 @@ func statusEmoji(status string) string {
 		return "✅"
 	case "failure":
 		return "❌"
+	case "skipped":
+		return "⏭️"
 	default:
 		return "⚠️"
 	}

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -3,6 +3,7 @@ package statuscomment
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -196,6 +197,28 @@ func TestPostCompletion_Cancelled(t *testing.T) {
 	assert.Equal(t, 1, fc.UpdatedComments[0].CommentID)
 	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Working")
 	assert.Contains(t, fc.UpdatedComments[0].Body, "⚠️ Cancelled")
+}
+
+func TestPostCompletion_Skipped(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.Len(t, fc.IssueComments["org/repo/7"], 1)
+
+	completionTime := fixedTime().Add(2 * time.Minute)
+	n.now = func() time.Time { return completionTime }
+
+	err = n.PostCompletion(context.Background(), "Working", "skipped")
+	require.NoError(t, err)
+
+	require.Len(t, fc.UpdatedComments, 1)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Working")
+	assert.Contains(t, fc.UpdatedComments[0].Body, "⏭️ Skipped")
 }
 
 func TestAllDisabled_NoAPICalls(t *testing.T) {
@@ -1080,4 +1103,83 @@ func TestClientFactory_CompletionDisabled_DeleteError(t *testing.T) {
 	require.NoError(t, err, "should not return error — fail-open on cleanup")
 	require.Len(t, warnings, 1)
 	assert.Contains(t, warnings[0], "forbidden")
+}
+
+func TestPostCompletionWithDetail_SkippedShowsReason(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+
+	completionTime := fixedTime().Add(2 * time.Minute)
+	n.now = func() time.Time { return completionTime }
+
+	err := n.PostCompletionWithDetail(context.Background(), "Working", "skipped",
+		"PR #123 already addresses this issue")
+	require.NoError(t, err)
+
+	require.Len(t, fc.UpdatedComments, 1)
+	// A skip with no visible reason is the one thing a reader needs and
+	// the one thing the status line used to omit.
+	assert.Contains(t, fc.UpdatedComments[0].Body, "⏭️ Skipped (PR #123 already addresses this issue)")
+}
+
+func TestSanitizeDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"empty":                    {"", ""},
+		"plain":                    {"open PR exists", "open PR exists"},
+		"newline collapses":        {"line one\nline two", "line one line two"},
+		"CR collapses":             {"a\rb", "a b"},
+		"tabs and NUL collapse":    {"a\t\x00b", "a b"},
+		"runs of space collapse":   {"a   b", "a b"},
+		"trims":                    {"  padded  ", "padded"},
+		"HTML comment neutralized": {"<!-- fullsend:status:terminal -->", "&lt;!-- fullsend:status:terminal -->"},
+		"markdown link neutralized": {"see [details](https://evil.example)",
+			"see &#91;details](https://evil.example)"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, sanitizeDetail(tc.in))
+		})
+	}
+}
+
+func TestSanitizeDetail_Truncates(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeDetail(strings.Repeat("x", maxDetailLen+50))
+	assert.Equal(t, strings.Repeat("x", maxDetailLen)+"…", got)
+}
+
+// A reason is script-controlled text, so it must not be able to forge the
+// marker comments ReconcileOrphaned depends on, nor escape the status line.
+func TestPostCompletionWithDetail_DetailCannotForgeMarkers(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+
+	err := n.PostCompletionWithDetail(context.Background(), "Working", "skipped",
+		"evil\n<!-- fullsend:agent-status:999 -->")
+	require.NoError(t, err)
+
+	body := fc.UpdatedComments[0].Body
+	// The escaped text may still read as "fullsend:agent-status", but it
+	// can no longer open an HTML comment, so only the real marker parses.
+	assert.NotContains(t, body, "<!-- fullsend:agent-status:999")
+	assert.Equal(t, 1, strings.Count(body, "<!-- fullsend:agent-status"))
+	assert.Equal(t, 1, strings.Count(body, terminalTag))
+	// And the detail stays on the status line.
+	assert.Contains(t, body, "⏭️ Skipped (evil &lt;!-- fullsend:agent-status:999 -->)")
 }


### PR DESCRIPTION
## Summary
CLI half of the direction agreed on #4718 ([comment](https://github.com/fullsend-ai/fullsend/issues/4718#issuecomment-5108348899), acked by @ifireball, @rh-hemartin, @ggallen): pre-scripts get a first-class skip protocol inside `fullsend run`, so the reusable workflows' inline pre-script calls — the source of the double execution, and the last consumer of the scaffold script copies (#5667) — become removable in a follow-up PR.

## Related Issue
Part of #4718 (also unblocks #5667, closed as duplicate into this effort).

## Changes
- **New `internal/prescript` package** owning the protocol: `fullsend run` exports `FULLSEND_PRESCRIPT_OUTPUT` (temp file path) into the pre-script env; the script may append GitHub-output-style `key=value` lines (`skipped=true`, optional `reason=...`). Missing/empty file → proceed (today's behavior). Malformed content is a hard error so a mistyped skip cannot silently proceed as a duplicate agent run.
- **`internal/cli/run.go`**: pre-script block extracted into a `runPreScript` helper wired to the protocol; on `skipped=true` the run reports a skipped status, relays outputs to `GITHUB_OUTPUT` (when under GHA; auto-detected in the CLI, not hard-coded in workflow YAML — portable per the review discussion on #5016), and exits 0 **before sandbox creation**.
- **`internal/statuscomment`**: new `skipped` completion status (⏭️).

Version skew (ADR 0062): both directions degrade to current behavior — scripts unaware of the protocol proceed as before; protocol-aware scripts must guard on the env var being unset under older CLIs (same pattern as the existing `GITHUB_OUTPUT` guard).

Follow-ups (sequenced on #4718): workflow cleanup + scaffold script deletion (resolves #5667), agents-repo script changes (recut of fullsend-ai/agents#175), ADR rewrite (#5016).

## Testing
- [x] `make lint` passes (staged)
- [x] Tests added/updated for new or modified logic — full coverage of `internal/prescript`, `runPreScript` exercised with fixture scripts (skip, proceed, runner-env, script failure, malformed output), `statuscomment` skipped-status test
- [x] `make go-vet`, `go build ./...`, `go test -race` on changed packages; full `go test ./...` run — one pre-existing failure on pristine `origin/main` unrelated to this diff (`TestListTriggeredHarnesses_BaseComposition`, macOS temp-dir symlink vs workspace-root escape check)
- [ ] `make e2e-test` not run locally (requires live pool orgs + mint OIDC); covered by CI

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it
