### PR TITLE
ci(#5733): pin podman to 4.x to avoid crun incompatibility

### DIFF
--- a/.github/scripts/install-podman.sh
+++ b/.github/scripts/install-podman.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Pin and install podman, working around a crun incompatibility on some
+# runner images.
+#
+# Runner images occasionally pre-install podman 5.x paired with a crun too
+# old to support it, breaking sandbox creation with "crun: unknown version
+# specified". Pin to the 4.x series, which matches the crun shipped on these
+# images, until GitHub Actions runner images ship a compatible crun pairing.
+# `apt-get install -y podman` alone does not downgrade an already-installed
+# newer version, so the pin's Pin-Priority authorizes the downgrade and
+# --allow-downgrades permits apt to execute it.
+#
+# See #5733. Remove this pin once runner images ship crun >= 1.15
+# (podman 5.x's requirement) as standard.
+#
+# Usage:
+#   .github/scripts/install-podman.sh
+set -euo pipefail
+
+sudo install -d /etc/apt/preferences.d
+printf 'Package: podman\nPin: version 4.*\nPin-Priority: 1001\n' \
+  | sudo tee /etc/apt/preferences.d/podman-pin >/dev/null
+sudo apt-get update
+sudo apt-get install -y --allow-downgrades podman
+
+installed_version="$(podman --version)"
+case "${installed_version}" in
+  *"version 4."*) ;;
+  *)
+    echo "::error::Failed to pin podman to the 4.x series (see #5733); got: ${installed_version}"
+    exit 1
+    ;;
+esac
+
+echo "${installed_version}"

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -185,9 +185,7 @@ jobs:
 
       - name: Install Podman
         if: steps.changes.outputs.relevant != 'false'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
+        run: .github/scripts/install-podman.sh
 
       - name: Configure rootless Podman
         if: steps.changes.outputs.relevant != 'false'

--- a/action.yml
+++ b/action.yml
@@ -257,10 +257,7 @@ runs:
 
     - name: Install Podman
       shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y podman
-        podman --version
+      run: "$GITHUB_ACTION_PATH/.github/scripts/install-podman.sh"
 
     - name: Configure rootless Podman
       shell: bash

--- a/internal/scaffold/vendormanifest.go
+++ b/internal/scaffold/vendormanifest.go
@@ -153,6 +153,7 @@ var vendoredDefaultsInfraPaths = []string{
 	".github/actions/setup-gcp/action.yml",
 	".github/actions/validate-enrollment/action.yml",
 	".github/scripts/install-openshell.sh",
+	".github/scripts/install-podman.sh",
 	".github/scripts/openshell-version.sh",
 }
 


### PR DESCRIPTION
## Summary
GitHub Actions runner images have begun pre-installing podman 5.8.4, which requires crun >= 1.15. The runner's system crun stays at 1.14.1, so sandbox creation fails deterministically with `crun: unknown version specified: OCI runtime error`, killing agent runs before the agent starts.

## Related Issue
Closes #5733

## Changes
- Add `.github/scripts/install-podman.sh` (matching the existing `install-openshell.sh` convention): writes an apt preferences file pinning `podman` to the `4.*` series with `Pin-Priority: 1001` (authorizes downgrading an already-installed newer version), runs `apt-get install -y --allow-downgrades podman`, then asserts the installed version is actually 4.x — fails loudly with a clear error if the pin didn't take, instead of silently leaving 5.x in place and resurfacing later as a confusing crun error.
- `action.yml` and `.github/workflows/functional-tests.yml`: replace the duplicated inline "Install Podman" step with a call to the shared script.
- `apt-get install -y podman` alone does not downgrade an already-installed newer version, which is why the plain install left podman 5.8.4 in place — this is why both the pin's `Pin-Priority` and `--allow-downgrades` are needed together.

## Testing
- [x] `make lint` passes (staged changes, including shellcheck on the new script, the GitHub Actions workflow linter, and pinact)
- [ ] Tests added/updated for new or modified logic — not applicable, no Go code changed
- [x] Manually validated via `workflow_dispatch` on this branch (`gh workflow run functional-tests.yml --ref fix-5733-pin-podman-version`): confirmed the new script executes (this PR's `pull_request_target`-triggered check does *not* exercise branch changes, since GitHub resolves that trigger's workflow YAML from `main`) and that podman resolves to `4.9.3+ds1-1ubuntu0.2` and passes the version assertion. Did not hit a runner with podman 5.x pre-installed during validation (that variant is still a partial rollout per #5733), so the downgrade path itself is not yet empirically exercised — the version assertion is the safety net for that case.
- [ ] `make e2e-test` / full dogfood install of `action.yml` against a test org not run (requires live pool orgs + mint OIDC per `docs/guides/dev/testing-workflows.md`); reviewed as low-risk since `action.yml`'s step is now the identical shared script already validated above

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (`ci(#5733)`, not `fix(ci)` — CI-only fix is `ci`, per the forbidden type/scope table in COMMITS.md; issue number used as scope per convention)
- [x] Commits are signed off (DCO)
- [x] I wrote this contribution myself and can explain all changes in it
