### PR TITLE
chore(#5824): remove CUSTOM_BASE overlay loop from reusable workflows

### DIFF
--- a/.github/actions/prepare-workspace/action.yml
+++ b/.github/actions/prepare-workspace/action.yml
@@ -43,20 +43,6 @@ runs:
             cp -r "${SRC}/${dir}/." "${DEST}${dir}/"
           fi
         done
-        CUSTOM_BASE="customized"
-        if [[ "${INSTALL_MODE}" == "per-repo" ]]; then
-          CUSTOM_BASE=".fullsend/customized"
-        fi
-        for dir in ${LAYERED_DIRS}; do
-          if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
-            find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
-              | while IFS= read -r -d '' f; do
-                  rel="${f#"${CUSTOM_BASE}"/}"
-                  mkdir -p "$(dirname "${DEST}${rel}")"
-                  cp "${f}" "${DEST}${rel}"
-                done
-          fi
-        done
         mkdir -p .github/scripts
         cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
 

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -113,20 +113,6 @@ jobs:
               cp -r "${SRC}/${dir}/." "${DEST}${dir}/"
             fi
           done
-          CUSTOM_BASE="customized"
-          if [[ "${INSTALL_MODE}" == "per-repo" ]]; then
-            CUSTOM_BASE=".fullsend/customized"
-          fi
-          for dir in ${LAYERED_DIRS}; do
-            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
-              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
-                | while IFS= read -r -d '' f; do
-                    rel="${f#"${CUSTOM_BASE}"/}"
-                    mkdir -p "$(dirname "${DEST}${rel}")"
-                    cp "${f}" "${DEST}${rel}"
-                  done
-            fi
-          done
           mkdir -p .github/scripts
           cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
 

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -129,20 +129,6 @@ jobs:
               cp -r "${SRC}/${dir}/." "${DEST}${dir}/"
             fi
           done
-          CUSTOM_BASE="customized"
-          if [[ "${INSTALL_MODE}" == "per-repo" ]]; then
-            CUSTOM_BASE=".fullsend/customized"
-          fi
-          for dir in ${LAYERED_DIRS}; do
-            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
-              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
-                | while IFS= read -r -d '' f; do
-                    rel="${f#"${CUSTOM_BASE}"/}"
-                    mkdir -p "$(dirname "${DEST}${rel}")"
-                    cp "${f}" "${DEST}${rel}"
-                  done
-            fi
-          done
           mkdir -p .github/scripts
           cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
 

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -114,20 +114,6 @@ jobs:
               cp -r "${SRC}/${dir}/." "${DEST}${dir}/"
             fi
           done
-          CUSTOM_BASE="customized"
-          if [[ "${INSTALL_MODE}" == "per-repo" ]]; then
-            CUSTOM_BASE=".fullsend/customized"
-          fi
-          for dir in ${LAYERED_DIRS}; do
-            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
-              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
-                | while IFS= read -r -d '' f; do
-                    rel="${f#"${CUSTOM_BASE}"/}"
-                    mkdir -p "$(dirname "${DEST}${rel}")"
-                    cp "${f}" "${DEST}${rel}"
-                  done
-            fi
-          done
           mkdir -p .github/scripts
           cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
 

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -110,20 +110,6 @@ jobs:
               cp -r "${SRC}/${dir}/." "${DEST}${dir}/"
             fi
           done
-          CUSTOM_BASE="customized"
-          if [[ "${INSTALL_MODE}" == "per-repo" ]]; then
-            CUSTOM_BASE=".fullsend/customized"
-          fi
-          for dir in ${LAYERED_DIRS}; do
-            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
-              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
-                | while IFS= read -r -d '' f; do
-                    rel="${f#"${CUSTOM_BASE}"/}"
-                    mkdir -p "$(dirname "${DEST}${rel}")"
-                    cp "${f}" "${DEST}${rel}"
-                  done
-            fi
-          done
           mkdir -p .github/scripts
           cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
 

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -111,20 +111,6 @@ jobs:
               cp -r "${SRC}/${dir}/." "${DEST}${dir}/"
             fi
           done
-          CUSTOM_BASE="customized"
-          if [[ "${INSTALL_MODE}" == "per-repo" ]]; then
-            CUSTOM_BASE=".fullsend/customized"
-          fi
-          for dir in ${LAYERED_DIRS}; do
-            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
-              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
-                | while IFS= read -r -d '' f; do
-                    rel="${f#"${CUSTOM_BASE}"/}"
-                    mkdir -p "$(dirname "${DEST}${rel}")"
-                    cp "${f}" "${DEST}${rel}"
-                  done
-            fi
-          done
           mkdir -p .github/scripts
           cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
 

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -115,20 +115,6 @@ jobs:
               cp -r "${SRC}/${dir}/." "${DEST}${dir}/"
             fi
           done
-          CUSTOM_BASE="customized"
-          if [[ "${INSTALL_MODE}" == "per-repo" ]]; then
-            CUSTOM_BASE=".fullsend/customized"
-          fi
-          for dir in ${LAYERED_DIRS}; do
-            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
-              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
-                | while IFS= read -r -d '' f; do
-                    rel="${f#"${CUSTOM_BASE}"/}"
-                    mkdir -p "$(dirname "${DEST}${rel}")"
-                    cp "${f}" "${DEST}${rel}"
-                  done
-            fi
-          done
           mkdir -p .github/scripts
           cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
 

--- a/docs/plans/deprecate-customized-directory-overlay.md
+++ b/docs/plans/deprecate-customized-directory-overlay.md
@@ -90,10 +90,11 @@ logs. No behavioral change.
 
 ---
 
-## PR 2: Remove overlay loop from reusable workflows
+## PR 2: Remove overlay loop from reusable workflows *(done — PR #5836)*
 
 **Scope:** Remove the `CUSTOM_BASE` overlay from all 6 reusable
-workflows.
+workflows, the `prepare-workspace` composite action, and the scaffold
+`repo-maintenance.yml` template.
 
 **`.github/workflows/reusable-triage.yml` (~lines 100–113):**
 **`.github/workflows/reusable-code.yml` (~lines 102–113):**

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -54,14 +54,6 @@ jobs:
           set -euo pipefail
           mkdir -p scripts
           cp -r ".defaults/internal/scaffold/fullsend-repo/scripts/." scripts/
-          if [[ -d "customized/scripts" ]]; then
-            find "customized/scripts" -type f ! -name '.gitkeep' -print0 \
-              | while IFS= read -r -d '' f; do
-                  rel="${f#customized/}"
-                  mkdir -p "$(dirname "${rel}")"
-                  cp "${f}" "${rel}"
-                done
-          fi
           rm -rf .defaults
 
       - name: Mint fullsend token

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -781,7 +781,8 @@ func TestRepoMaintenanceWorkflowContent(t *testing.T) {
 	assert.Contains(t, s, "fullsend-ai/fullsend/.github/actions/mint-token@__FULLSEND_AI_REF__")
 	assert.Contains(t, s, "Checkout upstream scripts")
 	assert.Contains(t, s, "Prepare scripts")
-	assert.Contains(t, s, "customized/scripts")
+	assert.NotContains(t, s, "customized/scripts",
+		"customized/ overlay removed per ADR-0064")
 	assert.Contains(t, s, "role: fullsend")
 	assert.Contains(t, s, "id-token: write")
 	assert.NotContains(t, s, "create-github-app-token")


### PR DESCRIPTION
## Summary

- Remove the `CUSTOM_BASE` overlay loop from all 6 reusable workflows (`triage`, `code`, `review`, `fix`, `retro`, `prioritize`) and the `prepare-workspace` composite action
- Remove the `customized/scripts` overlay from the scaffold `repo-maintenance.yml` template
- Update scaffold test to assert the overlay is absent
- Update implementation plan to reflect PR 2 completion
- The overlay ran every agent invocation but copied zero files — all `customized/` directories contain only `.gitkeep` placeholders

## Test plan

- [x] `grep -r 'CUSTOM_BASE' .github/workflows/reusable-*.yml .github/actions/prepare-workspace/action.yml` returns no matches
- [x] `grep -r 'customized/' internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml` returns no matches
- [x] All pre-commit hooks pass (YAML lint, actionlint, workflow file size)
- [x] `TestRepoMaintenanceWorkflowContent` updated to assert overlay is removed
- [ ] CI passes on this PR

Part of #5824

🤖 Generated with [Claude Code](https://claude.com/claude-code)