### PR TITLE
fix(#5361): set span status from run outcome, not runErr alone

### DIFF
--- a/docs/ADRs/0050-distributed-tracing-instrumentation.md
+++ b/docs/ADRs/0050-distributed-tracing-instrumentation.md
@@ -67,6 +67,11 @@ opt-in model:
 - Every run produces `run-telemetry.jsonl` and `run-summary.json` in the output
   directory (uploaded as GHA artifacts alongside transcripts)
 - Metadata only: span hierarchy, timing, token counts, tool names, errors
+- "Errors" covers operational error text on span statuses and exception
+  events — bounded, UTF-8-repaired, and sanitized where agent-controlled; a
+  failed sandbox create embeds excerpts of container/supervisor logs. The
+  Level 3 gate governs prompt/completion capture, which is separate from
+  error reporting.
 - No data leaves the runner. No backend required.
 
 **Level 2 — OTLP export (org opts in by setting endpoint):**

--- a/docs/guides/infrastructure/distributed-tracing.md
+++ b/docs/guides/infrastructure/distributed-tracing.md
@@ -125,6 +125,7 @@ and are recognized by LLM-aware backends for GenAI dashboards.
 | `fullsend.security_trace_id` | `run` | Security scanner trace correlation ID |
 | `fullsend.prescript.skipped` | `run` | Whether the pre-script signaled a skip |
 | `fullsend.prescript.skip_reason` | `run` | Human-readable skip reason from the pre-script |
+| `fullsend.transcript_error` | `agent` | Present (`true`) when the agent exited 0 but its transcript reported an error — the span's status is Error while `exit_code` keeps the raw process exit |
 
 ### Common attributes
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -961,12 +961,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			)
 		}
 
-		if runErr != nil {
-			recordSanitizedError(rootSpan, runErr)
-		}
-		code, msg := rootSpanStatus(runErr, exitCode, validationPassed)
-		rootSpan.SetStatus(code, msg)
-		rootSpan.End()
+		finalizeRootSpan(rootSpan, runErr, exitCode, validationPassed)
 
 		flushCtx, cancel := context.WithTimeout(context.Background(), telemetry.FlushTimeout)
 		defer cancel()
@@ -1028,17 +1023,11 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 
 	readyTimeout := time.Duration(h.SandboxTimeoutSeconds) * time.Second
 	if err := sandbox.CreateWithRetry(sandboxName, allProviderNames, h.Image, h.Policy, sandbox.DefaultMaxCreateAttempts, readyTimeout); err != nil {
-		// This error embeds raw supervisor/gateway/container logs — same
-		// treatment as the agent and root spans: the fuller bounded copy
-		// on the event, a tighter valid-UTF-8 status.
-		recordSanitizedError(sandboxSpan, err)
-		sandboxSpan.SetStatus(codes.Error, truncateStatusMsg(err.Error()))
-		sandboxSpan.End()
+		finalizeSandboxSpan(sandboxSpan, err)
 		printer.StepFail("Failed to create sandbox")
 		return fmt.Errorf("creating sandbox: %w", err)
 	}
-	sandboxSpan.SetStatus(codes.Ok, "")
-	sandboxSpan.End()
+	finalizeSandboxSpan(sandboxSpan, nil)
 
 	// repoExtractedOK tracks whether hostRepositoryDownloadDir is safe
 	// and corresponds to the validated iteration. It is false when:
@@ -2471,6 +2460,34 @@ func truncateStatusMsgTo(s string, n int) string {
 		truncated = truncated[:len(truncated)-1]
 	}
 	return truncated + statusEllipsis
+}
+
+// finalizeRootSpan records the run outcome on the root span and ends it:
+// a runtime error gets the bounded exception event before the status, and
+// the status comes from rootSpanStatus — validation, not the last agent
+// exit, is the run's success gate (#5361).
+func finalizeRootSpan(span trace.Span, runErr error, exitCode int, validationPassed bool) {
+	if runErr != nil {
+		recordSanitizedError(span, runErr)
+	}
+	code, msg := rootSpanStatus(runErr, exitCode, validationPassed)
+	span.SetStatus(code, msg)
+	span.End()
+}
+
+// finalizeSandboxSpan records the sandbox-create outcome and ends the
+// span. On failure the create error — which embeds raw supervisor/
+// gateway/container logs — gets the same treatment as the agent and root
+// spans: the fuller bounded copy on the exception event, a tighter
+// valid-UTF-8 status description.
+func finalizeSandboxSpan(span trace.Span, err error) {
+	if err != nil {
+		recordSanitizedError(span, err)
+		span.SetStatus(codes.Error, truncateStatusMsg(err.Error()))
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.End()
 }
 
 // transcriptErrorMessage builds the message for a transcript-reported

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 
@@ -922,6 +923,13 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	securityTraceID := security.GenerateTraceID()
 	rootSpan.SetAttributes(attribute.String("fullsend.security_trace_id", securityTraceID))
 
+	// validationPassed is declared before both defer closures that guard on
+	// it: the telemetry defer keys the root span's status on it (validation,
+	// not the last agent exit code, is the run's success gate), and the
+	// post-script defer must only run when validation has passed — running it
+	// on unvalidated output would violate ADR 0022's zero-trust model.
+	var validationPassed bool
+
 	defer func() {
 		exitCode := telemetryExitCode(lastExitCode, runErr)
 
@@ -954,10 +962,10 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		}
 
 		if runErr != nil {
-			rootSpan.SetStatus(codes.Error, runErr.Error())
-		} else {
-			rootSpan.SetStatus(codes.Ok, "")
+			rootSpan.RecordError(runErr)
 		}
+		code, msg := rootSpanStatus(runErr, exitCode, validationPassed)
+		rootSpan.SetStatus(code, msg)
 		rootSpan.End()
 
 		flushCtx, cancel := context.WithTimeout(context.Background(), telemetry.FlushTimeout)
@@ -1027,12 +1035,6 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	}
 	sandboxSpan.SetStatus(codes.Ok, "")
 	sandboxSpan.End()
-
-	// validationPassed is declared here (before the post-script defer) so the
-	// defer closure can guard on it. The post-script must only run when
-	// validation has passed — running it on unvalidated output would violate
-	// ADR 0022's zero-trust model.
-	var validationPassed bool
 
 	// repoExtractedOK tracks whether hostRepositoryDownloadDir is safe
 	// and corresponds to the validated iteration. It is false when:
@@ -1515,18 +1517,11 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		}, printer, agentStart, &metrics)
 		close(heartbeatDone)
 
-		agentSpan.SetAttributes(agentSpanEndAttrs(iteration, exitCode, rt.System(), &metrics)...)
-		if runErr != nil {
-			agentSpan.SetStatus(codes.Error, runErr.Error())
-		} else {
-			agentSpan.SetStatus(codes.Ok, "")
-		}
-		agentSpan.End()
-
 		// Accumulate behavioral metrics across iterations.
 		aggregateRunMetrics(&aggMetrics, &metrics, iteration)
 
 		if runErr != nil {
+			finalizeAgentSpan(agentSpan, runErr, iteration, exitCode, rt.System(), &metrics, "")
 			printer.StepFail("Agent execution failed")
 			// Record the real exit code (rt.Run returns -1 when the agent never
 			// started) so the telemetry summary reports the failure faithfully
@@ -1546,14 +1541,26 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		// invalid_grant, quota exhaustion) while setting is_error:true in
 		// the transcript. Treat these as failures so downstream gating
 		// (transcript surfacing, post-script skip) can act. See #2786.
+		// This runs before the agent span is finalized so the span's
+		// status reflects the transcript-reported failure (#5361).
+		var transcriptErrMsg string
 		if exitCode == 0 {
 			outputJSONL := filepath.Join(iterDir, "output.jsonl")
 			if te, ok := tx.ParseTranscriptFile(outputJSONL); ok && te.IsError {
 				printer.StepWarn(fmt.Sprintf("Agent exited with code 0 but transcript contains error: %s", te.ErrorMessage))
 				lastExitCode = 1
 				transcriptErrorOverride = true
+				// ErrorMessage can be empty (the transcript result field is
+				// omitempty); substitute the emitTranscriptErrors fallback so
+				// the span status never reads Ok for a transcript failure.
+				transcriptErrMsg = te.ErrorMessage
+				if transcriptErrMsg == "" {
+					transcriptErrMsg = fmt.Sprintf("agent terminated with error (subtype: %s)", te.Subtype)
+				}
 			}
 		}
+
+		finalizeAgentSpan(agentSpan, nil, iteration, exitCode, rt.System(), &metrics, transcriptErrMsg)
 
 		printer.Blank()
 		// Non-zero exit is a warning, not a failure — the validation loop is the success gate.
@@ -2405,6 +2412,77 @@ func telemetryExitCode(lastExitCode int, runErr error) int {
 		return 1
 	}
 	return lastExitCode
+}
+
+// maxSpanStatusMsgLen caps status descriptions so a runaway transcript error
+// message cannot bloat every export of the span.
+const maxSpanStatusMsgLen = 256
+
+// truncateStatusMsg trims a status description to maxSpanStatusMsgLen. If
+// truncated, walks back to a valid UTF-8 rune boundary before appending the
+// ellipsis — an invalid-UTF-8 status fails proto marshaling of the entire
+// OTLP batch, silently dropping every span in it.
+func truncateStatusMsg(s string) string {
+	if len(s) <= maxSpanStatusMsgLen {
+		return s
+	}
+	truncated := s[:maxSpanStatusMsgLen]
+	for len(truncated) > 0 && !utf8.Valid([]byte(truncated)) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated + "…"
+}
+
+// finalizeAgentSpan records the end-of-iteration attributes and status on an
+// agent span and ends it. transcriptErr is non-empty when the transcript
+// reported a failure the process exit code did not (#2786): exit_code keeps
+// the raw process exit and fullsend.transcript_error marks the override.
+func finalizeAgentSpan(span trace.Span, runErr error, iteration, exitCode int, system string, m *agentruntime.RunMetrics, transcriptErr string) {
+	span.SetAttributes(agentSpanEndAttrs(iteration, exitCode, system, m)...)
+	if runErr != nil {
+		span.RecordError(runErr)
+	}
+	if transcriptErr != "" {
+		span.SetAttributes(attribute.Bool("fullsend.transcript_error", true))
+	}
+	code, msg := agentSpanStatus(runErr, exitCode, transcriptErr)
+	span.SetStatus(code, msg)
+	span.End()
+}
+
+// agentSpanStatus maps one iteration's outcome to the agent span's status.
+// The validation loop, not the iteration, is the run's success gate — but the
+// span reports what happened in this iteration, and a failure is never
+// reported as success: a runtime error, a transcript-reported error (#2786),
+// or a non-zero exit is Error.
+func agentSpanStatus(runErr error, exitCode int, transcriptErr string) (codes.Code, string) {
+	switch {
+	case runErr != nil:
+		return codes.Error, truncateStatusMsg(runErr.Error())
+	case transcriptErr != "":
+		return codes.Error, truncateStatusMsg("transcript error: " + transcriptErr)
+	case exitCode != 0:
+		return codes.Error, fmt.Sprintf("agent exited with code %d", exitCode)
+	}
+	return codes.Ok, ""
+}
+
+// rootSpanStatus maps the run outcome to the root span's status. Validation,
+// not the last agent exit code, is the run's success gate: a passed
+// validation loop is Ok even when the final iteration exited non-zero.
+// exitCode is the telemetryExitCode result, so a harness without a
+// validation loop that returns nil alongside a failed agent still reports
+// Error (#5361).
+func rootSpanStatus(runErr error, exitCode int, validationPassed bool) (codes.Code, string) {
+	switch {
+	case runErr != nil:
+		return codes.Error, truncateStatusMsg(runErr.Error())
+	case validationPassed:
+		return codes.Ok, ""
+	case exitCode != 0:
+		return codes.Error, fmt.Sprintf("run finished with exit code %d", exitCode)
+	}
+	return codes.Ok, ""
 }
 
 // traceIdentity holds the resolved trace context for a run.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -912,16 +912,16 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	var aggMetrics aggregateMetrics
 	tracer, tracingCleanup := telemetry.Setup(runDir, Version())
 	tid := resolveTraceIdentity(ctx, tracer, os.Getenv("TRACEPARENT"), os.Getenv("TRACESTATE"), []attribute.KeyValue{
-		attribute.String("fullsend.agent", agentName),
-		attribute.String("fullsend.work_item_id", workItemID),
+		stringAttr("fullsend.agent", agentName),
+		stringAttr("fullsend.work_item_id", workItemID),
 		attribute.String("gen_ai.operation.name", "invoke_agent"),
-		attribute.String("gen_ai.agent.name", agentName),
+		stringAttr("gen_ai.agent.name", agentName),
 	})
 	ctx = tid.Ctx
 	rootSpan := tid.RootSpan
 	traceparent := tid.Traceparent
 	securityTraceID := security.GenerateTraceID()
-	rootSpan.SetAttributes(attribute.String("fullsend.security_trace_id", securityTraceID))
+	rootSpan.SetAttributes(stringAttr("fullsend.security_trace_id", securityTraceID))
 
 	// validationPassed is declared before both defer closures that guard on
 	// it: the telemetry defer keys the root span's status on it (validation,
@@ -945,11 +945,11 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			rootSpan.SetAttributes(attribute.Bool("fullsend.prescript.skipped", runSkipped))
 		}
 		if runSkipped && runSkipReason != "" {
-			rootSpan.SetAttributes(attribute.String("fullsend.prescript.skip_reason", runSkipReason))
+			rootSpan.SetAttributes(stringAttr("fullsend.prescript.skip_reason", runSkipReason))
 		}
 		if runCount > 0 {
 			rootSpan.SetAttributes(
-				attribute.String("gen_ai.request.model", aggMetrics.Model),
+				stringAttr("gen_ai.request.model", aggMetrics.Model),
 				attribute.Int("gen_ai.usage.input_tokens", aggMetrics.TokenUsage.Input),
 				attribute.Int("gen_ai.usage.output_tokens", aggMetrics.TokenUsage.Output),
 				attribute.Int("gen_ai.usage.cache_creation.input_tokens", aggMetrics.TokenUsage.CacheCreation),
@@ -2321,7 +2321,7 @@ func agentSpanStartAttrs(iteration int, agentName string) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.Int("iteration", iteration),
 		attribute.String("gen_ai.operation.name", "invoke_agent"),
-		attribute.String("gen_ai.agent.name", agentName),
+		stringAttr("gen_ai.agent.name", agentName),
 	}
 }
 
@@ -2329,8 +2329,8 @@ func agentSpanEndAttrs(iteration, exitCode int, system string, m *agentruntime.R
 	return []attribute.KeyValue{
 		attribute.Int("iteration", iteration),
 		attribute.Int("exit_code", exitCode),
-		attribute.String("gen_ai.system", system),
-		attribute.String("gen_ai.request.model", m.Model),
+		stringAttr("gen_ai.system", system),
+		stringAttr("gen_ai.request.model", m.Model),
 		attribute.Int("gen_ai.usage.input_tokens", m.InputTokens),
 		attribute.Int("gen_ai.usage.output_tokens", m.OutputTokens),
 		attribute.Int("gen_ai.usage.cache_creation.input_tokens", m.CacheCreationInputTokens),
@@ -2430,9 +2430,11 @@ const maxSpanStatusMsgLen = 2000
 // unbounded one: a sandbox-create failure embeds raw supervisor/gateway/
 // container logs, the SDK never truncates event attribute values, and an
 // oversized batch can be rejected by the collector whole. The value is the
-// provider's default attribute bound so the two defaults cannot drift
-// (an operator's runtime attribute override deliberately does not move
-// this bound — the SDK never truncates event attributes); it holds the
+// provider's default attribute bound so the shared numeric default cannot
+// drift — this bound counts bytes while the SDK counts attribute
+// characters, and an operator's runtime attribute override deliberately
+// does not move this bound (the SDK never truncates event attributes).
+// It holds the
 // worst-case transcript message — maxTranscriptErrorLength plus the parser
 // suffix, grown to just under 2x by sanitization's colon-pair breaking
 // (4,014 bytes) — with room to spare. No external limit mandates it.
@@ -2463,6 +2465,16 @@ func truncateStatusMsgTo(s string, n int) string {
 		truncated = truncated[:len(truncated)-1]
 	}
 	return truncated + statusEllipsis
+}
+
+// stringAttr builds a string attribute with the value repaired to valid
+// UTF-8. The SDK's attribute limit repairs encoding only when it
+// truncates — an under-limit value passes through untouched, and one
+// invalid byte fails proto marshaling of the whole OTLP batch — so every
+// dynamic string attribute goes through this helper; literal values may
+// use attribute.String directly.
+func stringAttr(key, val string) attribute.KeyValue {
+	return attribute.String(key, strings.ToValidUTF8(val, ""))
 }
 
 // finalizeRootSpan records the run outcome on the root span and ends it:

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1029,8 +1029,8 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	readyTimeout := time.Duration(h.SandboxTimeoutSeconds) * time.Second
 	if err := sandbox.CreateWithRetry(sandboxName, allProviderNames, h.Image, h.Policy, sandbox.DefaultMaxCreateAttempts, readyTimeout); err != nil {
 		// This error embeds raw supervisor/gateway/container logs — same
-		// treatment as the agent and root spans: full text on the event,
-		// bounded valid-UTF-8 status.
+		// treatment as the agent and root spans: the fuller bounded copy
+		// on the event, a tighter valid-UTF-8 status.
 		recordSanitizedError(sandboxSpan, err)
 		sandboxSpan.SetStatus(codes.Error, truncateStatusMsg(err.Error()))
 		sandboxSpan.End()
@@ -1551,19 +1551,14 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		if exitCode == 0 {
 			outputJSONL := filepath.Join(iterDir, "output.jsonl")
 			if te, ok := tx.ParseTranscriptFile(outputJSONL); ok && te.IsError {
-				printer.StepWarn(fmt.Sprintf("Agent exited with code 0 but transcript contains error: %s", te.ErrorMessage))
 				lastExitCode = 1
 				transcriptErrorOverride = true
-				// ErrorMessage can be empty (the transcript result field is
-				// omitempty); substitute the emitTranscriptErrors fallback so
-				// the span status never reads Ok for a transcript failure.
-				// Both fields are agent-controlled and reach a new export
-				// sink here, so they get the same sanitization the GHA
-				// annotation path applies.
-				transcriptErrMsg = agentruntime.SanitizeOutput(te.ErrorMessage)
-				if transcriptErrMsg == "" {
-					transcriptErrMsg = fmt.Sprintf("agent terminated with error (subtype: %s)", agentruntime.SanitizeOutput(te.Subtype))
-				}
+				transcriptErrMsg = transcriptErrorMessage(te)
+				// The console line prints the same bounded, sanitized string
+				// the span event records: the raw fields can carry ANSI
+				// escapes, a newline-led ::workflow-command::, or an
+				// unbounded Subtype into the CI job log.
+				printer.StepWarn("Agent exited with code 0 but transcript contains error: " + transcriptErrMsg)
 			}
 		}
 
@@ -2422,12 +2417,14 @@ func telemetryExitCode(lastExitCode int, runErr error) int {
 }
 
 // recordSanitizedError records err as an exception event with its message
-// repaired to valid UTF-8 — RecordError feeds the same OTLP proto marshal
-// path as status descriptions, and one invalid byte fails export of the
-// whole batch. The rewrap costs the concrete exception.type; the message is
-// what consumers read.
+// repaired to valid UTF-8 and bounded to maxSpanEventMsgLen — RecordError
+// feeds the same OTLP proto marshal path as status descriptions, one
+// invalid byte fails export of the whole batch, and the SDK's attribute
+// value-length limit is not applied to event attributes (v1.44.0: addEvent
+// enforces only count limits, never value truncation). The rewrap costs
+// the concrete exception.type; the message is what consumers read.
 func recordSanitizedError(span trace.Span, err error) {
-	span.RecordError(errors.New(strings.ToValidUTF8(err.Error(), "")))
+	span.RecordError(errors.New(truncateStatusMsgTo(err.Error(), maxSpanEventMsgLen)))
 }
 
 // maxSpanStatusMsgLen bounds a status description's total bytes, prefix and
@@ -2435,9 +2432,19 @@ func recordSanitizedError(span trace.Span, err error) {
 // mandates a specific value; 2000 matches maxTranscriptErrorLength
 // (internal/runtime/claude_transcript.go), the repo's bound for the same
 // class of error text. Every status built from an error is preceded by
-// recordSanitizedError on the same span, so truncation here never loses
-// the only copy.
+// recordSanitizedError on the same span, which keeps the fuller
+// maxSpanEventMsgLen copy.
 const maxSpanStatusMsgLen = 2000
+
+// maxSpanEventMsgLen bounds an exception event's message. The event carries
+// the fuller copy of an error than the status description, but not an
+// unbounded one: a sandbox-create failure embeds raw supervisor/gateway/
+// container logs, the SDK never truncates event attribute values, and an
+// oversized batch can be rejected by the collector whole. 8192 holds the
+// worst-case transcript message — maxTranscriptErrorLength plus the parser
+// suffix, grown up to 1.5x by sanitization's "::" breaking (3,015 bytes) —
+// with room to spare; no external limit mandates the value.
+const maxSpanEventMsgLen = 8192
 
 const statusEllipsis = "…"
 
@@ -2466,6 +2473,16 @@ func truncateStatusMsgTo(s string, n int) string {
 	return truncated + statusEllipsis
 }
 
+// transcriptErrorMessage builds the message for a transcript-reported
+// failure (#2786): the sanitized DisplayMessage the GHA annotation path
+// also renders, bounded to maxSpanEventMsgLen. The one string reaches the
+// console line and the span sinks; the bound matters because Subtype,
+// unlike ErrorMessage, is not truncated by the transcript parser, so an
+// agent-written result line could otherwise flood the CI job log.
+func transcriptErrorMessage(te agentruntime.TranscriptError) string {
+	return truncateStatusMsgTo(te.DisplayMessage(), maxSpanEventMsgLen)
+}
+
 // finalizeAgentSpan records the end-of-iteration attributes and status on an
 // agent span and ends it. transcriptErr is non-empty when the transcript
 // reported a failure the process exit code did not (#2786): exit_code keeps
@@ -2476,8 +2493,8 @@ func finalizeAgentSpan(span trace.Span, runErr error, iteration, exitCode int, s
 	case runErr != nil:
 		recordSanitizedError(span, runErr)
 	case transcriptErr != "":
-		// The status description is capped; this event carries the full
-		// text so a verbose API error payload survives export.
+		// The status description is capped; the event's larger bound keeps
+		// a parser-truncated transcript payload whole for export.
 		recordSanitizedError(span, errors.New(transcriptErr))
 	}
 	if transcriptErr != "" {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -962,7 +962,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		}
 
 		if runErr != nil {
-			rootSpan.RecordError(runErr)
+			recordSanitizedError(rootSpan, runErr)
 		}
 		code, msg := rootSpanStatus(runErr, exitCode, validationPassed)
 		rootSpan.SetStatus(code, msg)
@@ -2417,6 +2417,15 @@ func telemetryExitCode(lastExitCode int, runErr error) int {
 	return lastExitCode
 }
 
+// recordSanitizedError records err as an exception event with its message
+// repaired to valid UTF-8 — RecordError feeds the same OTLP proto marshal
+// path as status descriptions, and one invalid byte fails export of the
+// whole batch. The rewrap costs the concrete exception.type; the message is
+// what consumers read.
+func recordSanitizedError(span trace.Span, err error) {
+	span.RecordError(errors.New(strings.ToValidUTF8(err.Error(), "")))
+}
+
 // maxSpanStatusMsgLen caps status descriptions so a runaway transcript error
 // message cannot bloat every export of the span.
 const maxSpanStatusMsgLen = 256
@@ -2447,11 +2456,11 @@ func finalizeAgentSpan(span trace.Span, runErr error, iteration, exitCode int, s
 	span.SetAttributes(agentSpanEndAttrs(iteration, exitCode, system, m)...)
 	switch {
 	case runErr != nil:
-		span.RecordError(runErr)
+		recordSanitizedError(span, runErr)
 	case transcriptErr != "":
 		// The status description is capped; this event carries the full
 		// text so a verbose API error payload survives export.
-		span.RecordError(errors.New(transcriptErr))
+		recordSanitizedError(span, errors.New(transcriptErr))
 	}
 	if transcriptErr != "" {
 		span.SetAttributes(attribute.Bool("fullsend.transcript_error", true))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2429,11 +2429,14 @@ const maxSpanStatusMsgLen = 2000
 // the fuller copy of an error than the status description, but not an
 // unbounded one: a sandbox-create failure embeds raw supervisor/gateway/
 // container logs, the SDK never truncates event attribute values, and an
-// oversized batch can be rejected by the collector whole. 8192 holds the
+// oversized batch can be rejected by the collector whole. The value is the
+// provider's default attribute bound so the two defaults cannot drift
+// (an operator's runtime attribute override deliberately does not move
+// this bound — the SDK never truncates event attributes); it holds the
 // worst-case transcript message — maxTranscriptErrorLength plus the parser
-// suffix, grown up to 1.5x by sanitization's "::" breaking (3,015 bytes) —
-// with room to spare; no external limit mandates the value.
-const maxSpanEventMsgLen = 8192
+// suffix, grown to just under 2x by sanitization's colon-pair breaking
+// (4,014 bytes) — with room to spare. No external limit mandates it.
+const maxSpanEventMsgLen = telemetry.MaxSpanAttrValueLen
 
 const statusEllipsis = "…"
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1028,7 +1028,11 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 
 	readyTimeout := time.Duration(h.SandboxTimeoutSeconds) * time.Second
 	if err := sandbox.CreateWithRetry(sandboxName, allProviderNames, h.Image, h.Policy, sandbox.DefaultMaxCreateAttempts, readyTimeout); err != nil {
-		sandboxSpan.SetStatus(codes.Error, err.Error())
+		// This error embeds raw supervisor/gateway/container logs — same
+		// treatment as the agent and root spans: full text on the event,
+		// bounded valid-UTF-8 status.
+		recordSanitizedError(sandboxSpan, err)
+		sandboxSpan.SetStatus(codes.Error, truncateStatusMsg(err.Error()))
 		sandboxSpan.End()
 		printer.StepFail("Failed to create sandbox")
 		return fmt.Errorf("creating sandbox: %w", err)
@@ -2426,30 +2430,40 @@ func recordSanitizedError(span trace.Span, err error) {
 	span.RecordError(errors.New(strings.ToValidUTF8(err.Error(), "")))
 }
 
-// maxSpanStatusMsgLen caps status descriptions so a runaway error message
-// cannot bloat every export of the span. No OTel, collector, or backend
-// limit mandates a specific value; 2000 matches maxTranscriptErrorLength
-// (internal/runtime/claude_transcript.go), which bounds the same class of
-// consumer-facing error text — so a parse-time-truncated transcript message
-// is never truncated a second time here.
+// maxSpanStatusMsgLen bounds a status description's total bytes, prefix and
+// truncation ellipsis included. No OTel, collector, or backend limit
+// mandates a specific value; 2000 matches maxTranscriptErrorLength
+// (internal/runtime/claude_transcript.go), the repo's bound for the same
+// class of error text. Every status built from an error is preceded by
+// recordSanitizedError on the same span, so truncation here never loses
+// the only copy.
 const maxSpanStatusMsgLen = 2000
 
-// truncateStatusMsg repairs invalid UTF-8 and trims a status description to
-// maxSpanStatusMsgLen, walking back to a rune boundary before appending the
-// ellipsis. Both steps matter: an invalid-UTF-8 status fails proto marshaling
-// of the entire OTLP batch, silently dropping every span in it, and the
-// source text (a wrapped command error, a transcript payload) can be invalid
-// at any length.
+const statusEllipsis = "…"
+
+// truncateStatusMsg bounds s to maxSpanStatusMsgLen bytes.
 func truncateStatusMsg(s string) string {
+	return truncateStatusMsgTo(s, maxSpanStatusMsgLen)
+}
+
+// truncateStatusMsgTo repairs invalid UTF-8 and bounds s to n bytes,
+// ellipsis included, cutting on a rune boundary. Both steps matter: an
+// invalid-UTF-8 status fails proto marshaling of the entire OTLP batch,
+// silently dropping every span in it, and the source text (a wrapped
+// command error, a transcript payload) can be invalid at any length.
+func truncateStatusMsgTo(s string, n int) string {
 	s = strings.ToValidUTF8(s, "")
-	if len(s) <= maxSpanStatusMsgLen {
+	if len(s) <= n {
 		return s
 	}
-	truncated := s[:maxSpanStatusMsgLen]
+	if n < len(statusEllipsis) {
+		return ""
+	}
+	truncated := s[:n-len(statusEllipsis)]
 	for len(truncated) > 0 && !utf8.Valid([]byte(truncated)) {
 		truncated = truncated[:len(truncated)-1]
 	}
-	return truncated + "…"
+	return truncated + statusEllipsis
 }
 
 // finalizeAgentSpan records the end-of-iteration attributes and status on an
@@ -2484,7 +2498,10 @@ func agentSpanStatus(runErr error, exitCode int, transcriptErr string) (codes.Co
 	case runErr != nil:
 		return codes.Error, truncateStatusMsg(runErr.Error())
 	case transcriptErr != "":
-		return codes.Error, truncateStatusMsg("transcript error: " + transcriptErr)
+		// Budget the payload so the prefixed total stays within the cap;
+		// a message short enough to fit is not re-truncated.
+		const prefix = "transcript error: "
+		return codes.Error, prefix + truncateStatusMsgTo(transcriptErr, maxSpanStatusMsgLen-len(prefix))
 	case exitCode != 0:
 		return codes.Error, fmt.Sprintf("agent exited with code %d", exitCode)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1553,9 +1553,12 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 				// ErrorMessage can be empty (the transcript result field is
 				// omitempty); substitute the emitTranscriptErrors fallback so
 				// the span status never reads Ok for a transcript failure.
-				transcriptErrMsg = te.ErrorMessage
+				// Both fields are agent-controlled and reach a new export
+				// sink here, so they get the same sanitization the GHA
+				// annotation path applies.
+				transcriptErrMsg = agentruntime.SanitizeOutput(te.ErrorMessage)
 				if transcriptErrMsg == "" {
-					transcriptErrMsg = fmt.Sprintf("agent terminated with error (subtype: %s)", te.Subtype)
+					transcriptErrMsg = fmt.Sprintf("agent terminated with error (subtype: %s)", agentruntime.SanitizeOutput(te.Subtype))
 				}
 			}
 		}
@@ -2418,11 +2421,14 @@ func telemetryExitCode(lastExitCode int, runErr error) int {
 // message cannot bloat every export of the span.
 const maxSpanStatusMsgLen = 256
 
-// truncateStatusMsg trims a status description to maxSpanStatusMsgLen. If
-// truncated, walks back to a valid UTF-8 rune boundary before appending the
-// ellipsis — an invalid-UTF-8 status fails proto marshaling of the entire
-// OTLP batch, silently dropping every span in it.
+// truncateStatusMsg repairs invalid UTF-8 and trims a status description to
+// maxSpanStatusMsgLen, walking back to a rune boundary before appending the
+// ellipsis. Both steps matter: an invalid-UTF-8 status fails proto marshaling
+// of the entire OTLP batch, silently dropping every span in it, and the
+// source text (a wrapped command error, a transcript payload) can be invalid
+// at any length.
 func truncateStatusMsg(s string) string {
+	s = strings.ToValidUTF8(s, "")
 	if len(s) <= maxSpanStatusMsgLen {
 		return s
 	}
@@ -2439,8 +2445,13 @@ func truncateStatusMsg(s string) string {
 // the raw process exit and fullsend.transcript_error marks the override.
 func finalizeAgentSpan(span trace.Span, runErr error, iteration, exitCode int, system string, m *agentruntime.RunMetrics, transcriptErr string) {
 	span.SetAttributes(agentSpanEndAttrs(iteration, exitCode, system, m)...)
-	if runErr != nil {
+	switch {
+	case runErr != nil:
 		span.RecordError(runErr)
+	case transcriptErr != "":
+		// The status description is capped; this event carries the full
+		// text so a verbose API error payload survives export.
+		span.RecordError(errors.New(transcriptErr))
 	}
 	if transcriptErr != "" {
 		span.SetAttributes(attribute.Bool("fullsend.transcript_error", true))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2482,7 +2482,9 @@ func finalizeRootSpan(span trace.Span, runErr error, exitCode int, validationPas
 // span. On failure the create error — which embeds raw supervisor/
 // gateway/container logs — gets the same treatment as the agent and root
 // spans: the fuller bounded copy on the exception event, a tighter
-// valid-UTF-8 status description.
+// valid-UTF-8 status description. Log-bearing error text is "errors"
+// metadata under ADR 0050's levels, not Level 3 content — the same
+// excerpt rode this span's status unbounded before it was bounded here.
 func finalizeSandboxSpan(span trace.Span, err error) {
 	if err != nil {
 		recordSanitizedError(span, err)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2426,9 +2426,13 @@ func recordSanitizedError(span trace.Span, err error) {
 	span.RecordError(errors.New(strings.ToValidUTF8(err.Error(), "")))
 }
 
-// maxSpanStatusMsgLen caps status descriptions so a runaway transcript error
-// message cannot bloat every export of the span.
-const maxSpanStatusMsgLen = 256
+// maxSpanStatusMsgLen caps status descriptions so a runaway error message
+// cannot bloat every export of the span. No OTel, collector, or backend
+// limit mandates a specific value; 2000 matches maxTranscriptErrorLength
+// (internal/runtime/claude_transcript.go), which bounds the same class of
+// consumer-facing error text — so a parse-time-truncated transcript message
+// is never truncated a second time here.
+const maxSpanStatusMsgLen = 2000
 
 // truncateStatusMsg repairs invalid UTF-8 and trims a status description to
 // maxSpanStatusMsgLen, walking back to a rune boundary before appending the

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -491,6 +491,14 @@ func TestTruncateStatusMsg(t *testing.T) {
 	got = truncateStatusMsg(straddle)
 	assert.True(t, utf8.ValidString(got), "truncation must land on a rune boundary")
 	assert.True(t, strings.HasSuffix(got, "…"))
+
+	// Invalid UTF-8 must be repaired at any length — a short malformed
+	// message never reaches the exporter untouched.
+	short := "bad\xff\xfebytes"
+	require.False(t, utf8.ValidString(short))
+	got = truncateStatusMsg(short)
+	assert.True(t, utf8.ValidString(got), "short strings are validated too")
+	assert.Equal(t, "badbytes", got)
 }
 
 // TestFinalizeAgentSpan pins the finalized agent span as exported (#5361):
@@ -523,6 +531,22 @@ func TestFinalizeAgentSpan(t *testing.T) {
 		attrs := attrsOf(s)
 		assert.Equal(t, int64(0), attrs["exit_code"].AsInt64(), "exit_code stays the raw process exit")
 		assert.True(t, attrs["fullsend.transcript_error"].AsBool())
+	})
+
+	t.Run("transcript error records full text as an event", func(t *testing.T) {
+		long := "API Error: " + strings.Repeat("payload ", 60)
+		s := newRecorded(nil, 0, long)
+		require.Greater(t, len(long), maxSpanStatusMsgLen, "fixture must exceed the status cap")
+		assert.Less(t, len(s.Status.Description), len(long), "status description is capped")
+		var found string
+		for _, e := range s.Events {
+			for _, kv := range e.Attributes {
+				if kv.Key == "exception.message" {
+					found = kv.Value.AsString()
+				}
+			}
+		}
+		assert.Equal(t, long, found, "the event carries the untruncated message")
 	})
 
 	t.Run("runtime error records exception event", func(t *testing.T) {

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -481,16 +481,18 @@ func TestTruncateStatusMsg(t *testing.T) {
 
 	long := strings.Repeat("x", maxSpanStatusMsgLen+50)
 	got := truncateStatusMsg(long)
-	assert.LessOrEqual(t, len(got), maxSpanStatusMsgLen+len("…"), "capped at limit plus ellipsis")
+	assert.LessOrEqual(t, len(got), maxSpanStatusMsgLen, "cap includes the ellipsis")
 	assert.True(t, strings.HasSuffix(got, "…"))
 	assert.True(t, utf8.ValidString(got))
 
-	// A multi-byte rune straddling the cap must not be split: invalid UTF-8
-	// in a status description fails proto marshaling of the whole OTLP batch.
-	straddle := strings.Repeat("x", maxSpanStatusMsgLen-1) + "é" + strings.Repeat("y", 50)
+	// A multi-byte rune straddling the cut point (cap minus ellipsis) must
+	// not be split: invalid UTF-8 in a status description fails proto
+	// marshaling of the whole OTLP batch.
+	straddle := strings.Repeat("x", maxSpanStatusMsgLen-len(statusEllipsis)-1) + "é" + strings.Repeat("y", 50)
 	got = truncateStatusMsg(straddle)
 	assert.True(t, utf8.ValidString(got), "truncation must land on a rune boundary")
 	assert.True(t, strings.HasSuffix(got, "…"))
+	assert.LessOrEqual(t, len(got), maxSpanStatusMsgLen)
 
 	// Invalid UTF-8 must be repaired at any length — a short malformed
 	// message never reaches the exporter untouched.
@@ -499,6 +501,30 @@ func TestTruncateStatusMsg(t *testing.T) {
 	got = truncateStatusMsg(short)
 	assert.True(t, utf8.ValidString(got), "short strings are validated too")
 	assert.Equal(t, "badbytes", got)
+}
+
+// TestAgentSpanStatus_TranscriptBoundary pins the transcript-status budget:
+// the prefixed total never exceeds maxSpanStatusMsgLen, and a message that
+// fits within the prefix headroom passes through untouched.
+func TestAgentSpanStatus_TranscriptBoundary(t *testing.T) {
+	const prefix = "transcript error: "
+
+	// Exactly at the headroom: no truncation at all.
+	fits := strings.Repeat("a", maxSpanStatusMsgLen-len(prefix))
+	_, msg := agentSpanStatus(nil, 0, fits)
+	assert.Equal(t, prefix+fits, msg, "message within headroom is untouched")
+	assert.Equal(t, maxSpanStatusMsgLen, len(msg))
+
+	// Worst case from the transcript parser: truncateError emits up to
+	// maxTranscriptErrorLength bytes plus its own "… (truncated)" suffix.
+	// The prefixed status must still respect the cap, keep valid UTF-8,
+	// and end with the status ellipsis.
+	parserMax := strings.Repeat("b", 2000) + "… (truncated)"
+	_, msg = agentSpanStatus(nil, 0, parserMax)
+	assert.LessOrEqual(t, len(msg), maxSpanStatusMsgLen, "prefixed total stays within the cap")
+	assert.True(t, utf8.ValidString(msg))
+	assert.True(t, strings.HasPrefix(msg, prefix))
+	assert.True(t, strings.HasSuffix(msg, statusEllipsis))
 }
 
 // TestFinalizeAgentSpan pins the finalized agent span as exported (#5361):

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -824,10 +824,11 @@ func TestTranscriptErrorMessage(t *testing.T) {
 	assert.LessOrEqual(t, len(got), maxSpanEventMsgLen)
 
 	// Parser worst case survives sanitization growth whole: 2,000 bytes of
-	// colons grow to 3,000 when "::" is broken, plus the parser suffix —
-	// still inside the bound, so nothing is re-truncated.
+	// colons grow to 3,999 when every adjacent pair is broken to the fixed
+	// point, plus the parser suffix — still inside the bound, so nothing
+	// is re-truncated.
 	worst := strings.Repeat(":", 2000) + "… (truncated)"
 	got = transcriptErrorMessage(agentruntime.TranscriptError{ErrorMessage: worst})
-	assert.Equal(t, strings.Repeat(": :", 1000)+"… (truncated)", got,
+	assert.Equal(t, strings.Repeat(": ", 1999)+":"+"… (truncated)", got,
 		"worst-case sanitized growth stays whole")
 }

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -559,10 +560,11 @@ func TestFinalizeAgentSpan(t *testing.T) {
 		assert.True(t, attrs["fullsend.transcript_error"].AsBool())
 	})
 
-	t.Run("transcript error records full text as an event", func(t *testing.T) {
+	t.Run("in-bound transcript error is untouched on the event", func(t *testing.T) {
 		long := "API Error: " + strings.Repeat("payload ", 300)
 		s := newRecorded(nil, 0, long)
 		require.Greater(t, len(long), maxSpanStatusMsgLen, "fixture must exceed the status cap")
+		require.LessOrEqual(t, len(long), maxSpanEventMsgLen, "fixture must fit the event bound, like any parser-truncated transcript message")
 		assert.Less(t, len(s.Status.Description), len(long), "status description is capped")
 		var found string
 		for _, e := range s.Events {
@@ -572,7 +574,7 @@ func TestFinalizeAgentSpan(t *testing.T) {
 				}
 			}
 		}
-		assert.Equal(t, long, found, "the event carries the untruncated message")
+		assert.Equal(t, long, found, "a message within the event bound is untouched")
 	})
 
 	t.Run("runtime error records exception event", func(t *testing.T) {
@@ -610,4 +612,98 @@ func TestFinalizeAgentSpan(t *testing.T) {
 		assert.Equal(t, codes.Error, s.Status.Code)
 		assert.Equal(t, "agent exited with code 1", s.Status.Description)
 	})
+}
+
+// TestRecordSanitizedError pins the exception-event contract: the message is
+// repaired to valid UTF-8 and bounded to maxSpanEventMsgLen. The SDK applies
+// no length limit of its own to event attributes, and a sandbox-create error
+// embeds raw supervisor/gateway/container logs of arbitrary size.
+func TestRecordSanitizedError(t *testing.T) {
+	record := func(err error) tracetest.SpanStub {
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		_, span := tp.Tracer("test").Start(context.Background(), "op")
+		recordSanitizedError(span, err)
+		span.End()
+		ended := rec.Ended()
+		require.Len(t, ended, 1)
+		return tracetest.SpanStubFromReadOnlySpan(ended[0])
+	}
+	exceptionMessage := func(s tracetest.SpanStub) string {
+		for _, e := range s.Events {
+			for _, kv := range e.Attributes {
+				if kv.Key == "exception.message" {
+					return kv.Value.AsString()
+				}
+			}
+		}
+		return ""
+	}
+
+	t.Run("oversized message is bounded", func(t *testing.T) {
+		huge := fmt.Errorf("sandbox create failed: %s", strings.Repeat("image pull log line\n", 4096))
+		msg := exceptionMessage(record(huge))
+		assert.LessOrEqual(t, len(msg), maxSpanEventMsgLen, "event message must not exceed the bound")
+		assert.True(t, utf8.ValidString(msg))
+		assert.True(t, strings.HasSuffix(msg, statusEllipsis))
+		assert.True(t, strings.HasPrefix(msg, "sandbox create failed:"))
+	})
+
+	t.Run("parser-truncated transcript message stays whole", func(t *testing.T) {
+		// truncateError emits at most maxTranscriptErrorLength bytes plus
+		// its "… (truncated)" suffix; the event bound keeps that whole.
+		parserMax := strings.Repeat("b", 2000) + "… (truncated)"
+		msg := exceptionMessage(record(errors.New(parserMax)))
+		assert.Equal(t, parserMax, msg)
+	})
+
+	t.Run("invalid UTF-8 is repaired at any length", func(t *testing.T) {
+		msg := exceptionMessage(record(fmt.Errorf("cmd failed: %s", "\xff\xferaw")))
+		assert.True(t, utf8.ValidString(msg))
+		assert.Contains(t, msg, "raw")
+	})
+
+	t.Run("multi-byte rune straddling the event cut stays valid", func(t *testing.T) {
+		straddle := strings.Repeat("x", maxSpanEventMsgLen-len(statusEllipsis)-1) + "é" + strings.Repeat("y", 50)
+		msg := exceptionMessage(record(errors.New(straddle)))
+		assert.True(t, utf8.ValidString(msg), "truncation must land on a rune boundary")
+		assert.LessOrEqual(t, len(msg), maxSpanEventMsgLen)
+		assert.True(t, strings.HasSuffix(msg, statusEllipsis))
+	})
+}
+
+// TestTranscriptErrorMessage pins the transcript-reported failure message
+// (#2786): sanitized and bounded, because the one string reaches the
+// console line and the span sinks — an embedded newline would otherwise
+// let a ::workflow-command:: start a line in the CI job log, and Subtype,
+// unlike ErrorMessage, is not truncated by the transcript parser.
+func TestTranscriptErrorMessage(t *testing.T) {
+	// Exact pins: ANSI escapes stripped, "::" broken, newline flattened.
+	got := transcriptErrorMessage(agentruntime.TranscriptError{
+		ErrorMessage: "API Error\n::error::forged\x1b[31mred",
+	})
+	assert.Equal(t, "API Error : :error: :forgedred", got)
+
+	got = transcriptErrorMessage(agentruntime.TranscriptError{Subtype: "error_during_execution"})
+	assert.Equal(t, "agent terminated with error (subtype: error_during_execution)", got,
+		"empty message falls back to the sanitized subtype")
+
+	got = transcriptErrorMessage(agentruntime.TranscriptError{Subtype: "x::y\n"})
+	assert.Equal(t, "agent terminated with error (subtype: x: :y )", got)
+
+	// An agent-written result line can carry a Subtype up to the 1MB
+	// transcript line size; the bound here is what keeps it out of the
+	// console line and the span sinks.
+	got = transcriptErrorMessage(agentruntime.TranscriptError{Subtype: strings.Repeat("s", 1<<20)})
+	assert.LessOrEqual(t, len(got), maxSpanEventMsgLen, "message is bounded")
+	assert.True(t, utf8.ValidString(got))
+	assert.True(t, strings.HasSuffix(got, statusEllipsis))
+
+	// Parser worst case survives sanitization growth whole: 2,000 bytes of
+	// colons grow to 3,000 when "::" is broken, plus the parser suffix —
+	// still inside the bound, so nothing is re-truncated.
+	worst := strings.Repeat(":", 2000) + "… (truncated)"
+	got = transcriptErrorMessage(agentruntime.TranscriptError{ErrorMessage: worst})
+	assert.Equal(t, strings.Repeat(": :", 1000)+"… (truncated)", got,
+		"worst-case sanitized growth stays whole")
 }

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -692,12 +692,12 @@ func TestTranscriptErrorMessage(t *testing.T) {
 	assert.Equal(t, "agent terminated with error (subtype: x: :y )", got)
 
 	// An agent-written result line can carry a Subtype up to the 1MB
-	// transcript line size; the bound here is what keeps it out of the
-	// console line and the span sinks.
+	// transcript line size; DisplayMessage bounds the fallback at the
+	// source, so the console line and the span sinks all stay small.
 	got = transcriptErrorMessage(agentruntime.TranscriptError{Subtype: strings.Repeat("s", 1<<20)})
-	assert.LessOrEqual(t, len(got), maxSpanEventMsgLen, "message is bounded")
-	assert.True(t, utf8.ValidString(got))
-	assert.True(t, strings.HasSuffix(got, statusEllipsis))
+	assert.Equal(t, "agent terminated with error (subtype: "+strings.Repeat("s", 2000)+"… (truncated))", got,
+		"huge subtype is bounded at the source")
+	assert.LessOrEqual(t, len(got), maxSpanEventMsgLen)
 
 	// Parser worst case survives sanitization growth whole: 2,000 bytes of
 	// colons grow to 3,000 when "::" is broken, plus the parser suffix —

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -532,6 +532,7 @@ func TestAgentSpanStatus_TranscriptBoundary(t *testing.T) {
 // status, the fullsend.transcript_error marker, the raw exit_code, and the
 // exception event on the runtime-error path.
 func TestFinalizeAgentSpan(t *testing.T) {
+	pinSpanLimitEnv(t)
 	newRecorded := func(runErr error, exitCode int, transcriptErr string) tracetest.SpanStub {
 		rec := tracetest.NewSpanRecorder()
 		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
@@ -614,11 +615,134 @@ func TestFinalizeAgentSpan(t *testing.T) {
 	})
 }
 
+// pinSpanLimitEnv clears the OTEL span-limit variables so recorder tests
+// are hermetic — an ambient OTEL_SPAN_EVENT_COUNT_LIMIT=0 on a CI runner
+// would drop the exception events these tests assert on.
+func pinSpanLimitEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+		"OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT",
+		"OTEL_SPAN_EVENT_COUNT_LIMIT",
+		"OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// TestFinalizeRootSpan pins the root span's finalization the same way the
+// agent and sandbox spans are pinned: the exception event only on the
+// runtime-error path, the rootSpanStatus mapping on the wire, and the
+// span ended exactly once.
+func TestFinalizeRootSpan(t *testing.T) {
+	pinSpanLimitEnv(t)
+	newRecorded := func(runErr error, exitCode int, validationPassed bool) tracetest.SpanStub {
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		_, span := tp.Tracer("test").Start(context.Background(), "run")
+		finalizeRootSpan(span, runErr, exitCode, validationPassed)
+		ended := rec.Ended()
+		require.Len(t, ended, 1, "span must be ended exactly once")
+		return tracetest.SpanStubFromReadOnlySpan(ended[0])
+	}
+	eventNames := func(s tracetest.SpanStub) []string {
+		var names []string
+		for _, e := range s.Events {
+			names = append(names, e.Name)
+		}
+		return names
+	}
+
+	t.Run("run error records bounded repaired exception", func(t *testing.T) {
+		err := fmt.Errorf("creating sandbox: sandbox create failed: %s\xff", strings.Repeat("log\n", 4096))
+		require.Greater(t, len(err.Error()), maxSpanEventMsgLen, "fixture must exceed both caps")
+		s := newRecorded(err, 1, false)
+		assert.Equal(t, codes.Error, s.Status.Code)
+		assert.LessOrEqual(t, len(s.Status.Description), maxSpanStatusMsgLen)
+		assert.True(t, utf8.ValidString(s.Status.Description))
+		assert.Contains(t, eventNames(s), "exception")
+		for _, e := range s.Events {
+			for _, kv := range e.Attributes {
+				if kv.Key == "exception.message" {
+					assert.LessOrEqual(t, len(kv.Value.AsString()), maxSpanEventMsgLen)
+					assert.True(t, utf8.ValidString(kv.Value.AsString()))
+				}
+			}
+		}
+	})
+
+	t.Run("validation passed is Ok despite non-zero exit", func(t *testing.T) {
+		s := newRecorded(nil, 1, true)
+		assert.Equal(t, codes.Ok, s.Status.Code)
+		assert.Empty(t, s.Events, "no exception event without a runtime error")
+	})
+
+	t.Run("failed agent without validation loop is Error, status only", func(t *testing.T) {
+		s := newRecorded(nil, 1, false)
+		assert.Equal(t, codes.Error, s.Status.Code)
+		assert.Equal(t, "run finished with exit code 1", s.Status.Description)
+		assert.Empty(t, s.Events, "exit-code failures carry no exception event")
+	})
+
+	t.Run("green run", func(t *testing.T) {
+		s := newRecorded(nil, 0, false)
+		assert.Equal(t, codes.Ok, s.Status.Code)
+	})
+}
+
+// TestFinalizeSandboxSpan pins the sandbox-create span the same way
+// TestFinalizeAgentSpan pins the agent span: the create error — raw
+// supervisor/gateway/container logs, arbitrary size, possibly invalid
+// UTF-8 — gets the bounded exception event and the tighter bounded
+// status, and the span ends exactly once.
+func TestFinalizeSandboxSpan(t *testing.T) {
+	pinSpanLimitEnv(t)
+	newRecorded := func(err error) tracetest.SpanStub {
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		_, span := tp.Tracer("test").Start(context.Background(), "sandbox_create")
+		finalizeSandboxSpan(span, err)
+		ended := rec.Ended()
+		require.Len(t, ended, 1, "span must be ended exactly once")
+		return tracetest.SpanStubFromReadOnlySpan(ended[0])
+	}
+
+	t.Run("create failure with oversized invalid-UTF-8 logs", func(t *testing.T) {
+		logs := "\xff\xfepull: " + strings.Repeat("layer abc123 downloading\n", 4096)
+		err := fmt.Errorf("sandbox create failed: %s", logs)
+		require.Greater(t, len(err.Error()), maxSpanEventMsgLen, "fixture must exceed both caps")
+		s := newRecorded(err)
+		assert.Equal(t, codes.Error, s.Status.Code)
+		assert.LessOrEqual(t, len(s.Status.Description), maxSpanStatusMsgLen, "status is bounded")
+		assert.True(t, utf8.ValidString(s.Status.Description), "status is repaired UTF-8")
+		assert.True(t, strings.HasPrefix(s.Status.Description, "sandbox create failed:"))
+		var msg string
+		for _, e := range s.Events {
+			for _, kv := range e.Attributes {
+				if kv.Key == "exception.message" {
+					msg = kv.Value.AsString()
+				}
+			}
+		}
+		require.NotEmpty(t, msg, "create failure must record an exception event")
+		assert.LessOrEqual(t, len(msg), maxSpanEventMsgLen, "event carries the fuller bounded copy")
+		assert.True(t, utf8.ValidString(msg))
+	})
+
+	t.Run("create success", func(t *testing.T) {
+		s := newRecorded(nil)
+		assert.Equal(t, codes.Ok, s.Status.Code)
+		assert.Empty(t, s.Events, "no exception event on success")
+	})
+}
+
 // TestRecordSanitizedError pins the exception-event contract: the message is
 // repaired to valid UTF-8 and bounded to maxSpanEventMsgLen. The SDK applies
 // no length limit of its own to event attributes, and a sandbox-create error
 // embeds raw supervisor/gateway/container logs of arbitrary size.
 func TestRecordSanitizedError(t *testing.T) {
+	pinSpanLimitEnv(t)
 	record := func(err error) tracetest.SpanStub {
 		rec := tracetest.NewSpanRecorder()
 		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -608,6 +608,23 @@ func TestFinalizeAgentSpan(t *testing.T) {
 		assert.False(t, hasMarker, "no transcript marker on clean iterations")
 	})
 
+	t.Run("invalid UTF-8 in the model attribute is repaired", func(t *testing.T) {
+		// The SDK's attribute limit repairs UTF-8 only when it truncates;
+		// an under-limit invalid value would fail proto marshaling of the
+		// whole OTLP batch, so free-text attributes repair at the source.
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		_, span := tp.Tracer("test").Start(context.Background(), "agent")
+		m := &agentruntime.RunMetrics{Model: "claude-\xff\xfeopus"}
+		finalizeAgentSpan(span, nil, 1, 0, "gcp.vertex_ai", m, "")
+		ended := rec.Ended()
+		require.Len(t, ended, 1)
+		s := tracetest.SpanStubFromReadOnlySpan(ended[0])
+		model := attrsOf(s)["gen_ai.request.model"].AsString()
+		assert.True(t, utf8.ValidString(model), "model attribute must be valid UTF-8")
+		assert.Contains(t, model, "opus")
+	})
+
 	t.Run("non-zero exit", func(t *testing.T) {
 		s := newRecorded(nil, 1, "")
 		assert.Equal(t, codes.Error, s.Status.Code)
@@ -735,6 +752,19 @@ func TestFinalizeSandboxSpan(t *testing.T) {
 		assert.Equal(t, codes.Ok, s.Status.Code)
 		assert.Empty(t, s.Events, "no exception event on success")
 	})
+}
+
+// TestStringAttr pins the free-text attribute guard: values are repaired
+// to valid UTF-8 at the source, because the SDK's attribute limit leaves
+// under-limit values untouched and one invalid byte fails proto marshal
+// of the whole OTLP batch.
+func TestStringAttr(t *testing.T) {
+	kv := stringAttr("k", "bad\xff\xfebytes")
+	assert.True(t, utf8.ValidString(kv.Value.AsString()))
+	assert.Equal(t, "badbytes", kv.Value.AsString())
+
+	kv = stringAttr("k", "clean value")
+	assert.Equal(t, "clean value", kv.Value.AsString(), "valid values pass through unchanged")
 }
 
 // TestRecordSanitizedError pins the exception-event contract: the message is

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 
 	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
@@ -406,4 +409,142 @@ func TestResolveTraceIdentity_MalformedInput(t *testing.T) {
 			assert.NotEmpty(t, tid.Traceparent, "must produce a traceparent")
 		})
 	}
+}
+
+// TestAgentSpanStatus pins the iteration-outcome → span-status mapping
+// (#5361): a runtime error, a transcript-reported error (#2786), or a
+// non-zero exit is Error — a failed iteration is never exported as Ok.
+func TestAgentSpanStatus(t *testing.T) {
+	cases := []struct {
+		name          string
+		runErr        error
+		exitCode      int
+		transcriptErr string
+		wantCode      codes.Code
+		wantMsgSubstr string
+	}{
+		{"green run", nil, 0, "", codes.Ok, ""},
+		{"runtime error", fmt.Errorf("sandbox exploded"), -1, "", codes.Error, "sandbox exploded"},
+		{"transcript error with exit 0", nil, 0, "API Error: invalid_grant", codes.Error, "transcript error: API Error: invalid_grant"},
+		{"non-zero exit", nil, 1, "", codes.Error, "agent exited with code 1"},
+		{"infra exit -1", nil, -1, "", codes.Error, "agent exited with code -1"},
+		{"runtime error wins over transcript", fmt.Errorf("boom"), 0, "also failed", codes.Error, "boom"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, msg := agentSpanStatus(tc.runErr, tc.exitCode, tc.transcriptErr)
+			assert.Equal(t, tc.wantCode, code)
+			if tc.wantMsgSubstr == "" {
+				assert.Empty(t, msg)
+			} else {
+				assert.Contains(t, msg, tc.wantMsgSubstr)
+			}
+		})
+	}
+}
+
+// TestRootSpanStatus pins the run-outcome → root-span-status mapping (#5361).
+// exitCode is the telemetryExitCode result, so the "no validation loop,
+// agent failed, runErr nil" case must still report Error.
+func TestRootSpanStatus(t *testing.T) {
+	cases := []struct {
+		name             string
+		runErr           error
+		exitCode         int
+		validationPassed bool
+		wantCode         codes.Code
+		wantMsgSubstr    string
+	}{
+		{"green run", nil, 0, false, codes.Ok, ""},
+		{"run error", fmt.Errorf("validation failed after 2 iteration(s)"), 1, false, codes.Error, "validation failed"},
+		{"failed agent without validation loop", nil, 1, false, codes.Error, "run finished with exit code 1"},
+		{"infra exit preserved", nil, -1, false, codes.Error, "run finished with exit code -1"},
+		{"validation passed, last agent exit non-zero", nil, 1, true, codes.Ok, ""},
+		{"validation passed, transcript override earlier", nil, 1, true, codes.Ok, ""},
+		{"run error wins over validation pass", fmt.Errorf("post-script failed"), 0, true, codes.Error, "post-script failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, msg := rootSpanStatus(tc.runErr, tc.exitCode, tc.validationPassed)
+			assert.Equal(t, tc.wantCode, code)
+			if tc.wantMsgSubstr == "" {
+				assert.Empty(t, msg)
+			} else {
+				assert.Contains(t, msg, tc.wantMsgSubstr)
+			}
+		})
+	}
+}
+
+func TestTruncateStatusMsg(t *testing.T) {
+	assert.Equal(t, "short", truncateStatusMsg("short"))
+
+	long := strings.Repeat("x", maxSpanStatusMsgLen+50)
+	got := truncateStatusMsg(long)
+	assert.LessOrEqual(t, len(got), maxSpanStatusMsgLen+len("…"), "capped at limit plus ellipsis")
+	assert.True(t, strings.HasSuffix(got, "…"))
+	assert.True(t, utf8.ValidString(got))
+
+	// A multi-byte rune straddling the cap must not be split: invalid UTF-8
+	// in a status description fails proto marshaling of the whole OTLP batch.
+	straddle := strings.Repeat("x", maxSpanStatusMsgLen-1) + "é" + strings.Repeat("y", 50)
+	got = truncateStatusMsg(straddle)
+	assert.True(t, utf8.ValidString(got), "truncation must land on a rune boundary")
+	assert.True(t, strings.HasSuffix(got, "…"))
+}
+
+// TestFinalizeAgentSpan pins the finalized agent span as exported (#5361):
+// status, the fullsend.transcript_error marker, the raw exit_code, and the
+// exception event on the runtime-error path.
+func TestFinalizeAgentSpan(t *testing.T) {
+	newRecorded := func(runErr error, exitCode int, transcriptErr string) tracetest.SpanStub {
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		_, span := tp.Tracer("test").Start(context.Background(), "agent")
+		m := &agentruntime.RunMetrics{Model: "claude-opus-4-6"}
+		finalizeAgentSpan(span, runErr, 1, exitCode, "gcp.vertex_ai", m, transcriptErr)
+		ended := rec.Ended()
+		require.Len(t, ended, 1, "span must be ended exactly once")
+		return tracetest.SpanStubFromReadOnlySpan(ended[0])
+	}
+
+	attrsOf := func(s tracetest.SpanStub) map[attribute.Key]attribute.Value {
+		out := map[attribute.Key]attribute.Value{}
+		for _, kv := range s.Attributes {
+			out[kv.Key] = kv.Value
+		}
+		return out
+	}
+
+	t.Run("transcript error with exit 0", func(t *testing.T) {
+		s := newRecorded(nil, 0, "API Error: invalid_grant")
+		assert.Equal(t, codes.Error, s.Status.Code)
+		assert.Contains(t, s.Status.Description, "transcript error: API Error: invalid_grant")
+		attrs := attrsOf(s)
+		assert.Equal(t, int64(0), attrs["exit_code"].AsInt64(), "exit_code stays the raw process exit")
+		assert.True(t, attrs["fullsend.transcript_error"].AsBool())
+	})
+
+	t.Run("runtime error records exception event", func(t *testing.T) {
+		s := newRecorded(fmt.Errorf("sandbox exploded"), -1, "")
+		assert.Equal(t, codes.Error, s.Status.Code)
+		var eventNames []string
+		for _, e := range s.Events {
+			eventNames = append(eventNames, e.Name)
+		}
+		assert.Contains(t, eventNames, "exception")
+	})
+
+	t.Run("green iteration", func(t *testing.T) {
+		s := newRecorded(nil, 0, "")
+		assert.Equal(t, codes.Ok, s.Status.Code)
+		_, hasMarker := attrsOf(s)["fullsend.transcript_error"]
+		assert.False(t, hasMarker, "no transcript marker on clean iterations")
+	})
+
+	t.Run("non-zero exit", func(t *testing.T) {
+		s := newRecorded(nil, 1, "")
+		assert.Equal(t, codes.Error, s.Status.Code)
+		assert.Equal(t, "agent exited with code 1", s.Status.Description)
+	})
 }

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -534,7 +534,7 @@ func TestFinalizeAgentSpan(t *testing.T) {
 	})
 
 	t.Run("transcript error records full text as an event", func(t *testing.T) {
-		long := "API Error: " + strings.Repeat("payload ", 60)
+		long := "API Error: " + strings.Repeat("payload ", 300)
 		s := newRecorded(nil, 0, long)
 		require.Greater(t, len(long), maxSpanStatusMsgLen, "fixture must exceed the status cap")
 		assert.Less(t, len(s.Status.Description), len(long), "status description is capped")

--- a/internal/cli/telemetry_run_test.go
+++ b/internal/cli/telemetry_run_test.go
@@ -559,6 +559,19 @@ func TestFinalizeAgentSpan(t *testing.T) {
 		assert.Contains(t, eventNames, "exception")
 	})
 
+	t.Run("invalid UTF-8 in runtime error is repaired on the event", func(t *testing.T) {
+		s := newRecorded(fmt.Errorf("cmd failed: %s", "\xff\xferaw"), -1, "")
+		for _, e := range s.Events {
+			for _, kv := range e.Attributes {
+				if kv.Key == "exception.message" {
+					assert.True(t, utf8.ValidString(kv.Value.AsString()),
+						"exception message must be valid UTF-8 — it rides the same proto marshal as status")
+					assert.Contains(t, kv.Value.AsString(), "raw")
+				}
+			}
+		}
+	})
+
 	t.Run("green iteration", func(t *testing.T) {
 		s := newRecorded(nil, 0, "")
 		assert.Equal(t, codes.Ok, s.Status.Code)

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -314,6 +314,24 @@ func TestSanitizeOutput(t *testing.T) {
 			want:  "Edit: /src/config: :default.go",
 		},
 		{
+			// A single non-overlapping ReplaceAll pass turns ":::" into
+			// ": ::" — the replacement seam reconstitutes a literal "::".
+			// Colon runs must break to a fixed point.
+			name:  "three-colon run",
+			input: ":::",
+			want:  ": : :",
+		},
+		{
+			name:  "four-colon run reconstitution guard",
+			input: "::::",
+			want:  ": : : :",
+		},
+		{
+			name:  "colon run around a workflow command",
+			input: "safe text\n::::error::injected annotation",
+			want:  "safe text : : : :error: :injected annotation",
+		},
+		{
 			name:  "url-encoded newline",
 			input: "Read%0A::error::pwned",
 			want:  "Read : :error: :pwned",
@@ -381,6 +399,36 @@ func TestSanitizeOutput(t *testing.T) {
 				t.Errorf("sanitizeOutput(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestSanitize_ColonBreakIsIdempotent pins the guard property itself: no
+// sanitized output contains "::", and sanitizing twice equals sanitizing
+// once — for both variants, across colon runs long enough to reconstitute
+// a pair at a ReplaceAll seam.
+func TestSanitize_ColonBreakIsIdempotent(t *testing.T) {
+	inputs := []string{
+		"::", ":::", "::::", ":::::", "::::::",
+		"a::::b\n::::::c",
+		strings.Repeat(":", 100),
+		"::::error::forged",
+	}
+	for _, variant := range []struct {
+		name string
+		fn   func(string) string
+	}{
+		{"sanitizeOutput", sanitizeOutput},
+		{"sanitizeStreamText", sanitizeStreamText},
+	} {
+		for _, in := range inputs {
+			once := variant.fn(in)
+			if strings.Contains(once, "::") {
+				t.Errorf("%s(%q) = %q still contains \"::\"", variant.name, in, once)
+			}
+			if twice := variant.fn(once); twice != once {
+				t.Errorf("%s not idempotent on %q: %q -> %q", variant.name, in, once, twice)
+			}
+		}
 	}
 }
 

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -287,19 +287,6 @@ func TestProgressParserOversizedLineSkipped(t *testing.T) {
 	}
 }
 
-// TestSanitizeOutput_ExportedWrapper pins that the exported wrapper applies
-// the same treatment as the internal one — telemetry span status and GHA
-// annotations must not diverge on agent-controlled text.
-func TestSanitizeOutput_ExportedWrapper(t *testing.T) {
-	in := "\x1b[31mred\x1b[0m ::set-output:: ctrl\x07char"
-	if got, want := SanitizeOutput(in), sanitizeOutput(in); got != want {
-		t.Fatalf("SanitizeOutput(%q) = %q, want %q", in, got, want)
-	}
-	if got := SanitizeOutput(in); strings.Contains(got, "\x1b") || strings.Contains(got, "::") {
-		t.Errorf("SanitizeOutput left escapes or GHA markers: %q", got)
-	}
-}
-
 func TestSanitizeOutput(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -287,6 +287,19 @@ func TestProgressParserOversizedLineSkipped(t *testing.T) {
 	}
 }
 
+// TestSanitizeOutput_ExportedWrapper pins that the exported wrapper applies
+// the same treatment as the internal one — telemetry span status and GHA
+// annotations must not diverge on agent-controlled text.
+func TestSanitizeOutput_ExportedWrapper(t *testing.T) {
+	in := "\x1b[31mred\x1b[0m ::set-output:: ctrl\x07char"
+	if got, want := SanitizeOutput(in), sanitizeOutput(in); got != want {
+		t.Fatalf("SanitizeOutput(%q) = %q, want %q", in, got, want)
+	}
+	if got := SanitizeOutput(in); strings.Contains(got, "\x1b") || strings.Contains(got, "::") {
+		t.Errorf("SanitizeOutput left escapes or GHA markers: %q", got)
+	}
+}
+
 func TestSanitizeOutput(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/runtime/claude_transcript.go
+++ b/internal/runtime/claude_transcript.go
@@ -131,11 +131,7 @@ func truncateError(msg string) string {
 // agent failures diagnosable without downloading artifacts.
 func emitTranscriptErrors(w io.Writer, summaries []TranscriptError) {
 	for _, s := range summaries {
-		// Sanitize the error message to prevent GHA command injection.
-		msg := sanitizeOutput(s.ErrorMessage)
-		if msg == "" {
-			msg = fmt.Sprintf("agent terminated with error (subtype: %s)", sanitizeOutput(s.Subtype))
-		}
-		fmt.Fprintf(w, "::error title=Agent Error (%s)::%s\n", sanitizeOutput(s.Source), msg)
+		// DisplayMessage sanitizes to prevent GHA command injection.
+		fmt.Fprintf(w, "::error title=Agent Error (%s)::%s\n", sanitizeOutput(s.Source), s.DisplayMessage())
 	}
 }

--- a/internal/runtime/claude_transcript_test.go
+++ b/internal/runtime/claude_transcript_test.go
@@ -246,6 +246,30 @@ func TestEmitTranscriptErrors_NoSummaries(t *testing.T) {
 	}
 }
 
+// TestTranscriptError_DisplayMessage pins the one rendering every sink
+// shares: sanitized ErrorMessage, or the sanitized subtype fallback when
+// it comes up empty.
+func TestTranscriptError_DisplayMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		te   TranscriptError
+		want string
+	}{
+		{"plain message", TranscriptError{ErrorMessage: "Agent reached maximum turns"}, "Agent reached maximum turns"},
+		{"injection is sanitized", TranscriptError{ErrorMessage: "API Error\n::error::forged\x1b[31mred"}, "API Error : :error: :forgedred"},
+		{"empty message falls back to subtype", TranscriptError{Subtype: "error_max_turns"}, "agent terminated with error (subtype: error_max_turns)"},
+		{"subtype is sanitized too", TranscriptError{Subtype: "x::y\n"}, "agent terminated with error (subtype: x: :y )"},
+		{"message that sanitizes to empty falls back", TranscriptError{ErrorMessage: "\x1b[31m", Subtype: "error_unknown"}, "agent terminated with error (subtype: error_unknown)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.te.DisplayMessage(); got != tc.want {
+				t.Errorf("DisplayMessage() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestParseTranscriptFile_APIErrorExitZero covers the scenario from #2786:
 // Claude Code exits 0 with is_error:true and subtype "success" on API errors
 // (e.g., invalid_grant from a stale OIDC token).

--- a/internal/runtime/claude_transcript_test.go
+++ b/internal/runtime/claude_transcript_test.go
@@ -260,6 +260,8 @@ func TestTranscriptError_DisplayMessage(t *testing.T) {
 		{"empty message falls back to subtype", TranscriptError{Subtype: "error_max_turns"}, "agent terminated with error (subtype: error_max_turns)"},
 		{"subtype is sanitized too", TranscriptError{Subtype: "x::y\n"}, "agent terminated with error (subtype: x: :y )"},
 		{"message that sanitizes to empty falls back", TranscriptError{ErrorMessage: "\x1b[31m", Subtype: "error_unknown"}, "agent terminated with error (subtype: error_unknown)"},
+		// A colon run must not reconstitute "::" at a replacement seam.
+		{"colon run stays broken", TranscriptError{ErrorMessage: "x::::y"}, "x: : : :y"},
 		// Subtype is not truncated at parse time the way ErrorMessage is,
 		// and a transcript line can be up to 1MB — the fallback bounds it
 		// with the same truncateError treatment.

--- a/internal/runtime/claude_transcript_test.go
+++ b/internal/runtime/claude_transcript_test.go
@@ -260,6 +260,11 @@ func TestTranscriptError_DisplayMessage(t *testing.T) {
 		{"empty message falls back to subtype", TranscriptError{Subtype: "error_max_turns"}, "agent terminated with error (subtype: error_max_turns)"},
 		{"subtype is sanitized too", TranscriptError{Subtype: "x::y\n"}, "agent terminated with error (subtype: x: :y )"},
 		{"message that sanitizes to empty falls back", TranscriptError{ErrorMessage: "\x1b[31m", Subtype: "error_unknown"}, "agent terminated with error (subtype: error_unknown)"},
+		// Subtype is not truncated at parse time the way ErrorMessage is,
+		// and a transcript line can be up to 1MB — the fallback bounds it
+		// with the same truncateError treatment.
+		{"huge subtype is bounded", TranscriptError{Subtype: strings.Repeat("s", 1<<20)},
+			"agent terminated with error (subtype: " + strings.Repeat("s", 2000) + "… (truncated))"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -40,6 +41,22 @@ type TranscriptError struct {
 	IsError      bool
 	ErrorMessage string
 	Subtype      string
+}
+
+// DisplayMessage returns the sanitized message for a transcript error:
+// ErrorMessage with ANSI escapes, control characters, and GHA workflow
+// command markers stripped, or the subtype fallback when it sanitizes to
+// empty (both fields are omitempty in the transcript). Every sink that
+// renders a transcript error — GHA annotations, the CLI console, span
+// status and events — goes through this one method so the treatments
+// agree. Callers with a size-bounded sink truncate the result themselves;
+// ErrorMessage is parser-truncated but Subtype is not.
+func (te TranscriptError) DisplayMessage() string {
+	msg := sanitizeOutput(te.ErrorMessage)
+	if msg == "" {
+		msg = fmt.Sprintf("agent terminated with error (subtype: %s)", sanitizeOutput(te.Subtype))
+	}
+	return msg
 }
 
 // Runtime is an agent execution backend (LLM tool-use loop) inside the sandbox.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -43,18 +43,19 @@ type TranscriptError struct {
 	Subtype      string
 }
 
-// DisplayMessage returns the sanitized message for a transcript error:
-// ErrorMessage with ANSI escapes, control characters, and GHA workflow
-// command markers stripped, or the subtype fallback when it sanitizes to
-// empty (both fields are omitempty in the transcript). Every sink that
-// renders a transcript error — GHA annotations, the CLI console, span
-// status and events — goes through this one method so the treatments
-// agree. Callers with a size-bounded sink truncate the result themselves;
-// ErrorMessage is parser-truncated but Subtype is not.
+// DisplayMessage returns the sanitized, bounded message for a transcript
+// error: ErrorMessage with ANSI escapes, control characters, and GHA
+// workflow command markers stripped, or the subtype fallback when it
+// sanitizes to empty (both fields are omitempty in the transcript).
+// ErrorMessage is truncated at parse time; Subtype is not, so the
+// fallback applies the same truncateError bound before sanitizing. Every
+// sink that renders a transcript error — GHA annotations, the CLI
+// console, span status and events — goes through this one method so the
+// treatments agree.
 func (te TranscriptError) DisplayMessage() string {
 	msg := sanitizeOutput(te.ErrorMessage)
 	if msg == "" {
-		msg = fmt.Sprintf("agent terminated with error (subtype: %s)", sanitizeOutput(te.Subtype))
+		msg = fmt.Sprintf("agent terminated with error (subtype: %s)", sanitizeOutput(truncateError(te.Subtype)))
 	}
 	return msg
 }

--- a/internal/runtime/sanitize.go
+++ b/internal/runtime/sanitize.go
@@ -8,6 +8,14 @@ import (
 // ansiEscRe matches ANSI CSI sequences, OSC sequences, and charset designators.
 var ansiEscRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][A-Z0-9]`)
 
+// SanitizeOutput strips ANSI escape sequences, control characters, and GHA
+// workflow command markers from untrusted sandbox output. Callers outside
+// this package need it wherever agent-controlled transcript text reaches a
+// new sink (telemetry span status, annotations, rendered output).
+func SanitizeOutput(s string) string {
+	return sanitizeOutput(s)
+}
+
 // sanitizeOutput strips ANSI escape sequences, control characters, and GHA
 // workflow command markers from untrusted sandbox output.
 func sanitizeOutput(s string) string {

--- a/internal/runtime/sanitize.go
+++ b/internal/runtime/sanitize.go
@@ -16,15 +16,24 @@ func sanitizeOutput(s string) string {
 }
 
 // sanitizeStreamText is like sanitizeOutput but preserves newlines for
-// streaming text/thinking deltas. GHA command injection is still blocked
-// because "::" is broken into ": :".
+// streaming text/thinking deltas. Within a single input, "::" is broken
+// into ": :"; a caller concatenating separately sanitized chunks owns the
+// chunk boundaries, where a trailing and a leading colon can still meet.
 func sanitizeStreamText(s string) string {
 	return sanitize(s, true)
 }
 
 func sanitize(s string, preserveNewlines bool) string {
 	s = ansiEscRe.ReplaceAllString(s, "")
-	s = strings.ReplaceAll(s, "::", ": :")
+	// A single non-overlapping ReplaceAll pass reconstitutes "::" at the
+	// seam of two replacements (":::" -> ": ::"), so break colon pairs to
+	// a fixed point: no output contains "::" and re-sanitizing is a no-op.
+	// At most two passes run: the first leaves no colon run longer than
+	// two (every seam pair sits between inserted spaces), and the second
+	// breaks those isolated pairs without creating new ones.
+	for strings.Contains(s, "::") {
+		s = strings.ReplaceAll(s, "::", ": :")
+	}
 	for _, enc := range []string{"%0A", "%0a", "%0D", "%0d"} {
 		s = strings.ReplaceAll(s, enc, " ")
 	}

--- a/internal/runtime/sanitize.go
+++ b/internal/runtime/sanitize.go
@@ -8,16 +8,9 @@ import (
 // ansiEscRe matches ANSI CSI sequences, OSC sequences, and charset designators.
 var ansiEscRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][A-Z0-9]`)
 
-// SanitizeOutput strips ANSI escape sequences, control characters, and GHA
-// workflow command markers from untrusted sandbox output. Callers outside
-// this package need it wherever agent-controlled transcript text reaches a
-// new sink (telemetry span status, annotations, rendered output).
-func SanitizeOutput(s string) string {
-	return sanitizeOutput(s)
-}
-
 // sanitizeOutput strips ANSI escape sequences, control characters, and GHA
-// workflow command markers from untrusted sandbox output.
+// workflow command markers from untrusted sandbox output. External sinks
+// consume it through TranscriptError.DisplayMessage.
 func sanitizeOutput(s string) string {
 	return sanitize(s, false)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -80,12 +80,16 @@ func validateEndpoints(endpoint, tracesEndpoint string) error {
 }
 
 // MaxSpanAttrValueLen bounds every span attribute value recorded through
-// this provider. The SDK applies the limit (with UTF-8-safe truncation)
-// to span attributes only — event messages are bounded at their call
-// site — and free-text attributes such as a transcript-derived model
-// name or a pre-script skip reason are otherwise unbounded. The
-// exception-event bound in internal/cli (maxSpanEventMsgLen) is defined
-// from this constant so the two cannot drift. It applies only when the
+// this provider. The SDK applies the limit to span attributes only —
+// event messages are bounded at their call site — counting characters,
+// not bytes (a multibyte value can reach four bytes per character on the
+// wire), and it repairs invalid UTF-8 only when it truncates: values at
+// or under the limit pass through unrepaired, so free-text attribute
+// values are repaired at their call sites (internal/cli stringAttr).
+// Both properties are pinned by TestAttrLimit_SDKBehaviorCanary. The
+// exception-event bound in internal/cli (maxSpanEventMsgLen, bytes) is
+// defined from this constant so the shared numeric default cannot drift,
+// each side applying it in its own unit. It applies only when the
 // SDK took no operator override — the first non-empty of
 // OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT and
 // OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT decides alone, and a parseable value

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -83,20 +84,38 @@ func validateEndpoints(endpoint, tracesEndpoint string) error {
 // to span attributes only — event messages are bounded at their call
 // site — and free-text attributes such as a transcript-derived model
 // name or a pre-script skip reason are otherwise unbounded. 8192 matches
-// the exception-event bound in internal/cli; an operator's
-// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT / OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
-// setting takes precedence.
+// the exception-event bound in internal/cli; it applies only when the
+// operator has not set OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT or
+// OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT — any parseable setting, including
+// -1 (unlimited), is honored as-is.
 const maxSpanAttrValueLen = 8192
 
-// spanLimits returns the SDK span limits (env vars included), with the
-// attribute value-length limit defaulted to maxSpanAttrValueLen when the
-// operator has not set one.
+// spanLimits returns the SDK span limits. NewSpanLimits collapses "env
+// unset" and an explicit "-1" (the OTel sentinel for unlimited) to the
+// same struct value, so the env vars are consulted directly: the
+// maxSpanAttrValueLen default applies only when the operator has not set
+// a parseable integer in either variable.
 func spanLimits() sdktrace.SpanLimits {
 	limits := sdktrace.NewSpanLimits()
-	if limits.AttributeValueLengthLimit < 0 {
+	if limits.AttributeValueLengthLimit < 0 && !attrValueLenConfigured() {
 		limits.AttributeValueLengthLimit = maxSpanAttrValueLen
 	}
 	return limits
+}
+
+// attrValueLenConfigured reports whether the operator set an attribute
+// value-length limit via the standard OTel env vars. Values are parsed
+// the way the SDK parses them (strconv.Atoi, no trimming), so a value
+// the SDK ignores is not treated as a setting here either.
+func attrValueLenConfigured() bool {
+	for _, key := range []string{"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT"} {
+		if v, ok := os.LookupEnv(key); ok {
+			if _, err := strconv.Atoi(v); err == nil {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Setup creates a TracerProvider with file and (optionally) OTLP exporters.

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -79,27 +79,28 @@ func validateEndpoints(endpoint, tracesEndpoint string) error {
 	return nil
 }
 
-// maxSpanAttrValueLen bounds every span attribute value recorded through
+// MaxSpanAttrValueLen bounds every span attribute value recorded through
 // this provider. The SDK applies the limit (with UTF-8-safe truncation)
 // to span attributes only — event messages are bounded at their call
 // site — and free-text attributes such as a transcript-derived model
-// name or a pre-script skip reason are otherwise unbounded. 8192 matches
-// the exception-event bound in internal/cli; it applies only when the SDK
-// took no operator override — the first non-empty of
+// name or a pre-script skip reason are otherwise unbounded. The
+// exception-event bound in internal/cli (maxSpanEventMsgLen) is defined
+// from this constant so the two cannot drift. It applies only when the
+// SDK took no operator override — the first non-empty of
 // OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT and
 // OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT decides alone, and a parseable value
 // there, including -1 (unlimited), is honored as-is.
-const maxSpanAttrValueLen = 8192
+const MaxSpanAttrValueLen = 8192
 
 // spanLimits returns the SDK span limits. NewSpanLimits collapses "env
 // unset" and an explicit "-1" (the OTel sentinel for unlimited) to the
 // same struct value, so the env vars are consulted directly: the
-// maxSpanAttrValueLen default applies only when the deciding variable —
+// MaxSpanAttrValueLen default applies only when the deciding variable —
 // the first non-empty one — holds no parseable integer.
 func spanLimits() sdktrace.SpanLimits {
 	limits := sdktrace.NewSpanLimits()
 	if limits.AttributeValueLengthLimit < 0 && !attrValueLenConfigured() {
-		limits.AttributeValueLengthLimit = maxSpanAttrValueLen
+		limits.AttributeValueLengthLimit = MaxSpanAttrValueLen
 	}
 	return limits
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -78,6 +78,27 @@ func validateEndpoints(endpoint, tracesEndpoint string) error {
 	return nil
 }
 
+// maxSpanAttrValueLen bounds every span attribute value recorded through
+// this provider. The SDK applies the limit (with UTF-8-safe truncation)
+// to span attributes only — event messages are bounded at their call
+// site — and free-text attributes such as a transcript-derived model
+// name or a pre-script skip reason are otherwise unbounded. 8192 matches
+// the exception-event bound in internal/cli; an operator's
+// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT / OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+// setting takes precedence.
+const maxSpanAttrValueLen = 8192
+
+// spanLimits returns the SDK span limits (env vars included), with the
+// attribute value-length limit defaulted to maxSpanAttrValueLen when the
+// operator has not set one.
+func spanLimits() sdktrace.SpanLimits {
+	limits := sdktrace.NewSpanLimits()
+	if limits.AttributeValueLengthLimit < 0 {
+		limits.AttributeValueLengthLimit = maxSpanAttrValueLen
+	}
+	return limits
+}
+
 // Setup creates a TracerProvider with file and (optionally) OTLP exporters.
 // On any failure it returns a noop tracer and an empty cleanup func so the
 // run is never affected. The cleanup func shuts down the provider (flushing
@@ -100,6 +121,7 @@ func Setup(dir string, serviceVersion string) (trace.Tracer, func(context.Contex
 	opts := []sdktrace.TracerProviderOption{
 		sdktrace.WithResource(res),
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithRawSpanLimits(spanLimits()),
 		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(newFileExporter(f))),
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -84,17 +84,18 @@ func validateEndpoints(endpoint, tracesEndpoint string) error {
 // to span attributes only — event messages are bounded at their call
 // site — and free-text attributes such as a transcript-derived model
 // name or a pre-script skip reason are otherwise unbounded. 8192 matches
-// the exception-event bound in internal/cli; it applies only when the
-// operator has not set OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT or
-// OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT — any parseable setting, including
-// -1 (unlimited), is honored as-is.
+// the exception-event bound in internal/cli; it applies only when the SDK
+// took no operator override — the first non-empty of
+// OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT and
+// OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT decides alone, and a parseable value
+// there, including -1 (unlimited), is honored as-is.
 const maxSpanAttrValueLen = 8192
 
 // spanLimits returns the SDK span limits. NewSpanLimits collapses "env
 // unset" and an explicit "-1" (the OTel sentinel for unlimited) to the
 // same struct value, so the env vars are consulted directly: the
-// maxSpanAttrValueLen default applies only when the operator has not set
-// a parseable integer in either variable.
+// maxSpanAttrValueLen default applies only when the deciding variable —
+// the first non-empty one — holds no parseable integer.
 func spanLimits() sdktrace.SpanLimits {
 	limits := sdktrace.NewSpanLimits()
 	if limits.AttributeValueLengthLimit < 0 && !attrValueLenConfigured() {
@@ -103,17 +104,20 @@ func spanLimits() sdktrace.SpanLimits {
 	return limits
 }
 
-// attrValueLenConfigured reports whether the operator set an attribute
-// value-length limit via the standard OTel env vars. Values are parsed
-// the way the SDK parses them (strconv.Atoi, no trimming), so a value
-// the SDK ignores is not treated as a setting here either.
+// attrValueLenConfigured reports whether the SDK honored an operator's
+// attribute value-length limit. It mirrors the SDK's firstInt resolution
+// exactly (sdk/trace/internal/env, v1.44.0): the first non-empty variable
+// decides alone — if its value fails strconv.Atoi, the SDK falls back to
+// its default without consulting the second variable, so a discarded
+// override is not a setting here either.
 func attrValueLenConfigured() bool {
 	for _, key := range []string{"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT"} {
-		if v, ok := os.LookupEnv(key); ok {
-			if _, err := strconv.Atoi(v); err == nil {
-				return true
-			}
+		v := os.Getenv(key)
+		if v == "" {
+			continue
 		}
+		_, err := strconv.Atoi(v)
+		return err == nil
 	}
 	return false
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -16,9 +16,11 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/protobuf/proto"
@@ -101,6 +103,50 @@ func TestSetup_SpanAttributeValueLengthLimit(t *testing.T) {
 	}
 	require.NotEmpty(t, got, "test attribute must be exported")
 	assert.Len(t, got, MaxSpanAttrValueLen, "attribute value must be truncated to the provider limit")
+}
+
+// TestAttrLimit_SDKBehaviorCanary pins two SDK properties this package's
+// callers depend on, so an SDK upgrade that changes either fails here
+// instead of silently shifting the export contract: (1) the attribute
+// limit counts characters, not bytes — a multibyte value truncates to
+// MaxSpanAttrValueLen runes, which is more than MaxSpanAttrValueLen
+// bytes on the wire; (2) an under-limit value is returned unchanged,
+// invalid UTF-8 included — which is why free-text attribute values are
+// repaired at their call sites (internal/cli stringAttr).
+func TestAttrLimit_SDKBehaviorCanary(t *testing.T) {
+	pinOTELEnv(t)
+	record := func(val string) string {
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(
+			sdktrace.WithRawSpanLimits(spanLimits()),
+			sdktrace.WithSpanProcessor(rec),
+		)
+		_, span := tp.Tracer("t").Start(context.Background(), "s")
+		span.SetAttributes(attribute.String("k", val))
+		span.End()
+		ended := rec.Ended()
+		require.Len(t, ended, 1)
+		for _, kv := range ended[0].Attributes() {
+			if kv.Key == "k" {
+				return kv.Value.AsString()
+			}
+		}
+		t.Fatal("attribute not recorded")
+		return ""
+	}
+
+	t.Run("limit counts characters, not bytes", func(t *testing.T) {
+		got := record(strings.Repeat("é", MaxSpanAttrValueLen+100))
+		assert.Equal(t, MaxSpanAttrValueLen, utf8.RuneCountInString(got))
+		assert.Equal(t, 2*MaxSpanAttrValueLen, len(got),
+			"two-byte runes make the byte size twice the limit")
+	})
+
+	t.Run("under-limit invalid UTF-8 passes through unrepaired", func(t *testing.T) {
+		got := record("bad\xff\xfebytes")
+		assert.False(t, utf8.ValidString(got),
+			"the SDK repairs only when truncating — call sites own the repair")
+	})
 }
 
 // TestSpanLimits pins the default and the operator-env precedence,

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -125,6 +125,23 @@ func TestSpanLimits(t *testing.T) {
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "banana")
 	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
 		"an unparseable value is not an operator setting; the default applies")
+
+	// The SDK's firstInt short-circuits on the first non-empty key: an
+	// unparseable specific variable falls back to the SDK default without
+	// ever consulting the generic one. The helper must mirror that, or a
+	// mixed valid/invalid override leaves attribute values unbounded.
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "garbage")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "500")
+	require.Equal(t, -1, sdktrace.NewSpanLimits().AttributeValueLengthLimit,
+		"SDK ground truth: invalid specific var short-circuits, generic var ignored")
+	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
+		"an override the SDK discarded is not an operator setting; the default applies")
+
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "512")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "garbage")
+	require.Equal(t, 512, sdktrace.NewSpanLimits().AttributeValueLengthLimit)
+	assert.Equal(t, 512, spanLimits().AttributeValueLengthLimit,
+		"a valid specific var wins regardless of the generic one")
 }
 
 func TestSetup_NoopOnBadDir(t *testing.T) {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -99,15 +99,32 @@ func TestSetup_SpanAttributeValueLengthLimit(t *testing.T) {
 	assert.Len(t, got, maxSpanAttrValueLen, "attribute value must be truncated to the provider limit")
 }
 
-// TestSpanLimits pins the default and the operator-env precedence.
+// TestSpanLimits pins the default and the operator-env precedence,
+// including the explicit "-1" (unlimited) sentinel, which the SDK
+// collapses to the same struct value as "unset".
 func TestSpanLimits(t *testing.T) {
 	pinOTELEnv(t)
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
 		"unset env defaults to maxSpanAttrValueLen")
 
 	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "512")
 	assert.Equal(t, 512, spanLimits().AttributeValueLengthLimit,
 		"operator env setting wins over the default")
+
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "-1")
+	assert.Equal(t, -1, spanLimits().AttributeValueLengthLimit,
+		"an explicit -1 (unlimited) is honored, not capped")
+
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "-1")
+	assert.Equal(t, -1, spanLimits().AttributeValueLengthLimit,
+		"the generic variable's explicit -1 is honored too")
+
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "banana")
+	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
+		"an unparseable value is not an operator setting; the default applies")
 }
 
 func TestSetup_NoopOnBadDir(t *testing.T) {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -65,6 +66,48 @@ func TestSetup_FileExporter(t *testing.T) {
 	require.NotEmpty(t, td.ResourceSpans)
 	require.NotEmpty(t, td.ResourceSpans[0].ScopeSpans)
 	assert.Equal(t, "test-span", td.ResourceSpans[0].ScopeSpans[0].Spans[0].Name)
+}
+
+// TestSetup_SpanAttributeValueLengthLimit pins the provider-level bound on
+// attribute values: a free-text attribute (model name, skip reason) cannot
+// ride an export at arbitrary size.
+func TestSetup_SpanAttributeValueLengthLimit(t *testing.T) {
+	pinOTELEnv(t)
+	dir := t.TempDir()
+	tracer, cleanup := Setup(dir, "1.0.0-test")
+
+	_, span := tracer.Start(context.Background(), "attr-span")
+	span.SetAttributes(attribute.String("fullsend.test_attr", strings.Repeat("a", 100_000)))
+	span.End()
+	cleanup(context.Background())
+
+	data, err := os.ReadFile(filepath.Join(dir, TelemetryFile))
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(data, &doc))
+	spans := doc["resourceSpans"].([]any)[0].(map[string]any)["scopeSpans"].([]any)[0].(map[string]any)["spans"].([]any)
+	attrs := spans[0].(map[string]any)["attributes"].([]any)
+	var got string
+	for _, a := range attrs {
+		kv := a.(map[string]any)
+		if kv["key"] == "fullsend.test_attr" {
+			got = kv["value"].(map[string]any)["stringValue"].(string)
+		}
+	}
+	require.NotEmpty(t, got, "test attribute must be exported")
+	assert.Len(t, got, maxSpanAttrValueLen, "attribute value must be truncated to the provider limit")
+}
+
+// TestSpanLimits pins the default and the operator-env precedence.
+func TestSpanLimits(t *testing.T) {
+	pinOTELEnv(t)
+	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
+		"unset env defaults to maxSpanAttrValueLen")
+
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "512")
+	assert.Equal(t, 512, spanLimits().AttributeValueLengthLimit,
+		"operator env setting wins over the default")
 }
 
 func TestSetup_NoopOnBadDir(t *testing.T) {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -28,12 +28,16 @@ import (
 )
 
 // pinOTELEnv clears ambient OTEL variables so tests are hermetic in CI
-// (where OTEL_EXPORTER_OTLP_TRACES_ENDPOINT may be set by org vars).
+// (where OTEL_EXPORTER_OTLP_TRACES_ENDPOINT may be set by org vars). The
+// span-limit variables are load-bearing for spanLimits, so every caller
+// gets them cleared too.
 func pinOTELEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("OTEL_SDK_DISABLED", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
+	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 }
 
 func TestSetup_FileExporter(t *testing.T) {
@@ -104,8 +108,6 @@ func TestSetup_SpanAttributeValueLengthLimit(t *testing.T) {
 // collapses to the same struct value as "unset".
 func TestSpanLimits(t *testing.T) {
 	pinOTELEnv(t)
-	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
-	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 	assert.Equal(t, MaxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
 		"unset env defaults to MaxSpanAttrValueLen")
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -96,7 +96,7 @@ func TestSetup_SpanAttributeValueLengthLimit(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, got, "test attribute must be exported")
-	assert.Len(t, got, maxSpanAttrValueLen, "attribute value must be truncated to the provider limit")
+	assert.Len(t, got, MaxSpanAttrValueLen, "attribute value must be truncated to the provider limit")
 }
 
 // TestSpanLimits pins the default and the operator-env precedence,
@@ -106,8 +106,8 @@ func TestSpanLimits(t *testing.T) {
 	pinOTELEnv(t)
 	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "")
-	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
-		"unset env defaults to maxSpanAttrValueLen")
+	assert.Equal(t, MaxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
+		"unset env defaults to MaxSpanAttrValueLen")
 
 	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "512")
 	assert.Equal(t, 512, spanLimits().AttributeValueLengthLimit,
@@ -123,7 +123,7 @@ func TestSpanLimits(t *testing.T) {
 		"the generic variable's explicit -1 is honored too")
 
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "banana")
-	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
+	assert.Equal(t, MaxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
 		"an unparseable value is not an operator setting; the default applies")
 
 	// The SDK's firstInt short-circuits on the first non-empty key: an
@@ -134,7 +134,7 @@ func TestSpanLimits(t *testing.T) {
 	t.Setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "500")
 	require.Equal(t, -1, sdktrace.NewSpanLimits().AttributeValueLengthLimit,
 		"SDK ground truth: invalid specific var short-circuits, generic var ignored")
-	assert.Equal(t, maxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
+	assert.Equal(t, MaxSpanAttrValueLen, spanLimits().AttributeValueLengthLimit,
 		"an override the SDK discarded is not an operator setting; the default applies")
 
 	t.Setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "512")


### PR DESCRIPTION
## Summary

- Agent and root spans previously exported **Status Ok for failed runs**: both status writes keyed solely on `runErr == nil`, and the agent span ended before the #2786 `is_error` transcript check could flip the outcome. Any consumer keying on span/trace status (MLflow trace state, dashboards, filters) counted failed iterations as successes — one leg of the file-vs-MLflow discrepancy gating the tracing rollout.
- The agent span is now finalized **after** the transcript check via `finalizeAgentSpan`: a runtime error, a transcript-reported error, or a non-zero exit is Status Error, with `RecordError` attaching the exception event on both error paths (runtime error and transcript error), message UTF-8-repaired. The root span keys on the run outcome: **validation passed is Ok** (validation, not the last agent exit, is the success gate); otherwise a non-zero `telemetryExitCode` is Error even when `runErr` is nil (harnesses without a `validation_loop`).
- Two deliberate calls, stated up front: (1) agent-span `exit_code` **stays the raw process exit** — `fullsend.transcript_error` marks the #2786 override, status is the failure signal, and the root span's `exit_code` remains the effective `telemetryExitCode`, so run-level filtering is unaffected; (2) status descriptions are **bounded at 2,000 bytes total — prefix and truncation ellipsis included — on a UTF-8 rune boundary**. No OTel, collector, or backend limit mandates a value; 2,000 reuses `maxTranscriptErrorLength`, the repo's bound for the same class of error text (raised from this PR's earlier 256 after review). The transcript payload is budgeted for its `transcript error: ` prefix: messages within the 1,982-byte headroom pass through untouched, while parser-truncated messages (which arrive at 2,012+ bytes) are re-truncated, with the full text preserved on the exception event. The same bounding applies to `runErr` messages and to the sandbox-create status (which embeds raw container logs — previously exported unbounded and unrepaired), because an invalid-UTF-8 or oversized status fails proto marshaling of the whole export batch. Exception events are bounded too — 8,192 bytes, UTF-8-repaired, cut on a rune boundary (added after review: the sandbox-create error embeds supervisor/gateway logs collected with no line limit, and the SDK never truncates event attribute values). The event still carries the fuller copy of every truncated status, and a parser-truncated transcript message stays whole on it even after sanitization growth. The transcript console line prints the same bounded, sanitized string the span records, through the rendering the GHA annotation path uses (`TranscriptError.DisplayMessage`), whose subtype fallback is bounded with the same `truncateError` treatment `ErrorMessage` gets at parse time (the parser never truncates `Subtype`). Span attribute values get a provider-level SDK limit of 8,192 characters — the SDK counts characters, not bytes, so multibyte content can reach four bytes per character on the wire, and it repairs invalid UTF-8 only when it truncates, so every dynamic string attribute is UTF-8-repaired at the source (`stringAttr`), with both SDK properties pinned by a canary test — the first non-empty of `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` / `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` decides alone, matching the SDK's own resolution: a parseable value there (including -1, unlimited) is honored as-is, and an override the SDK discards falls back to the 8,192 default — so free-text attributes — a transcript-derived model name, a pre-script skip reason — are bounded without per-site caps; the SDK applies this limit to span attributes only, which is why events are bounded at their call site instead. Classification (ADR 0050): error text on statuses and exception events — including the container/supervisor log excerpt a failed sandbox create embeds — is Level 1/2 "errors" metadata, not Level 3 content; the same excerpt was exported unbounded on the sandbox status before this PR, and both channels are now bounded. The ADR's Level 1 wording states this explicitly.

Relates to #5361 (fixes the span-status leg only — the enrichment and cost-fidelity legs remain open, so this deliberately does not close it). The diff does not touch the root-span attribute block that #5788 edits.

## Evidence (live runs, `minimal-explore`, local sandbox)

| Run | Transcript | Agent spans before | Agent spans after |
|---|---|---|---|
| auth failure (`invalid_grant`) | `is_error=true`, exit 1, $0 | **Status OK**, `exit_code=1` | **Status ERROR** `"agent exited with code 1"`, `exit_code=1` |
| green control | success, validation passed | Status OK, `exit_code=0` | Status OK, `exit_code=0` (unchanged) |

Root span on the failed run: Status ERROR `"validation failed after 2 iteration(s)"` with an `exception` event.

## Test plan

- [x] `TestAgentSpanStatus` / `TestRootSpanStatus` — table tests pinning both outcome→status mappings, including the #2786 exit-0 override, the no-validation-loop root case, and validation-passed-with-non-zero-last-exit staying Ok
- [x] `TestFinalizeAgentSpan` — `tracetest.SpanRecorder` tests pinning the exported span: status, `fullsend.transcript_error` marker, raw `exit_code`, exception event, ended exactly once
- [x] `TestTruncateStatusMsg` / `TestAgentSpanStatus_TranscriptBoundary` — cap includes the ellipsis; multi-byte rune straddling the cap stays valid UTF-8; invalid UTF-8 repaired at any length; prefixed transcript status never exceeds the cap and a fitting message is not re-truncated
- [x] `TestSetup_SpanAttributeValueLengthLimit` / `TestSpanLimits` — a 100KB span attribute exports truncated to 8,192; operator env setting wins over the default
- [x] `TestRecordSanitizedError` / `TestTranscriptErrorMessage` / `TestTranscriptError_DisplayMessage` — exception events bounded (ellipsis included, rune boundary, UTF-8 repaired); the transcript message is sanitized, bounded against an untruncated `Subtype`, and worst-case sanitization growth (4,014 bytes at the colon-run fixed point) stays whole on the event
- [x] `go test ./internal/cli/ -race` full suite passes (183s)
- [x] Live validation: failed run (fake GCP credentials → `invalid_grant`) exports agent spans ERROR + root ERROR with exception event; green control run unchanged, all Ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)





