### PR TITLE
docs(tracing): split tracing docs by audience

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -26,7 +26,7 @@ Advanced guides for platform operators who deploy and manage the GCP-side infras
 - [Standalone mint](infrastructure/standalone-mint.md) — Running the token mint as a standalone HTTP server without GCP
 - [Infrastructure reference](infrastructure/infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
 - [Enabling fullsend on private repositories](infrastructure/private-repositories.md) — Additional guardrails and configuration for private repos
-- [Distributed tracing](infrastructure/distributed-tracing.md) — Configuring OpenTelemetry instrumentation and OTLP backends
+- [Tracing reference](infrastructure/distributed-tracing.md) — Telemetry levels, environment variables, span hierarchy, and attributes
 
 ## User guides
 
@@ -39,6 +39,8 @@ Guides for developers working in repositories where fullsend is active.
 - [Configuring with skills](user/customizing-with-skills.md) — Extend or replace built-in agent skills
 - [Bring Your Own Agent](user/bring-your-own-agent.md) — Add a custom agent or configure an existing one, from harness file to CI
 - [CEL Triggers Reference](user/cel-triggers-reference.md) — Dispatch flow, NormalizedEvent fields, transition kinds, and trigger patterns
+- [How to emit traces](user/how-to-emit-traces.md) — Configure a repository or organization to send OpenTelemetry traces to a remote backend
+- [Tracing with MLflow](user/tracing-with-mlflow.md) — MLflow-specific setup: experiment routing, Basic auth encoding, org-level organization, and cost column caveats
 - [Jira Integration](user/jira-integration.md) — Connect fullsend to a Jira project so that issue comments and label changes trigger agents
 - [Building custom agents from scratch](user/building-custom-agents.md) — _(deprecated — see [Bring Your Own Agent](user/bring-your-own-agent.md))_
 - [Default, derived, and custom agents](../agents/topics/default-vs-custom.md) — When configuration crosses into derived or custom agent territory
@@ -52,3 +54,4 @@ Guides for contributors developing and testing fullsend itself.
 - [Behaviour testing](dev/behaviour-testing.md) — Write Gherkin scenarios for end-to-end agent behaviour
 - [Behaviour test drivers](dev/behaviour-drivers.md) — Implement SCM and CI drivers for behaviour tests
 - [Testing workflow changes](dev/testing-workflows.md) — Point a live GitHub org at a branch to test workflow, action, and agent changes before release
+- [Tracing internals](dev/tracing.md) — How the distributed tracing implementation works and how to extend it

--- a/docs/guides/dev/tracing.md
+++ b/docs/guides/dev/tracing.md
@@ -1,0 +1,274 @@
+# Tracing Internals
+
+Fullsend's distributed tracing system records structured telemetry for every
+agent run. This document explains how the tracing implementation works and
+how to extend it. It is aimed at contributors modifying the telemetry
+package or the span instrumentation in the run command.
+
+For enabling tracing on an installation, see
+[How To Emit Traces](../user/how-to-emit-traces.md). For span schemas and
+attribute definitions, see the
+[Tracing Reference](../infrastructure/distributed-tracing.md). The design
+is specified in
+[ADR 0050](../../ADRs/0050-distributed-tracing-instrumentation.md).
+
+## How the tracing system is structured
+
+The tracing code is split between two locations:
+
+- **`internal/telemetry/`** - the TracerProvider, exporters, and W3C
+  traceparent helpers.
+- **`internal/cli/run.go`** - span creation, attribute assignment, and
+  trace context propagation to child scripts.
+
+The telemetry package owns the provider and exporters. `run.go` owns the
+span lifecycle: it decides when spans start and end, and which attributes
+they carry.
+
+### Package layout
+
+```
+internal/telemetry/
+├── telemetry.go          Setup, TracerProvider wiring, env parsing
+├── fileexporter.go       Synchronous OTLP JSON file exporter
+├── trace.go              W3C traceparent formatting helpers
+├── main_test.go
+├── telemetry_test.go
+├── fileexporter_test.go
+├── otlpsink_test.go
+└── trace_test.go
+```
+
+## TracerProvider setup
+
+`telemetry.Setup(dir, version)` returns a `trace.Tracer` and a cleanup
+function. It creates a `TracerProvider` with two span processors:
+
+1. **fileExporter** via `SimpleSpanProcessor`: writes every completed span
+   as one OTLP JSON line to `run-telemetry.jsonl`. Calls `f.Sync()` after
+   each write so spans survive a process crash.
+
+2. **otlptracehttp** via `BatchSpanProcessor` wrapped in
+   `parentSampledProcessor`: exports to a remote backend when an
+   `OTEL_EXPORTER_OTLP_*ENDPOINT` env var is set.
+
+If neither exporter can be created (bad directory, SDK disabled), `Setup`
+returns a noop tracer. Telemetry failures never affect the run.
+
+```
+telemetry.Setup()
+│
+├── OTEL_SDK_DISABLED check   → noop tracer if "true"
+├── os.OpenFile(jsonl)        → noop tracer on error
+│
+├── SimpleSpanProcessor(fileExporter)           ← always present
+│
+└── OTEL_EXPORTER_OTLP_*ENDPOINT check
+    ├── validateEndpoints()   → stderr warning, skip
+    ├── newOTLPExporter()     → stderr warning, skip
+    └── parentSampledProcessor(BatchSpanProcessor(otlpExporter))
+```
+
+### Why parentSampledProcessor exists
+
+The OTel SDK's `AlwaysSample` sampler records all spans locally, which is
+needed for the file exporter. But `AlwaysSample` ignores an upstream
+unsampled decision. The `parentSampledProcessor` wraps the OTLP batch
+processor and suppresses the entire trace from export when the root span's
+remote parent has the W3C sampled flag unset (`-00`). It tracks suppressed
+trace IDs in a `sync.Map` so child spans under the same trace are also
+dropped.
+
+Result: the file exporter always writes all spans; the OTLP exporter
+respects upstream sampling.
+
+### Endpoint validation
+
+`validateEndpoints` rejects non-http(s) URLs and unsupported protocols
+before creating the exporter. A malformed endpoint produces a stderr
+warning; the SDK's default `localhost:4318` fallback is never used
+silently.
+
+## Span lifecycle in run.go
+
+`run.go` creates three span types arranged in a parent-child hierarchy:
+
+```
+run (root)
+├── sandbox_create    (gen_ai.operation.name=create_agent)
+└── agent             (one per iteration; gen_ai.operation.name=invoke_agent)
+```
+
+### Root span
+
+Created by `resolveTraceIdentity()`. When an inbound `TRACEPARENT` env var
+is present, the W3C propagator extracts a remote span context and the root
+span is `SpanKindConsumer`. Otherwise it is `SpanKindInternal`.
+
+Start attributes: `fullsend.agent`, `fullsend.work_item_id`,
+`gen_ai.operation.name`, `gen_ai.agent.name`.
+
+End attributes (set in a deferred cleanup): `exit_code`, aggregated token
+usage (`gen_ai.usage.*`), `fullsend.cost_usd`, `fullsend.num_turns`,
+`fullsend.tool_calls`, `fullsend.iterations`, `gen_ai.request.model`.
+
+For the full attribute list (including `fullsend.security_trace_id` and
+`fullsend.prescript.*`), see the
+[Tracing reference attribute table](../infrastructure/distributed-tracing.md#span-attributes).
+
+### sandbox_create span
+
+Started before sandbox creation, ended after bootstrap completes. Carries
+`gen_ai.operation.name=create_agent`.
+
+### agent spans
+
+One per iteration (validation loop iterations included). Started before
+`Exec()`, ended after output extraction.
+
+The helper functions `agentSpanStartAttrs()` and `agentSpanEndAttrs()`
+build the attribute slices. Start attributes: `iteration`,
+`gen_ai.operation.name`, `gen_ai.agent.name`. End attributes: `iteration`,
+`exit_code`, `gen_ai.system`, model, token counts, `fullsend.cost_usd`,
+`fullsend.tool_calls`.
+
+## Trace identity and TRACEPARENT propagation
+
+`resolveTraceIdentity()` handles W3C trace context propagation in three
+steps:
+
+1. Extracts `TRACEPARENT` and `TRACESTATE` from env via the W3C propagator.
+2. Starts the root span (Consumer if remote parent, Internal otherwise).
+3. Computes the propagated traceparent with flag preservation: if the
+   inbound parent was valid, remote, and unsampled, the outbound
+   traceparent keeps the unsampled flag instead of the local
+   `AlwaysSample` flag. This prevents child runs from re-advertising as
+   sampled when the parent trace opted out.
+
+The resulting `TRACEPARENT` string is passed to pre-scripts, post-scripts,
+and the sandbox environment via `childScriptEnv()`. That function strips
+any inherited `TRACEPARENT` from `os.Environ()` and `runner_env` before
+appending fullsend's own value (issue #2779).
+
+## File exporter output format
+
+`fileExporter` writes OTLP JSON with hex-encoded trace/span IDs (per the
+OTLP JSON spec, not base64). Each line is a complete `TracesData` message.
+Non-finite floats (NaN, Infinity) are encoded as proto3 JSON strings per
+the protobuf spec.
+
+`buildResourceSpans()` groups SDK spans by resource and instrumentation
+scope, preserving insertion order. This matches the structure a backend
+receives via OTLP/HTTP.
+
+## Prerequisites
+
+- A local clone of the fullsend repo
+- Go toolchain (see `go.mod` for the minimum version)
+- Podman or Docker, if testing with a local tracing backend
+
+## How to add a new span attribute
+
+1. Add the `attribute.String` / `attribute.Int` / `attribute.Float64` call
+   in `run.go` at the appropriate point. Use start attributes for values
+   known when the span opens; use end attributes (set before `span.End()`)
+   for values computed during the span.
+
+2. Choose the attribute key namespace:
+   - `gen_ai.*` for attributes defined by the
+     [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
+   - `fullsend.*` for project-specific attributes.
+
+3. Update the attribute tables in the
+   [Tracing Reference](../infrastructure/distributed-tracing.md).
+
+4. No exporter changes are needed; both exporters pick up new attributes
+   automatically.
+
+## How to test
+
+### Unit tests
+
+```bash
+go test ./internal/telemetry/...
+```
+
+Tests use `t.Setenv` for OTEL env vars and `t.TempDir` for the file
+exporter. No external backend is required.
+
+### Test seam for the OTLP exporter
+
+`newOTLPExporter` is a package-level `var` that tests override to spy on
+or stub out exporter creation:
+
+```go
+orig := newOTLPExporter
+defer func() { newOTLPExporter = orig }()
+newOTLPExporter = func(_ context.Context) (sdktrace.SpanExporter, error) {
+    // spy or stub
+}
+```
+
+### Testing with a local backend
+
+Start a Jaeger instance and point the exporter at it:
+
+```bash
+podman run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/jaeger
+
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+go run ./cmd/fullsend run triage ...
+```
+
+See [Running Agents Locally](../user/running-agents-locally.md) for full
+flags. View traces at `http://localhost:16686`.
+
+## Replaying collected traces
+
+`hack/upload-traces.sh` replays `run-telemetry.jsonl` files into any OTLP
+backend using `otelcol-contrib`. This is useful for inspecting traces from
+CI runs or from another machine without re-running the agent.
+
+```bash
+# Replay a single file
+hack/upload-traces.sh run/agent-run-123/run-telemetry.jsonl \
+  --endpoint http://localhost:4318
+
+# Replay all .jsonl files under a directory
+hack/upload-traces.sh run/ --endpoint http://localhost:4318
+```
+
+The collector runs continuously and watches for new data; press Ctrl+C
+when done.
+
+**Prerequisites:** `otelcol-contrib` >= 0.120.0 on `PATH`
+([releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases)).
+
+**Authentication headers:** `otelcol-contrib` ignores the standard
+`OTEL_EXPORTER_OTLP_HEADERS` env var. Edit
+`hack/upload-traces-otelcol-config.yaml` and uncomment the `headers:`
+block to set auth tokens or routing headers (e.g.
+`x-mlflow-experiment-id`).
+
+## Compatible backends
+
+Any OTLP/HTTP-capable backend works. LLM-aware backends recognize the
+`gen_ai.*` attributes and surface GenAI dashboards (token cost rollups,
+prompt/completion inspection, agent-specific views) without CLI-side
+changes.
+
+| Backend | Local quickstart | UI |
+|---------|-----------------|-----|
+| Jaeger | `podman run -p 16686:16686 -p 4318:4318 jaegertracing/jaeger` | `localhost:16686` |
+| Arize Phoenix | `podman run -p 6006:6006 -p 4318:4318 arizephoenix/phoenix` | `localhost:6006` |
+| MLflow >= 3.6 | `uvx mlflow server` | `localhost:5000` |
+| otel-gui | `podman run -p 4318:4318 ghcr.io/metafab/otel-gui:latest` | `localhost:4318` |
+
+## See also
+
+- [How To Emit Traces](../user/how-to-emit-traces.md): user guide for enabling tracing
+- [Tracing Reference](../infrastructure/distributed-tracing.md): span schemas and attribute tables
+- [ADR 0050](../../ADRs/0050-distributed-tracing-instrumentation.md): design decision

--- a/docs/guides/infrastructure/distributed-tracing.md
+++ b/docs/guides/infrastructure/distributed-tracing.md
@@ -1,158 +1,164 @@
-# Distributed Tracing
+# Tracing Reference
 
-Fullsend produces structured telemetry for every agent run. This guide covers
-how to configure, consume, and extend the tracing system.
+Structured reference for fullsend's distributed tracing system: environment
+variables, span hierarchy, attributes, and operational behavior. For
+step-by-step setup, see [How To Emit Traces](../user/how-to-emit-traces.md).
+For implementation details, see the
+[Tracing Development Guide](../dev/tracing.md).
 
-## Zero-configuration baseline (Level 1)
+## Telemetry levels
 
-Every `fullsend run` produces one file in the run output directory with no
-configuration required:
+| Level | What it produces | Configuration required |
+|-------|-----------------|----------------------|
+| 1 | `run-telemetry.jsonl` file in the run output directory | None |
+| 2 | OTLP/HTTP export to a remote backend (metadata only) | `OTEL_EXPORTER_OTLP_*ENDPOINT` |
+| 3 | Content capture (prompts, completions, tool I/O) in spans | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` *(planned, not yet implemented)* |
 
-- **`run-telemetry.jsonl`** — OTLP JSON spans covering the run lifecycle
-  (sandbox creation, agent iterations, validation) with timestamps, durations,
-  trace IDs, and token/cost attributes.
+All levels produce metadata (timing, token counts, tool names, errors).
+Level 3 adds prompt/completion content to spans.
 
-This file is written on every run. It contains metadata only — no prompts,
-completions, or source code content.
+## Environment variables
 
-## Prerequisites
+### Endpoint configuration
 
-Level 1 requires nothing. To enable OTLP export (Level 2 and Level 3) you need:
+| Variable | Purpose | Notes |
+|----------|---------|-------|
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Signal-specific endpoint URL | Takes precedence; used as-is, no `/v1/traces` appended |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base endpoint URL | SDK appends `/v1/traces` automatically |
 
-- An **OTLP/HTTP-capable backend** and its endpoint URL — e.g. Jaeger, Tempo,
-  Grafana, MLflow ≥ 3.6, or any OpenTelemetry Collector.
-- Any **backend authentication** (bearer token or basic auth) for the
-  `OTEL_EXPORTER_OTLP_TRACES_HEADERS` variable.
-- **Network reachability** from where runs execute (your machine or CI runners)
-  to the backend endpoint.
-- For a backend behind a **private CA** (e.g. an internal MLflow): the CA
-  certificate bundle, pointed to by `OTEL_EXPORTER_OTLP_CERTIFICATE`. In
-  managed workflows the PEM file must be present in the repository checkout
-  (e.g. `.fullsend/otel-ca.pem`) because the runner has no other persistent
-  filesystem; bring-your-own-workflow runs can use any local path.
+### Authentication
 
-## Disabling telemetry
+| Variable | Purpose | Notes |
+|----------|---------|-------|
+| `OTEL_EXPORTER_OTLP_TRACES_HEADERS` | Signal-specific headers | Takes precedence; `key=value` pairs separated by commas; values are URL-decoded |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Base headers | Same format as above |
 
-To disable all telemetry, including the local file exporter:
+### Private CA
 
-```bash
-export OTEL_SDK_DISABLED=true  # case-insensitive
-```
+| Variable | Purpose | Notes |
+|----------|---------|-------|
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` | PEM file path for TLS root certificates | Points at a CA bundle for verifying the OTLP backend's certificate; no skip-verify option exists. In managed workflows the PEM file must be committed into the repository checkout (e.g. `.fullsend/otel-ca.pem`) because the runner has no other persistent filesystem; bring-your-own-workflow runs can use any local path |
 
-To disable only the OTLP exporter:
+### Resource attributes
+
+| Variable | Purpose | Notes |
+|----------|---------|-------|
+| `OTEL_RESOURCE_ATTRIBUTES` | Static `k=v,k=v` trace tags | Merged into the OTel resource; `${{ github.* }}` expressions only evaluate in workflow YAML, not in Actions variables |
+
+### Kill switches
+
+| Variable | Value | Effect |
+|----------|-------|--------|
+| `OTEL_SDK_DISABLED` | `true` (case-insensitive) | Disables all telemetry output: OTLP export and the local file |
+
+To disable only OTLP export without affecting the local file, unset the
+endpoint variables:
 
 ```bash
 unset OTEL_EXPORTER_OTLP_ENDPOINT
 unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 ```
 
-## Enabling OTLP export (Level 2)
+### Trace propagation
 
-To send metadata spans to an OpenTelemetry-compatible backend, set one of the
-standard OTEL environment variables:
+| Variable | Purpose | Notes |
+|----------|---------|-------|
+| `TRACEPARENT` | W3C Trace Context parent | When present, the root span becomes `SpanKindConsumer`; when the sampled flag is unset (`-00`), OTLP export is suppressed but the local file is still written |
+| `TRACESTATE` | W3C Trace Context state | Propagated alongside `TRACEPARENT` |
 
-```bash
-# Signal-specific (used as-is, no path appended)
-export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://your-backend:4318/v1/traces"
+### Content capture (planned)
 
-# Base URL (SDK appends /v1/traces)
-export OTEL_EXPORTER_OTLP_ENDPOINT="https://your-backend:4318"
+| Variable | Value | Effect |
+|----------|-------|--------|
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `true` | Includes prompts, completions, tool arguments, tool results, and reasoning text in spans |
+
+Content capture follows the [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/gen-ai/gen-ai-spans.md).
+When enabled, spans may contain proprietary source code, PII, or
+credentials visible in tool outputs.
+
+## Span hierarchy
+
+A run produces this span tree. Span names match the `name` field in
+`run-telemetry.jsonl`; exported spans and the local file are two views
+of the same trace with identical span IDs.
+
+```
+run (root; Consumer when dispatched with TRACEPARENT, else Internal)
+├── sandbox_create (gen_ai.operation.name=create_agent)
+└── agent           (one per iteration; gen_ai.operation.name=invoke_agent)
 ```
 
-**Precedence:** `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` > `OTEL_EXPORTER_OTLP_ENDPOINT`.
-Headers follow the same pattern: `OTEL_EXPORTER_OTLP_TRACES_HEADERS` > `OTEL_EXPORTER_OTLP_HEADERS`.
+### SpanKind
 
-The local file (`run-telemetry.jsonl`) is produced with no configuration
-needed (Level 1).
+| Span | Kind | Condition |
+|------|------|-----------|
+| `run` | Consumer | Valid inbound `TRACEPARENT` (dispatched by an instrumented system) |
+| `run` | Internal | No inbound `TRACEPARENT` (local/manual invocation) |
+| `sandbox_create` | Internal | Always |
+| `agent` | Internal | Always |
 
-When an endpoint is configured, spans are exported via OTLP/HTTP. Any backend
-that speaks OTLP works: Jaeger, Grafana Tempo, MLflow, Arize Phoenix,
-Langfuse, SigNoz, Honeycomb, Datadog, etc.
+## Span attributes
 
-If the endpoint is unreachable, the CLI continues normally; local files are
-still produced and the run is not affected.
+### GenAI semantic convention attributes
 
-Operational details:
+These follow the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+and are recognized by LLM-aware backends for GenAI dashboards.
 
-- **Export timing:** spans are exported live via the OTel SDK's batch
-  processor as they complete. On shutdown, the provider flushes remaining
-  spans within a 5-second budget. A dead endpoint does not block the run.
-- **Retry:** the exporter retries on transient failures (HTTP 503, etc.)
-  with an initial interval of 250 ms and a max interval of 2 s. The
-  5-second context deadline passed to `tp.Shutdown` bounds both retries
-  and in-flight requests, so a persistently failing or hanging endpoint
-  does not extend shutdown.
-- **Crashed runs:** completed spans that were already flushed mid-run reach
-  the backend; spans still in the batch buffer are lost. The local
-  `run-telemetry.jsonl` (written synchronously per span) remains the
-  forensic record.
-- **Sampling:** when the run continues an inbound `TRACEPARENT` whose W3C
-  sampled flag is unset (`-00`), the upstream sampling decision is respected:
-  nothing is exported. The local file is still written.
-- **Endpoint validation:** before creating the OTLP exporter, the CLI
-  validates whichever endpoint the SDK will actually use
-  (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` if set, else
-  `OTEL_EXPORTER_OTLP_ENDPOINT`). An endpoint is invalid if it cannot be
-  parsed as a URL, has no scheme, uses a scheme other than `http` or `https`,
-  or has no host (e.g. `localhost:4318` instead of
-  `http://localhost:4318`). When invalid, the CLI prints a warning to stderr
-  and skips OTLP export; the local file exporter is unaffected. A valid
-  signal-specific endpoint is not blocked by an invalid generic endpoint.
-- **Private CAs:** point `OTEL_EXPORTER_OTLP_CERTIFICATE` at a PEM bundle for
-  backends with certificates outside the system trust store. There is no
-  skip-verify option.
+| Attribute | Example | Present on |
+|-----------|---------|------------|
+| `gen_ai.operation.name` | `invoke_agent` | `run`, `agent` (`create_agent` on `sandbox_create`) |
+| `gen_ai.agent.name` | `triage` | `run`, `agent` |
+| `gen_ai.system` | `anthropic` | `agent` (the model vendor, from the runtime) |
+| `gen_ai.request.model` | `claude-opus-4-6` | `run` (aggregated), `agent` (resolved model) |
+| `gen_ai.usage.input_tokens` / `output_tokens` / `cache_*_input_tokens` | `109938` | `run` (aggregated), `agent` |
 
-### MLflow example
+### Fullsend-specific attributes
 
-MLflow ≥ 3.6 ingests OTLP/HTTP natively at `{server}/v1/traces` and routes
-traces to an experiment via a required header:
+| Attribute | Present on | Description |
+|-----------|------------|-------------|
+| `fullsend.work_item_id` | `run` | Work item identity (e.g. `owner/repo#123`); primary cross-run correlation key |
+| `fullsend.agent` | `run` | Agent name |
+| `fullsend.cost_usd` | `run` (aggregated), `agent` | Cost in USD, rounded to cents |
+| `fullsend.tool_calls` | `run` (aggregated), `agent` | Number of tool invocations |
+| `fullsend.num_turns` | `run` | Total conversation turns across all iterations |
+| `fullsend.iterations` | `run` | Number of agent iterations (validation loop included) |
+| `fullsend.security_trace_id` | `run` | Security scanner trace correlation ID |
+| `fullsend.prescript.skipped` | `run` | Whether the pre-script signaled a skip |
+| `fullsend.prescript.skip_reason` | `run` | Human-readable skip reason from the pre-script |
 
-```bash
-export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://mlflow.example.com/v1/traces"
-export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-mlflow-experiment-id=42"
-```
+### Common attributes
 
-Header values are URL-decoded, so spaces are percent-encoded — for a
-Basic-auth-fronted instance:
+| Attribute | Present on | Description |
+|-----------|------------|-------------|
+| `exit_code` | `run`, `agent` | Process exit code |
+| `iteration` | `agent` | 1-based iteration index |
 
-```bash
-export OTEL_EXPORTER_OTLP_TRACES_HEADERS="authorization=Basic%20${CREDS_B64},x-mlflow-experiment-id=42"
-```
+### Resource attributes
 
-> **Cost columns:** MLflow's per-trace cost is its own estimate — extracted
-> input/output token counts priced against MLflow's internal model table. It
-> excludes cache-creation/cache-read tokens, which dominate agent-run cost.
-> The authoritative figure is the runtime-reported `fullsend.cost_usd` on
-> `agent` spans (also in `run-telemetry.jsonl`).
+Set on every span via the OTel resource:
 
-## Enabling content capture (Level 3)
+| Attribute | Value |
+|-----------|-------|
+| `service.name` | `fullsend` |
+| `service.version` | CLI version string |
 
-> **Planned:** Level 3 content capture is not yet implemented. This section
-> documents the telemetry contract.
+Additional resource attributes from `OTEL_RESOURCE_ATTRIBUTES` are merged in.
 
-By default, spans contain metadata only (timing, token counts, tool names,
-errors). To include full prompt/completion content in spans:
+## Output file format
 
-```bash
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
-```
+`run-telemetry.jsonl` contains one JSON object per line. Each object is a
+complete OTLP `TracesData` message with hex-encoded trace/span IDs (per
+the OTLP JSON spec, not base64).
 
-This follows the [OTEL GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/gen-ai/gen-ai-spans.md)
-which mandate that content capture is opt-in. When enabled, spans include:
+Non-finite float values (NaN, Infinity) are encoded as proto3 JSON strings
+(`"NaN"`, `"Infinity"`, `"-Infinity"`).
 
-- System prompts and user messages
-- Tool arguments and results (file contents, command output)
-- Agent reasoning/thinking text
-- Completion text
-
-**Warning:** Only enable content capture when your backend's access controls
-are appropriate for the sensitivity of the data. Content may include
-proprietary source code, issue descriptions with PII, or credentials visible
-in tool outputs.
+The file is written synchronously per span. Spans are flushed to disk as
+they complete; the file is the forensic record for crashed runs.
 
 ## Cross-run trace correlation
 
-Multi-agent pipelines (triage → code → review) propagate trace context via
+Multi-agent pipelines (triage, code, review) propagate trace context via
 the `TRACEPARENT` environment variable (W3C Trace Context).
 
 When a workflow dispatches a child run:
@@ -162,58 +168,38 @@ env:
   TRACEPARENT: ${{ steps.parent.outputs.traceparent }}
 ```
 
-The child run's root span becomes part of the parent trace, creating a
-unified view of the entire pipeline.
+The child run's root span becomes part of the parent trace.
 
-For separate workflow runs on the same work item (triage → code → review as
-independent GHA workflows), `TRACEPARENT` must be propagated manually — for
-example, via hidden issue/PR comments. GitHub webhooks do not support custom
-trace headers natively.
+For separate workflow runs on the same work item (e.g. triage, code, review
+as independent GHA workflows), `TRACEPARENT` must be propagated manually.
+GitHub webhooks do not support custom trace headers.
 
-## Span structure
+Within a single work item, `fullsend.work_item_id` on the root `run` span
+is the correlation key for filtering related traces in a backend.
 
-A run produces this span hierarchy (span names match the `name` field in
-`run-telemetry.jsonl` — the exported spans and the local file are two views
-of the same trace, with identical span ids):
+## Operational behavior
 
-```
-run (root; Consumer when dispatched with TRACEPARENT, else Internal)
-├── sandbox_create (gen_ai.operation.name=create_agent)
-└── agent           (one per iteration; gen_ai.operation.name=invoke_agent)
-```
-
-### GenAI semantic conventions
-
-Spans carry [OTEL GenAI semantic convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) attributes:
-
-| Attribute | Example | On |
-|-----------|---------|-----|
-| `gen_ai.operation.name` | `invoke_agent` | `run` and `agent` spans (`create_agent` on `sandbox_create`) |
-| `gen_ai.agent.name` | `triage` | `run` and `agent` spans |
-| `gen_ai.request.model` | `claude-opus-4-6` | `agent` spans (resolved model) |
-| `gen_ai.system` | `anthropic` | `agent` spans (the model vendor, from the runtime) |
-| `gen_ai.usage.input_tokens` / `output_tokens` / `cache_*_input_tokens` | `109938` | `agent` spans |
-
-These attributes enable LLM-aware backends to recognize fullsend spans as
-agent operations and surface them in GenAI-specific dashboards.
-
-### SpanKind
-
-- **Consumer**: The root span when a valid inbound `TRACEPARENT` was adopted
-  (the run was dispatched by an instrumented system).
-- **Internal**: The root span for local/manual invocations, and all child
-  spans.
-
-## Custom attributes
-
-Fullsend-specific attributes:
-
-| Attribute | On | Description |
-|-----------|-----|-------------|
-| `fullsend.work_item_id` | `run` span | Work item identity (e.g. `owner/repo#123`) — the primary cross-run correlation key |
-| `fullsend.cost_usd` | `agent` spans | Iteration cost in USD, rounded to cents |
-| `fullsend.tool_calls` | `agent` spans | Tool invocations in the iteration |
-| `fullsend.agent` | `run` span | Agent name (renamed from bare `agent` in the OTel SDK migration) |
+- **Export timing:** spans are exported live via the batch processor. On
+  shutdown, the provider flushes remaining spans within a 5-second budget.
+  A dead endpoint does not block the run.
+- **Retry:** the exporter retries on transient failures (HTTP 503, etc.)
+  with an initial interval of 250 ms and a max interval of 2 s. The
+  5-second context deadline passed to `tp.Shutdown` bounds both retries
+  and in-flight requests, so a persistently failing or hanging endpoint
+  does not extend shutdown.
+- **Crashed runs:** completed spans already flushed mid-run reach the
+  backend; spans in the batch buffer are lost. The local file remains.
+- **Sampling:** when `TRACEPARENT` has the sampled flag unset (`-00`),
+  OTLP export is suppressed. The local file is still written.
+- **Endpoint validation:** the CLI validates the endpoint before creating
+  the OTLP exporter. An endpoint is invalid if it cannot be parsed as a
+  URL, has no scheme, uses a scheme other than `http` or `https`, or has no
+  host (e.g. `localhost:4318` instead of `http://localhost:4318`). When
+  invalid, the CLI prints a warning to stderr and skips OTLP export; the
+  local file exporter is unaffected. A valid signal-specific endpoint is not
+  blocked by an invalid generic endpoint.
+- **Private CAs:** `OTEL_EXPORTER_OTLP_CERTIFICATE` points at a PEM
+  bundle. No skip-verify option exists.
 
 ## GHA workflow configuration
 
@@ -223,26 +209,14 @@ All agent stages (triage, code, review, fix, retro, prioritize, harness)
 forward OTEL configuration. To enable export, set on the org (or repo)
 that hosts the fullsend caller workflows:
 
-1. Actions **variable** `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — the backend's
-   full traces URL (e.g. `https://mlflow.example.com/v1/traces`).
-   Alternatively, set `OTEL_EXPORTER_OTLP_ENDPOINT` (the base URL without a
-   signal path); managed workflows forward both variants.
-2. Actions **secret** `OTEL_EXPORTER_OTLP_TRACES_HEADERS` — the complete
-   header string, auth and routing included (e.g.
-   `Authorization=Bearer%20<token>,x-mlflow-experiment-id=42`).
-3. Optional: Actions **secret** `OTEL_EXPORTER_OTLP_HEADERS` — generic
-   (non-signal-specific) OTLP headers. Same format as the traces variant.
-   Useful when a single header set covers all signals.
-4. Optional: Actions **variable** `OTEL_EXPORTER_OTLP_CERTIFICATE` — path
-   to a PEM CA bundle for backends behind a private CA. The path must
-   resolve on the runner; commit the bundle into the config repo (e.g.
-   `.fullsend/otel-ca.pem`) and set the variable to that checkout-relative
-   path.
-5. Optional: Actions **variable** `OTEL_RESOURCE_ATTRIBUTES` — static
-   `k=v,k=v` trace tags. The value is used verbatim: `${{ github.* }}`
-   expressions evaluate only in workflow YAML, not in variables.
-6. Optional: Actions **variable** `OTEL_SDK_DISABLED` — set to `true` to
-   disable all telemetry, including the local file exporter.
+| Name | Type | Required | Purpose |
+|------|------|----------|---------|
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Variable | Yes | Backend's full traces URL (e.g. `https://mlflow.example.com/v1/traces`). Alternatively, set `OTEL_EXPORTER_OTLP_ENDPOINT` (the base URL without a signal path); managed workflows forward both variants. |
+| `OTEL_EXPORTER_OTLP_TRACES_HEADERS` | Secret | Yes | Complete header string, auth and routing included (e.g. `Authorization=Bearer%20<token>,x-mlflow-experiment-id=42`). |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Secret | No | Generic (non-signal-specific) OTLP headers. Same format as the traces variant. Useful when a single header set covers all signals. |
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` | Variable | No | Path to a PEM CA bundle for backends behind a private CA. Commit the bundle into the config repo (e.g. `.fullsend/otel-ca.pem`) and set the variable to that checkout-relative path. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Variable | No | Static `k=v,k=v` trace tags. The value is used verbatim; `${{ github.* }}` expressions evaluate only in workflow YAML, not in variables. |
+| `OTEL_SDK_DISABLED` | Variable | No | Set to `true` to disable all telemetry, including the local file exporter. |
 
 Installations scaffolded before OTEL support was added must also forward the
 secrets (add `OTEL_EXPORTER_OTLP_TRACES_HEADERS` and
@@ -259,76 +233,17 @@ env:
   OTEL_EXPORTER_OTLP_ENDPOINT: "${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}"
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}"
   OTEL_EXPORTER_OTLP_TRACES_HEADERS: "${{ secrets.OTEL_EXPORTER_OTLP_TRACES_HEADERS }}"
+  OTEL_EXPORTER_OTLP_HEADERS: "${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}"
+  OTEL_RESOURCE_ATTRIBUTES: "${{ vars.OTEL_RESOURCE_ATTRIBUTES }}"
+  OTEL_SDK_DISABLED: "${{ vars.OTEL_SDK_DISABLED }}"
+  OTEL_EXPORTER_OTLP_CERTIFICATE: "${{ vars.OTEL_EXPORTER_OTLP_CERTIFICATE }}"
 ```
 
-Any variable and secret names work here — the values reach the exporter
+Any variable and secret names work here; the values reach the exporter
 as-is. Consult your backend's documentation for the endpoint URL and
 authentication mechanism.
 
-### Organizing traces for an org
+## See also
 
-Two conventions keep a shared backend navigable as repos onboard:
-
-1. **One backend bucket per org.** On MLflow, create one experiment per org
-   (e.g. `fullsend-<org>`) and point the org's header secret at its id. The
-   backend's per-bucket access controls then align with org boundaries.
-2. **Slice inside the bucket with resource attributes.** Standard OTel
-   resource env is honored, so workflows can tag every trace with repo,
-   agent, and environment:
-
-   ```yaml
-   env:
-     OTEL_RESOURCE_ATTRIBUTES: "fullsend.repo=${{ github.repository }},fullsend.agent=triage,deployment.environment=prod"
-   ```
-
-   The example is inline workflow `env:`, where `${{ github.* }}` evaluates.
-   On the managed path, set the `OTEL_RESOURCE_ATTRIBUTES` Actions variable
-   to a static value instead — variables are not expression-expanded.
-
-   These become filterable trace tags (enable them as columns in MLflow's
-   Traces table). `fullsend.work_item_id` is on the root `run` span, so runs
-   for the same issue correlate by filtering on the root span.
-
-## Local development
-
-Run an agent locally with traces going to a local backend:
-
-1. Start a local Jaeger instance (OTLP-compatible):
-
-   ```bash
-   podman run -d --name jaeger \
-     -p 16686:16686 \
-     -p 4318:4318 \
-     jaegertracing/jaeger
-   ```
-
-2. Point the exporter at it and run an agent:
-
-   ```bash
-   export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
-   fullsend run triage --issue 42
-   ```
-
-3. View the traces at <http://localhost:16686>.
-
-Other lightweight local backends:
-
-| Backend | Command | UI |
-|---------|---------|-----|
-| Jaeger | `podman run -p 16686:16686 -p 4318:4318 jaegertracing/jaeger` | `localhost:16686` |
-| Arize Phoenix | `podman run -p 6006:6006 -p 4318:4318 arizephoenix/phoenix` | `localhost:6006` |
-| MLflow ≥ 3.6 | `uvx "mlflow>=3.6" server --backend-store-uri sqlite:///mlflow.db` (native OTLP at `/v1/traces`; requires the `x-mlflow-experiment-id` header — see the MLflow example above) | `localhost:5000` |
-
-## Other backends
-
-Any OTLP-compatible backend works. Choosing an LLM-aware backend (MLflow,
-Phoenix, Langfuse) activates GenAI dashboards — token cost rollups,
-prompt/completion inspection, agent-specific views — without any CLI-side
-configuration change. The `gen_ai.*` span attributes are recognized
-automatically.
-
-For production deployments, consult your backend's documentation for:
-- High-availability configuration
-- Authentication and access control
-- Data retention policies
-- Cost considerations for high-volume trace ingestion
+- [How To Emit Traces](../user/how-to-emit-traces.md): step-by-step setup guide
+- [Tracing Development Guide](../dev/tracing.md): implementation details for contributors

--- a/docs/guides/user/how-to-emit-traces.md
+++ b/docs/guides/user/how-to-emit-traces.md
@@ -1,0 +1,148 @@
+# How To Emit Traces
+
+## Overview
+
+Fullsend emits OpenTelemetry traces for every agent run. By default, traces
+are written to the `run-telemetry.jsonl` file that gets uploaded into an artifact
+in the workflow. Fullsend is able to send traces to a remote OpenTelemetry-compatible
+endpoint.
+
+Follow this guide to configure a GitHub repository or organization to send traces
+to a backend like MLflow, Jaeger, Grafana Tempo, etc.
+
+## Before you begin
+
+- An **OTLP/HTTP-compatible endpoint** and its URL (e.g.
+  `https://mlflow.example.com:4318/v1/traces`).
+- **Authentication credentials** for the endpoint (bearer token, basic
+  auth, or API key) if required.
+- **Network reachability** from where runs execute (your machine or CI
+  runners) to the backend endpoint.
+- The **`gh` CLI** installed and authenticated, or access to the GitHub UI
+  for setting variables and secrets.
+
+## Send traces from a repository
+
+1. Determine the endpoint URL where your backend receives traces.
+
+   For most systems this is `<host>:4318/v1/traces`.
+
+2. Set the endpoint as a GitHub Actions variable on the repository.
+
+   ```bash
+   gh variable set OTEL_EXPORTER_OTLP_ENDPOINT --body "https://example.com:4318" --repo <owner/repo>
+   ```
+
+   `OTEL_EXPORTER_OTLP_ENDPOINT` gets `/v1/traces` appended automatically
+   by the SDK. If your backend uses a different path, use
+   `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and specify the full URL instead.
+
+3. Build the authentication header for your endpoint.
+
+   The header format depends on your backend. Common patterns include:
+
+   - Bearer token: `Authorization=Bearer%20<token>`
+   - Basic auth: `Authorization=Basic%20<base64 of user:password>`
+
+    `%20` is the encoding for space, don't use spaces directly.
+
+4. Set the authentication header as a GitHub Actions secret on the repository.
+
+   ```bash
+   gh secret set OTEL_EXPORTER_OTLP_TRACES_HEADERS --body "<authentication-header>" --repo <owner/repo>
+   ```
+
+5. *(Optional)* Add backend-specific routing headers to the same secret.
+
+   Some backends require additional headers. For MLflow, append the
+   experiment ID:
+
+   ```bash
+   gh secret set OTEL_EXPORTER_OTLP_TRACES_HEADERS \
+     --body "<authentication-header>,x-mlflow-experiment-id=<id>" \
+     --repo <owner/repo>
+   ```
+
+6. *(Optional)* Set resource attributes to tag traces with metadata.
+
+   ```bash
+   gh variable set OTEL_RESOURCE_ATTRIBUTES \
+     --body "deployment.env=prod,category=a" \
+     --repo <owner/repo>
+   ```
+
+   Resource attributes may become filterable trace tags depending on your backend.
+
+## Send traces to an endpoint from a GitHub organization
+
+1. Set the endpoint as an organization-level variable.
+
+   To make it visible to all repositories:
+
+   ```bash
+   gh variable set OTEL_EXPORTER_OTLP_ENDPOINT \
+     --body "https://example.com:4318" \
+     --org <org> --visibility all
+   ```
+
+   To restrict visibility to specific repositories:
+
+   ```bash
+   gh variable set OTEL_EXPORTER_OTLP_ENDPOINT \
+     --body "https://example.com:4318" \
+     --org <org> --repos repo1,repo2,repo3
+   ```
+
+2. Set the authentication header as an organization-level secret with the
+   same visibility.
+
+   ```bash
+   gh secret set OTEL_EXPORTER_OTLP_TRACES_HEADERS \
+     --body "<authentication-header>" \
+     --org <org> --visibility all
+   ```
+
+   To restrict visibility to specific repositories:
+
+   ```bash
+   gh secret set OTEL_EXPORTER_OTLP_TRACES_HEADERS \
+     --body "<authentication-header>" \
+     --org <org> --repos repo1,repo2,repo3
+   ```
+
+## Disable trace export
+
+Remove the endpoint variable and header secret from the repository or
+organization to stop sending traces to the endpoint. The local
+`run-telemetry.jsonl` file continues to be produced.
+
+```bash
+gh variable delete OTEL_EXPORTER_OTLP_ENDPOINT --repo <owner/repo>
+gh secret delete OTEL_EXPORTER_OTLP_TRACES_HEADERS --repo <owner/repo>
+```
+
+## Disable the local trace file
+
+Set `OTEL_SDK_DISABLED` to suppress all telemetry output, including the
+local file and any configured endpoint export.
+
+```bash
+gh variable set OTEL_SDK_DISABLED --body "true" --repo <owner/repo>
+```
+
+To disable at the organization level and then re-enable individual
+repositories:
+
+```bash
+gh variable set OTEL_SDK_DISABLED --body "true" --org <org> --visibility all
+gh variable set OTEL_SDK_DISABLED --body "false" --repo <owner/repo>
+```
+
+## See also
+
+- [Tracing with MLflow](tracing-with-mlflow.md): experiment routing, Basic
+  auth encoding, org-level organization, and cost column caveats
+- [Tracing Reference](../infrastructure/distributed-tracing.md): span
+  schemas, attribute tables, and environment variable reference
+- [Tracing Development Guide](../dev/tracing.md): implementation details
+  for contributors

--- a/docs/guides/user/tracing-with-mlflow.md
+++ b/docs/guides/user/tracing-with-mlflow.md
@@ -1,0 +1,101 @@
+# Tracing with MLflow
+
+MLflow 3.6+ ingests OTLP/HTTP traces natively and provides experiment-based
+routing, a traces UI, and per-trace cost estimates. This guide covers
+MLflow-specific configuration on top of the general
+[How To Emit Traces](how-to-emit-traces.md) setup.
+
+## Before you begin
+
+- MLflow **3.6 or later** running with a traces endpoint at
+  `{server}/v1/traces`.
+- A completed [How To Emit Traces](how-to-emit-traces.md) setup (endpoint
+  variable and header secret configured).
+
+## Endpoint and experiment routing
+
+MLflow routes traces to an experiment via the `x-mlflow-experiment-id`
+header. Append it to the authentication header in the same secret:
+
+```bash
+gh secret set OTEL_EXPORTER_OTLP_TRACES_HEADERS \
+  --body "<authentication-header>,x-mlflow-experiment-id=<id>" \
+  --repo <owner/repo>
+```
+
+Use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (signal-specific) rather than the
+base endpoint, because MLflow's traces path is `{server}/v1/traces` and the
+SDK would otherwise append `/v1/traces` to the base URL:
+
+```bash
+gh variable set OTEL_EXPORTER_OTLP_TRACES_ENDPOINT \
+  --body "https://mlflow.example.com/v1/traces" \
+  --repo <owner/repo>
+```
+
+## Basic auth encoding
+
+Header values are URL-decoded by the OTel SDK. Encode spaces as `%20`:
+
+```bash
+# Base64-encode the credentials
+CREDS_B64=$(echo -n "user:password" | base64)
+
+# Set the header with URL-encoded space
+gh secret set OTEL_EXPORTER_OTLP_TRACES_HEADERS \
+  --body "Authorization=Basic%20${CREDS_B64},x-mlflow-experiment-id=<id>" \
+  --repo <owner/repo>
+```
+
+## Organizing traces for an org
+
+Two conventions keep a shared MLflow instance navigable as repos onboard:
+
+1. **One experiment per org.** Create an experiment per org (e.g.
+   `fullsend-<org>`) and point the org's header secret at its ID. MLflow's
+   per-experiment access controls then align with org boundaries.
+
+2. **Slice inside the experiment with resource attributes.** The standard
+   `OTEL_RESOURCE_ATTRIBUTES` variable tags every trace:
+
+   ```yaml
+   # In workflow YAML (where ${{ github.* }} evaluates):
+   env:
+     OTEL_RESOURCE_ATTRIBUTES: "fullsend.repo=${{ github.repository }},fullsend.agent=triage,deployment.environment=prod"
+   ```
+
+   On the managed path, set the `OTEL_RESOURCE_ATTRIBUTES` Actions variable
+   to a static value instead; variables are not expression-expanded.
+
+   Enable these as columns in MLflow's Traces table.
+   `fullsend.work_item_id` on the root `run` span correlates runs for the
+   same issue.
+
+## Cost column caveat
+
+MLflow's per-trace cost column is its own estimate: it extracts input/output
+token counts and prices them against MLflow's internal model table. This
+excludes cache-creation and cache-read tokens, which dominate agent-run cost.
+
+The authoritative cost figure is the runtime-reported `fullsend.cost_usd`
+attribute on `agent` spans (also in `run-telemetry.jsonl`).
+
+## Local development
+
+Start a local MLflow instance and point the exporter at it:
+
+```bash
+uvx mlflow server
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:5000/v1/traces"
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-mlflow-experiment-id=0"
+fullsend run triage ...
+```
+
+See [Running Agents Locally](../user/running-agents-locally.md) for full
+flags. View traces at `http://localhost:5000`.
+
+## See also
+
+- [How To Emit Traces](how-to-emit-traces.md): general setup for any OTLP backend
+- [Tracing reference](../infrastructure/distributed-tracing.md): span
+  schemas, attribute tables, and environment variable reference

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -234,6 +234,8 @@ export default defineConfig({
             },
             { text: "Running Agents Locally", link: "/guides/user/running-agents-locally" },
             { text: "Jira Integration", link: "/guides/user/jira-integration" },
+            { text: "How To Emit Traces", link: "/guides/user/how-to-emit-traces" },
+            { text: "Tracing with MLflow", link: "/guides/user/tracing-with-mlflow" },
           ],
         },
         {
@@ -257,7 +259,7 @@ export default defineConfig({
             { text: "Mint Administration", link: "/guides/infrastructure/mint-administration" },
             { text: "Standalone Mint", link: "/guides/infrastructure/standalone-mint" },
             { text: "Private Repositories", link: "/guides/infrastructure/private-repositories" },
-            { text: "Distributed Tracing", link: "/guides/infrastructure/distributed-tracing" },
+            { text: "Tracing Reference", link: "/guides/infrastructure/distributed-tracing" },
             { text: "Advanced Setup", link: "/guides/infrastructure/advanced-setup" },
             {
               text: "Layered Config Reference",
@@ -278,6 +280,7 @@ export default defineConfig({
                 { text: "CLI Internals", link: "/guides/dev/cli-internals" },
                 { text: "E2E Testing", link: "/guides/dev/e2e-testing" },
                 { text: "Testing Workflows", link: "/guides/dev/testing-workflows" },
+                { text: "Tracing Internals", link: "/guides/dev/tracing" },
               ],
             },
             {


### PR DESCRIPTION
## Summary

- Split the monolithic `distributed-tracing.md` into three audience-targeted docs: dev internals (`tracing.md`), user how-to (`how-to-emit-traces.md`), and infrastructure reference (`distributed-tracing.md`)
- Add VitePress sidebar entries for both new pages
- Update GHA workflow sections to reflect OTEL variable forwarding from #5887

Closes #5659

🤖 Generated with [Claude Code](https://claude.com/claude-code)