### PR TITLE
refactor(#5696): scope shim permissions to dispatch job

### DIFF
--- a/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
@@ -17,14 +17,6 @@
 # stage jobs with -agent- suffix. Roles operate independently (#2452).
 name: fullsend
 
-permissions:
-  actions: write
-  id-token: write
-  contents: write
-  issues: write
-  packages: read
-  pull-requests: write
-
 on:
   issues:
     types: [opened, edited, labeled]
@@ -35,6 +27,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   dispatch:
     if: >-
@@ -42,6 +36,13 @@ jobs:
        || github.event.pull_request.head.ref != 'fullsend/scaffold-install')
       && (github.event_name != 'issue_comment'
        || github.event.comment.user.type != 'Bot')
+    permissions:
+      actions: write
+      id-token: write
+      contents: write
+      issues: write
+      packages: read
+      pull-requests: write
     uses: __REUSABLE_DISPATCH__
     with:
       event_action: ${{ github.event.action }}

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
@@ -19,12 +19,6 @@
 # changes to enrolled repos.
 name: fullsend
 
-permissions:
-  actions: write
-  id-token: write
-  contents: read
-  pull-requests: read
-
 on:
   issues:
     types: [opened, edited, labeled]
@@ -34,6 +28,8 @@ on:
     types: [opened, synchronize, ready_for_review, closed, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
+
+permissions: {}
 
 jobs:
   dispatch:
@@ -54,6 +50,11 @@ jobs:
         github.event.action != 'labeled'
         || startsWith(github.event.label.name, 'ready-')
       )
+    permissions:
+      actions: write
+      id-token: write
+      contents: read
+      pull-requests: read
     uses: __ORG__/.fullsend/.github/workflows/dispatch.yml@main
     with:
       event_action: ${{ github.event.action }}


### PR DESCRIPTION
## Summary

- Moves workflow-level `permissions` into `jobs.dispatch.permissions` in both `shim-per-repo.yaml` and `shim-workflow-call.yaml`
- No behavioral change; the dispatch job already received these permissions via inheritance
- Prevents future jobs from silently inheriting broad permissions and silences false positives from security linters (CodeRabbit, etc.)

Closes #5696

## Test plan

- [ ] Verify `make lint` passes (pre-commit hooks confirmed on commit)
- [ ] Confirm scaffold output matches expected permissions placement
- [ ] Review that no other jobs in the shim templates relied on inherited permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)