### PR TITLE
fix(docs): track OpenShell pin with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,17 @@
     },
     {
       "customType": "regex",
+      "description": "Track OpenShell version pin in the local agents guide",
+      "managerFilePatterns": ["/^docs/guides/user/running-agents-locally\\.md$/"],
+      "matchStrings": [
+        "export OPENSHELL_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "NVIDIA/OpenShell",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
       "description": "Track the gcloud CLI version pin in the runner image. GCLOUD_SHA256_{AMD64,ARM64} must be refreshed manually from https://cloud.google.com/sdk/docs/install — the runner-image PR build fails on checksum mismatch until they are.",
       "managerFilePatterns": ["/^images/runner/Containerfile$/"],
       "matchStrings": [


### PR DESCRIPTION
## Summary

Teach Renovate to track the OpenShell version embedded in the local agents guide. This keeps the documented install command in sync with the repository's OpenShell pin during future dependency updates.

## Related Issue

Fixes fullsend-ai/fullsend#4808

## Changes

- add a regex custom manager for `docs/guides/user/running-agents-locally.md`
- use the existing `NVIDIA/OpenShell` dependency name so the docs update joins the `openshell` package group

## Testing

- [x] `make lint` passes (stage changes first, then run)
- [ ] Tests added/updated for new or modified logic — N/A; this is a Renovate configuration-only change
- `jq empty renovate.json`
- verified the configured regex extracts `0.0.83` from the guide and matches `.github/scripts/openshell-version.sh`

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it
