### PR TITLE
ci(renovate): auto-update SHA256 checksums for tirith and cosign

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -47,3 +47,4 @@ jobs:
           LOG_LEVEL: info
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_DRY_RUN: ${{ inputs.dry-run || 'false' }}
+          RENOVATE_ALLOWED_COMMANDS: '["^bash scripts/renovate/[a-zA-Z0-9_-]+\\.sh$"]'

--- a/images/sandbox/Containerfile
+++ b/images/sandbox/Containerfile
@@ -142,8 +142,8 @@ RUN apt-get update \
 # ---------------------------------------------------------------------------
 # tirith — terminal security scanner for PreToolUse hooks.
 # Pinned version + sha256 checksum for supply chain safety.
-# To update: bump TIRITH_VERSION and TIRITH_SHA256_{AMD64,ARM64} from the checksums.txt
-# in the GitHub release: https://github.com/sheeki03/tirith/releases
+# Renovate bumps TIRITH_VERSION; postUpgradeTasks runs
+# scripts/renovate/update-tirith-checksums.sh to refresh the SHA256 ARGs.
 ARG TIRITH_VERSION=0.3.1
 ARG TIRITH_SHA256_AMD64=571e6a300e4c444293476537a322666069e561c7f05283d6650f5b8ef83db3ac
 ARG TIRITH_SHA256_ARM64=0462fe5083b4c72c45a8de918d5413e21d17aa8077aa7dbe53c0876b112847bb

--- a/renovate.json
+++ b/renovate.json
@@ -30,9 +30,24 @@
       "groupName": "cloudflare-workers"
     },
     {
-      "description": "Disable automerge for tirith — Renovate bumps the version but SHA256 checksums need manual refresh, so the PR always needs human intervention",
+      "description": "After cosign version bump, verify the new binary's sigstore signature and update COSIGN_SHA256",
+      "matchPackageNames": ["sigstore/cosign"],
+      "automerge": false,
+      "postUpgradeTasks": {
+        "commands": ["bash scripts/renovate/update-cosign-checksum.sh"],
+        "fileFilters": ["scripts/renovate/update-tirith-checksums.sh"],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "description": "After tirith version bump, fetch and update SHA256 checksums from the release",
       "matchPackageNames": ["sheeki03/tirith"],
-      "automerge": false
+      "automerge": false,
+      "postUpgradeTasks": {
+        "commands": ["bash scripts/renovate/update-tirith-checksums.sh"],
+        "fileFilters": ["images/sandbox/Containerfile"],
+        "executionMode": "branch"
+      }
     }
   ],
   "postUpdateOptions": ["gomodTidy"],
@@ -89,12 +104,23 @@
     },
     {
       "customType": "regex",
-      "description": "Track tirith CLI version pin in the sandbox image. TIRITH_SHA256_{AMD64,ARM64} must be refreshed manually from the release checksums.txt at https://github.com/sheeki03/tirith/releases — the image build fails on checksum mismatch until they are.",
+      "description": "Track tirith CLI version pin in the sandbox image. SHA256 checksums are updated automatically by postUpgradeTasks (scripts/renovate/update-tirith-checksums.sh).",
       "managerFilePatterns": ["/^images/sandbox/Containerfile$/"],
       "matchStrings": [
         "ARG TIRITH_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "sheeki03/tirith",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Track cosign version pin in update-tirith-checksums.sh. COSIGN_SHA256 is updated automatically by postUpgradeTasks (scripts/renovate/update-cosign-checksum.sh).",
+      "managerFilePatterns": ["/^scripts/renovate/update-tirith-checksums\\.sh$/"],
+      "matchStrings": [
+        "COSIGN_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "sigstore/cosign",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }

--- a/scripts/renovate/update-cosign-checksum.sh
+++ b/scripts/renovate/update-cosign-checksum.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Called by Renovate postUpgradeTasks after a cosign version bump.
+# Downloads the new cosign binary, verifies its sigstore bundle signature
+# using the old (currently installed) cosign binary, then updates
+# COSIGN_SHA256 in update-tirith-checksums.sh.
+set -euo pipefail
+
+SCRIPT="scripts/renovate/update-tirith-checksums.sh"
+
+# --- Read old and new versions ---
+OLD_VERSION=$(git show HEAD:"${SCRIPT}" | grep -oP '^COSIGN_VERSION=\K\S+' || true)
+if [[ -z "${OLD_VERSION}" ]]; then
+  echo "error: could not extract COSIGN_VERSION from committed ${SCRIPT}" >&2
+  exit 1
+fi
+if [[ ! "${OLD_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: OLD_VERSION is not a valid semver: ${OLD_VERSION}" >&2
+  exit 1
+fi
+
+OLD_SHA256=$(git show HEAD:"${SCRIPT}" | grep -oP '^COSIGN_SHA256=\K\S+' || true)
+if [[ -z "${OLD_SHA256}" ]]; then
+  echo "error: could not extract COSIGN_SHA256 from committed ${SCRIPT}" >&2
+  exit 1
+fi
+if [[ ! "${OLD_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "error: OLD_SHA256 is not a valid sha256 hex digest: ${OLD_SHA256}" >&2
+  exit 1
+fi
+
+NEW_VERSION=$(grep -oP '^COSIGN_VERSION=\K\S+' "${SCRIPT}" || true)
+if [[ -z "${NEW_VERSION}" ]]; then
+  echo "error: could not extract COSIGN_VERSION from working-tree ${SCRIPT}" >&2
+  exit 1
+fi
+if [[ ! "${NEW_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: NEW_VERSION is not a valid semver: ${NEW_VERSION}" >&2
+  exit 1
+fi
+
+if [[ "${OLD_VERSION}" == "${NEW_VERSION}" ]]; then
+  echo "cosign version unchanged (${OLD_VERSION}), nothing to do"
+  exit 0
+fi
+
+echo "cosign: ${OLD_VERSION} -> ${NEW_VERSION}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+BASE_URL="https://github.com/sigstore/cosign/releases/download"
+
+# --- Bootstrap the old cosign binary to use as verifier ---
+OLD_BINARY="${WORKDIR}/cosign-old"
+curl -fsSL "${BASE_URL}/v${OLD_VERSION}/cosign-linux-amd64" -o "${OLD_BINARY}"
+echo "${OLD_SHA256}  ${OLD_BINARY}" | sha256sum -c -
+chmod +x "${OLD_BINARY}"
+
+# --- Download new cosign binary and its sigstore bundle ---
+NEW_BINARY="${WORKDIR}/cosign-linux-amd64"
+curl -fsSL "${BASE_URL}/v${NEW_VERSION}/cosign-linux-amd64" -o "${NEW_BINARY}"
+curl -fsSL "${BASE_URL}/v${NEW_VERSION}/cosign-linux-amd64.sigstore.json" -o "${NEW_BINARY}.sigstore.json"
+
+# --- Verify the new binary's signature using the old cosign ---
+"${OLD_BINARY}" verify-blob \
+  --bundle "${NEW_BINARY}.sigstore.json" \
+  --certificate-identity "keyless@projectsigstore.iam.gserviceaccount.com" \
+  --certificate-oidc-issuer "https://accounts.google.com" \
+  "${NEW_BINARY}"
+
+echo "cosign signature verified for v${NEW_VERSION}"
+
+# --- Compute and update the SHA256 ---
+NEW_SHA256=$(sha256sum "${NEW_BINARY}" | awk '{print $1}')
+
+if [[ ! "${NEW_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "error: computed checksum is not a valid sha256 hex digest: ${NEW_SHA256}" >&2
+  exit 1
+fi
+
+sed -i "s/^COSIGN_SHA256=.*/COSIGN_SHA256=${NEW_SHA256}/" "${SCRIPT}"
+
+echo "updated COSIGN_SHA256 to ${NEW_SHA256}"

--- a/scripts/renovate/update-tirith-checksums.sh
+++ b/scripts/renovate/update-tirith-checksums.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Called by Renovate postUpgradeTasks after a tirith version bump.
+# Fetches the new release's checksums.txt, verifies its cosign signature
+# against the Sigstore transparency log, and patches the Containerfile
+# so the SHA256 ARGs match the bumped version.
+set -euo pipefail
+
+# --- Retrieve the new Tirith version ---
+FILE="images/sandbox/Containerfile"
+VERSION=$(grep -oP 'ARG TIRITH_VERSION=\K\S+' "${FILE}" || true)
+if [[ -z "${VERSION}" ]]; then
+    echo "Tried to retrieve Tirith version from ${FILE}, couldn't do it. Exiting."
+    exit 1
+fi
+if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: VERSION is not a valid semver: ${VERSION}" >&2
+    exit 1
+fi
+
+BASE_URL="https://github.com/sheeki03/tirith/releases/download/v${VERSION}"
+
+# --- Bootstrap cosign if not already available ---
+# Pinned version + SHA256 so this script is self-contained inside the
+# Renovate container, which does not ship cosign.
+COSIGN_VERSION=3.1.2
+COSIGN_SHA256=f7622ed3cf22e55e1ae6377c080979ff77a22da9981c11df222a2e444991e7cf
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+if command -v cosign &>/dev/null; then
+  COSIGN=cosign
+else
+  COSIGN="${WORKDIR}/cosign"
+  curl -fsSL "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64" \
+    -o "${COSIGN}"
+  echo "${COSIGN_SHA256}  ${COSIGN}" | sha256sum -c -
+  chmod +x "${COSIGN}"
+fi
+
+# --- Fetch checksums and cosign verification artifacts ---
+for f in checksums.txt checksums.txt.sig checksums.txt.pem; do
+  if ! curl -fsSL "${BASE_URL}/${f}" -o "${WORKDIR}/${f}"; then
+    echo "error: failed to fetch ${BASE_URL}/${f}" >&2
+    exit 1
+  fi
+done
+
+# --- Verify the cosign signature on checksums.txt ---
+# Pin the certificate SAN to tirith's .github/workflows/ path (not the whole
+# repo), matching the upstream install.sh scope.
+"${COSIGN}" verify-blob \
+  --certificate "${WORKDIR}/checksums.txt.pem" \
+  --signature "${WORKDIR}/checksums.txt.sig" \
+  --certificate-identity-regexp "^https://github\\.com/sheeki03/tirith/\\.github/workflows/" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "${WORKDIR}/checksums.txt"
+
+echo "cosign signature verified for tirith v${VERSION} checksums.txt"
+
+# --- Extract per-architecture SHA256 hashes ---
+AMD64=$(grep -E '^[0-9a-f]{64}  tirith-x86_64-unknown-linux-gnu\.tar\.gz$' "${WORKDIR}/checksums.txt" | awk '{print $1}' || true)
+ARM64=$(grep -E '^[0-9a-f]{64}  tirith-aarch64-unknown-linux-gnu\.tar\.gz$' "${WORKDIR}/checksums.txt" | awk '{print $1}' || true)
+
+if [[ ! "${AMD64}" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "error: amd64 checksum is not a valid sha256 hex digest: ${AMD64}" >&2
+  exit 1
+fi
+if [[ ! "${ARM64}" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "error: arm64 checksum is not a valid sha256 hex digest: ${ARM64}" >&2
+  exit 1
+fi
+
+sed -i "s/^ARG TIRITH_SHA256_AMD64=.*/ARG TIRITH_SHA256_AMD64=${AMD64}/" "${FILE}"
+sed -i "s/^ARG TIRITH_SHA256_ARM64=.*/ARG TIRITH_SHA256_ARM64=${ARM64}/" "${FILE}"
+
+echo "updated tirith checksums to v${VERSION}: amd64=${AMD64} arm64=${ARM64}"


### PR DESCRIPTION
## Summary

- Adds `scripts/renovate/update-tirith-checksums.sh` that fetches `checksums.txt` from the tirith GitHub release, verifies its cosign signature against the Sigstore transparency log, and patches `TIRITH_SHA256_AMD64`/`ARM64` in the sandbox Containerfile. Cosign is not installed on the Renovate base image, so the script bootstraps it from a pinned version and SHA256.
- Adds `scripts/renovate/update-cosign-checksum.sh` that downloads the new cosign binary, verifies its sigstore bundle using the old pinned binary, and updates `COSIGN_SHA256` in `update-tirith-checksums.sh`.
- Adds `postUpgradeTasks` to the tirith and cosign package rules in `renovate.json` so both scripts run after Renovate bumps their respective versions.
- Adds a `customManager` so Renovate tracks the cosign version pin in `update-tirith-checksums.sh`.
- Allows the scripts via `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS` in `.github/workflows/renovate.yml`.
- Retains `automerge: false` for tirith so a human still reviews each version bump before merge.

Fixes: #5618

## Test plan

- [x] Ran the tirith script locally against v0.3.1 (current); checksums unchanged
- [x] Simulated a tirith bump to v0.3.3; checksums updated correctly to match the release
- [x] Trigger a Renovate dry-run to verify postUpgradeTasks wiring (https://github.com/fullsend-ai/fullsend/actions/runs/30794383857/job/91624555395)
- [x] Verified cosign `verify-blob` passes against live v0.3.1 release artifacts with identity pinned to `sheeki03/tirith` and GitHub Actions OIDC issuer
- [x] Verify cosign checksum update script with a simulated cosign version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)