### PR TITLE
chore: add reproducible GitLab Runner VM setup with OCI CA hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ script-test:
 	$(call run-timed,bash .github/scripts/redact-behaviour-artifacts-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh)
+	$(call run-timed,bash hack/gitlab-runner-vm/executor/prepare_validation_test.sh)
 	$(call run-timed,python3 skills/topissues/scripts/topissues_test.py)
 	$(call run-timed,python3 skills/nextwork/scripts/nextwork_test.py)
 	$(call run-timed,python3 -m pytest gitlint_rules_test.py -v)

--- a/hack/gitlab-runner-vm/README.md
+++ b/hack/gitlab-runner-vm/README.md
@@ -1,0 +1,94 @@
+# GitLab Runner VM
+
+Provisions GitLab Runner VMs on OpenShift Virtualization with a Podman custom
+executor and OpenShell gateway for fullsend agent jobs.
+
+> **Requires:** `oc`, `virtctl` (client >= 1.5 — ships with OpenShift Virtualization >= 4.19),
+> `python3`, and a local `ssh` binary (virtctl wraps it via ProxyCommand).
+
+## Architecture
+
+Each runner VM runs:
+- **gitlab-runner** (custom executor) — receives CI jobs from GitLab
+- **Podman** (rootless) — creates per-job containers
+- **OpenShell gateway** — provides sandbox compute for fullsend agents
+
+Job containers use `--network=host` to reach the gateway. An OCI
+`createRuntime` hook injects the host CA trust bundle into every container
+(Debian and RHEL-family layouts) so jobs can verify internal TLS endpoints.
+Gateway mTLS credentials are mounted read-only from the runner user's
+OpenShell config.
+
+This is a deployment variant of the container isolation model described in
+ADR-0036. It uses a Podman custom executor instead of Docker/Kubernetes
+executors but maintains equivalent container-level isolation for agent jobs.
+
+See also:
+- [ADR 0036: Agent Execution Sandbox](../../docs/ADRs/0036-agent-execution-sandbox.md)
+
+## Quick start
+
+```bash
+# 1. Create and provision a VM (auto-numbers):
+GL_TOKEN=glpat-xxx PROJECT_ID=12345 \
+  GITLAB_URL=https://gitlab.example.com \
+  NAMESPACE=my-namespace \
+  RUNNER_IMAGE=ghcr.io/org/runner:v1.2.3 \
+  ./create-vm.sh
+
+# 2. Delete a VM:
+GL_TOKEN=glpat-xxx \
+  GITLAB_URL=https://gitlab.example.com \
+  NAMESPACE=my-namespace \
+  ./delete-vm.sh fullsend-gitlab-runner-01
+
+# 3. List VMs:
+NAMESPACE=my-namespace ./delete-vm.sh --list
+```
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GL_TOKEN` | yes | — | GitLab PAT (Owner role, scopes: `create_runner` + `manage_runner` + `api`) |
+| `PROJECT_ID` | yes (create) | — | GitLab project ID |
+| `GITLAB_URL` | yes | — | GitLab instance URL |
+| `NAMESPACE` | yes (create/delete) | — | OpenShift namespace |
+| `RUNNER_IMAGE` | yes | — | Image pre-pulled as a warm cache; jobs must still set `image:` in `.gitlab-ci.yml` |
+| `RUNNER_TAG` | no | `fullsend-gitlab-runner` | Runner tag for job matching |
+| `VM_USER` | no | `fedora` | Cloud-image login user (`cloud-user` on RHEL/CentOS Stream images) |
+| `RUNNER_ACCESS_LEVEL` | no | `not_protected` | `ref_protected` restricts the runner to protected branches and tags, so merge-request pipelines on unprotected source refs never match and sit `pending`. Note the trade-off: with `not_protected`, any job on any branch of the project runs on this VM and can read the mounted gateway credentials (see Security below) — set `ref_protected` if the runner only needs to serve protected refs |
+| `OPENSHELL_VERSION` | no | from `.github/scripts/openshell-version.sh` | OpenShell version (Renovate-tracked) |
+| `GITLAB_RUNNER_VERSION` | no | `19.2.1` | gitlab-runner version |
+| `SSH_PUBLIC_KEY` | no | contents of `~/.ssh/id_rsa.pub` or `id_ed25519.pub` | SSH public key contents (not a path) |
+| `REGISTRATION_TOKEN` | setup only | — | GitLab runner registration token |
+
+## Files
+
+- `create-vm.sh` — end-to-end VM creation + runner registration + setup
+- `delete-vm.sh` — VM teardown + runner deregistration
+- `setup.sh` — standalone VM configuration (called by create-vm.sh)
+- `gitlab-runner-version.sh` — central pin for the gitlab-runner version
+- `vm.yaml` — KubeVirt VirtualMachine template
+- `executor/prepare.sh` — custom executor prepare stage
+- `executor/run.sh` — custom executor run stage
+- `executor/cleanup.sh` — custom executor cleanup stage
+
+## Security notes
+
+- The CA trust bootstrap uses trust-on-first-use (TOFU). For higher assurance,
+  provide the CA bundle out-of-band before running setup.sh.
+- The OCI CA-injection hook fires for all containers on the host. It only
+  copies a CA bundle file and is scoped to the `createRuntime` stage.
+- Job containers share the host network namespace (`--network=host`) to reach
+  the OpenShell gateway. The gateway binds to `0.0.0.0` (required for the
+  Podman compute driver — sandbox containers register via
+  `host.containers.internal`). mTLS protects the endpoint.
+- Job containers receive read-only access to the runner's gateway mTLS
+  credentials (`~/.config/openshell`). This is required for the fullsend
+  agent inside job containers to authenticate to the gateway. The runner is
+  scoped to one project by `runner_type=project_type` and `locked=true`, so
+  only jobs from that project can access these credentials; `run_untagged=false`
+  narrows this further to tag-matched jobs. If job-scoped credential minting
+  is added to the gateway, this mount should be replaced with short-lived
+  per-job tokens.

--- a/hack/gitlab-runner-vm/create-vm.sh
+++ b/hack/gitlab-runner-vm/create-vm.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+#
+# create-vm.sh — Create and provision a GitLab Runner VM in one command.
+#
+# This script:
+#   1. Auto-numbers the VM (fullsend-gitlab-runner-01, -02, ...)
+#   2. Creates the VM on OpenShift Virtualization from vm.yaml
+#   3. Waits for it to boot and accept SSH (~2 minutes)
+#   4. Registers a new project runner via the GitLab API
+#   5. Copies setup files and runs setup.sh to configure the custom
+#      executor, OpenShell gateway, and pre-pull images
+#
+# When done, the runner is online and accepting jobs tagged with RUNNER_TAG.
+#
+# Required environment variables:
+#   GL_TOKEN     — GitLab personal access token (Owner role on PROJECT_ID,
+#                  scopes: create_runner + manage_runner + api)
+#   PROJECT_ID   — GitLab project ID to register the runner against
+#   GITLAB_URL   — GitLab instance URL (e.g. https://gitlab.example.com)
+#   NAMESPACE    — OpenShift namespace for the VM
+#   RUNNER_IMAGE — image pre-pulled as warm cache (e.g. ghcr.io/org/runner:v1.2.3)
+#
+# Optional environment variables:
+#   RUNNER_TAG            — runner tag for job matching (default: fullsend-gitlab-runner)
+#   GITLAB_RUNNER_VERSION — gitlab-runner version to install (default: 19.2.1)
+#   VM_USER               — cloud-image login user (default: fedora; RHEL/CentOS
+#                           Stream images use cloud-user)
+#   RUNNER_ACCESS_LEVEL   — not_protected (default) or ref_protected. Protected
+#                           runners only pick up jobs on protected branches and
+#                           tags, so merge-request pipelines never match.
+#
+# Arguments:
+#   [NUMBER]  — optional runner number (e.g. 01, 03). Auto-increments if omitted.
+#
+# Examples:
+#   # Auto-numbers the VM:
+#   GL_TOKEN=glpat-xxx PROJECT_ID=12345 \
+#     GITLAB_URL=https://gitlab.example.com NAMESPACE=my-namespace \
+#     RUNNER_IMAGE=ghcr.io/org/runner:v1.2.3 ./create-vm.sh
+#
+#   # Explicit runner number:
+#   GL_TOKEN=glpat-xxx PROJECT_ID=12345 \
+#     GITLAB_URL=https://gitlab.example.com NAMESPACE=my-namespace \
+#     RUNNER_IMAGE=ghcr.io/org/runner:v1.2.3 ./create-vm.sh 01
+#
+set -euo pipefail
+
+GITLAB_URL="${GITLAB_URL:-}"
+NAMESPACE="${NAMESPACE:-}"
+RUNNER_TAG="${RUNNER_TAG:-fullsend-gitlab-runner}"
+RUNNER_IMAGE="${RUNNER_IMAGE:-}"
+# Cloud-image login user. Fedora images use "fedora"; RHEL/CentOS Stream
+# images use "cloud-user", so keep this overridable alongside vm.yaml.
+VM_USER="${VM_USER:-fedora}"
+# ref_protected restricts the runner to jobs on protected branches and tags.
+# Merge-request pipelines run on the (unprotected) source ref, so the default
+# is not_protected; scoping comes from runner_type=project_type + locked=true.
+RUNNER_ACCESS_LEVEL="${RUNNER_ACCESS_LEVEL:-not_protected}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source the central gitlab-runner version pin (shared with setup.sh).
+_runner_version_sh="${SCRIPT_DIR}/gitlab-runner-version.sh"
+if [ -f "${_runner_version_sh}" ]; then
+  # shellcheck source=gitlab-runner-version.sh
+  source "${_runner_version_sh}"
+fi
+GITLAB_RUNNER_VERSION="${GITLAB_RUNNER_VERSION:-19.2.1}"
+# Source the repo-wide OpenShell version pin (Renovate-tracked).
+_openshell_version_sh="${SCRIPT_DIR}/../../.github/scripts/openshell-version.sh"
+if [ -f "${_openshell_version_sh}" ]; then
+  # shellcheck source=../../.github/scripts/openshell-version.sh
+  source "${_openshell_version_sh}"
+fi
+OPENSHELL_VERSION="${OPENSHELL_VERSION:-0.0.83}"
+TEMPLATE="${SCRIPT_DIR}/vm.yaml"
+PREFIX="fullsend-gitlab-runner"
+
+# Wrap curl with GL_TOKEN passed via a temp config file to avoid
+# exposing the token in /proc/<pid>/cmdline.
+gl_curl() {
+  local config old_umask rc
+  old_umask=$(umask)
+  umask 077
+  config=$(mktemp)
+  umask "${old_umask}"
+  printf 'header = "PRIVATE-TOKEN: %s"\n' "${GL_TOKEN}" > "${config}"
+  rc=0
+  curl --max-time 30 --connect-timeout 10 -sf -K "${config}" "$@" || rc=$?
+  rm -f "${config}"
+  return "${rc}"
+}
+
+# ----------------------------------------------------------------------
+# Validate inputs
+# ----------------------------------------------------------------------
+usage() {
+  echo "Usage: GL_TOKEN=glpat-xxx PROJECT_ID=<id> $0 [NUMBER]"
+  echo ""
+  echo "Run '$0' with --help for details."
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  head -44 "$0" | tail -42 | sed 's/^# \?//'
+  exit 0
+fi
+
+if [ -z "${GL_TOKEN:-}" ]; then
+  echo "ERROR: GL_TOKEN is required (GitLab personal access token)" >&2
+  usage >&2
+  exit 1
+fi
+if ! [[ "${GL_TOKEN}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: GL_TOKEN contains invalid characters" >&2
+  exit 1
+fi
+
+if [ -z "${PROJECT_ID:-}" ]; then
+  echo "ERROR: PROJECT_ID is required (GitLab project ID)" >&2
+  usage >&2
+  exit 1
+fi
+
+if [ -z "${GITLAB_URL}" ]; then
+  echo "ERROR: GITLAB_URL is required (e.g. https://gitlab.example.com)" >&2
+  exit 1
+fi
+if ! [[ "${GITLAB_URL}" =~ ^https://[a-zA-Z0-9._-]+(:[0-9]+)?$ ]]; then
+  echo "ERROR: GITLAB_URL must start with https:// (got: ${GITLAB_URL})" >&2
+  exit 1
+fi
+
+if [ -z "${NAMESPACE}" ]; then
+  echo "ERROR: NAMESPACE is required (OpenShift namespace)" >&2
+  exit 1
+fi
+
+if [ -z "${RUNNER_IMAGE}" ]; then
+  echo "ERROR: RUNNER_IMAGE is required (e.g. ghcr.io/fullsend-ai/fullsend-runner:v1.2.3)" >&2
+  exit 1
+fi
+
+if [ ! -f "${TEMPLATE}" ]; then
+  echo "ERROR: VM template not found: ${TEMPLATE}" >&2
+  exit 1
+fi
+
+if ! [[ "${VM_USER}" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+  echo "ERROR: VM_USER must be a plain Unix user name (got: ${VM_USER})" >&2
+  exit 1
+fi
+if [[ "${RUNNER_ACCESS_LEVEL}" != "not_protected" && "${RUNNER_ACCESS_LEVEL}" != "ref_protected" ]]; then
+  echo "ERROR: RUNNER_ACCESS_LEVEL must be not_protected or ref_protected (got: ${RUNNER_ACCESS_LEVEL})" >&2
+  exit 1
+fi
+
+# Preflight — every tool and file this run depends on. Without this, a missing
+# executor script or an absent `timeout` is discovered only after the VM has
+# booted and a runner has been registered, so the failure costs a rollback.
+REPO_ROOT="$(cd "${SCRIPT_DIR}" && cd ../.. && pwd)"
+_missing=0
+for tool in oc virtctl python3 curl timeout sha256sum; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "ERROR: required tool not found in PATH: ${tool}" >&2
+    _missing=1
+  fi
+done
+for _f in setup.sh create-vm.sh vm.yaml gitlab-runner-version.sh \
+  executor/job_id.sh executor/prepare.sh executor/run.sh executor/cleanup.sh; do
+  if [ ! -f "${SCRIPT_DIR}/${_f}" ]; then
+    echo "ERROR: required file not found: ${SCRIPT_DIR}/${_f}" >&2
+    _missing=1
+  fi
+done
+for _f in install-openshell.sh openshell-version.sh; do
+  if [ ! -f "${REPO_ROOT}/.github/scripts/${_f}" ]; then
+    echo "ERROR: required file not found: ${REPO_ROOT}/.github/scripts/${_f}" >&2
+    _missing=1
+  fi
+done
+if [ "${_missing}" -ne 0 ]; then
+  exit 1
+fi
+
+# ----------------------------------------------------------------------
+# 1. Pick the VM number (explicit arg or auto-increment)
+# ----------------------------------------------------------------------
+if [ -n "${1:-}" ]; then
+  if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: NUMBER must be numeric (got: $1)" >&2
+    exit 1
+  fi
+  next=$(printf "%02d" "$((10#$1))")
+  vm_name="${PREFIX}-${next}"
+else
+  max=0
+  while IFS= read -r name; do
+    num="${name#"${PREFIX}"-}"
+    if [[ "${num}" =~ ^[0-9]+$ ]] && [ "$((10#${num}))" -gt "$((10#${max}))" ]; then
+      max="${num}"
+    fi
+  done < <(oc -n "${NAMESPACE}" get vm --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null \
+    | grep "^${PREFIX}-" || true)
+
+  next=$(printf "%02d" $((10#${max} + 1)))
+  vm_name="${PREFIX}-${next}"
+fi
+
+echo "==> Creating VM: ${vm_name} in ${NAMESPACE}"
+
+# ----------------------------------------------------------------------
+# 2. Apply the VM manifest
+# ----------------------------------------------------------------------
+if oc -n "${NAMESPACE}" get vm "${vm_name}" >/dev/null 2>&1; then
+  echo "ERROR: VM ${vm_name} already exists in ${NAMESPACE} — delete it first or choose a different number" >&2
+  exit 1
+fi
+
+if ! [[ "${vm_name}" =~ ^[a-z0-9-]+$ ]]; then
+  echo "ERROR: vm_name contains invalid characters: ${vm_name}" >&2
+  exit 1
+fi
+
+SSH_PUBLIC_KEY="${SSH_PUBLIC_KEY:-}"
+if [ -z "${SSH_PUBLIC_KEY}" ]; then
+  if [ -f "${HOME}/.ssh/id_rsa.pub" ]; then
+    SSH_PUBLIC_KEY=$(cat "${HOME}/.ssh/id_rsa.pub")
+  elif [ -f "${HOME}/.ssh/id_ed25519.pub" ]; then
+    SSH_PUBLIC_KEY=$(cat "${HOME}/.ssh/id_ed25519.pub")
+  else
+    echo "ERROR: SSH_PUBLIC_KEY not set and no key found in ~/.ssh/" >&2
+    exit 1
+  fi
+fi
+
+if [[ "${SSH_PUBLIC_KEY}" == *$'\n'* ]]; then
+  echo "ERROR: SSH_PUBLIC_KEY must not contain newlines" >&2
+  exit 1
+fi
+if ! [[ "${SSH_PUBLIC_KEY}" =~ ^(ssh-|ecdsa-) ]]; then
+  echo "ERROR: SSH_PUBLIC_KEY must contain key contents (e.g. ssh-rsa AAAA...), not a file path" >&2
+  exit 1
+fi
+
+python3 -c "
+import sys
+template = sys.stdin.read()
+print(template.replace('__VM_NAME__', sys.argv[1]).replace('__SSH_PUBLIC_KEY__', sys.argv[2]).replace('__VM_USER__', sys.argv[3]), end='')
+" "${vm_name}" "${SSH_PUBLIC_KEY}" "${VM_USER}" < "${TEMPLATE}" \
+  | oc create -n "${NAMESPACE}" -f -
+
+cleanup_vm() {
+  echo "  NOTE: VM ${vm_name} was created — to clean up run:" >&2
+  echo "    NAMESPACE=${NAMESPACE} GL_TOKEN=\$GL_TOKEN GITLAB_URL=${GITLAB_URL} ./delete-vm.sh ${vm_name}" >&2
+}
+trap cleanup_vm ERR
+# ERR does not fire on Ctrl-C; the boot and cloud-init waits below can take
+# up to 20 minutes, so print the cleanup hint on interrupt as well.
+trap 'cleanup_vm; exit 130' INT
+trap 'cleanup_vm; exit 143' TERM
+
+# ----------------------------------------------------------------------
+# 3. Wait for the VM to boot and accept SSH
+# ----------------------------------------------------------------------
+echo "==> Waiting for ${vm_name} to boot..."
+for i in $(seq 1 60); do
+  if virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+    -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" -t "-o ConnectTimeout=5" \
+    -c "true" >/dev/null 2>&1; then
+    echo "  OK: VM is up (${i}0s)"
+    break
+  fi
+  if [ "${i}" -eq 60 ]; then
+    echo "ERROR: VM did not become reachable after 10 minutes" >&2
+    cleanup_vm
+    exit 1
+  fi
+  sleep 10
+done
+
+# Wait for cloud-init to finish installing packages (podman, curl, git, python3).
+# Bounded at 10 minutes to match the SSH readiness loop.
+echo "==> Waiting for cloud-init to complete..."
+if ! timeout 600 virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+  -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+  -c "cloud-init status --wait" 2>&1; then
+  echo "ERROR: cloud-init failed or timed out — check cloud-init logs on the VM" >&2
+  cleanup_vm
+  exit 1
+fi
+echo "  OK: cloud-init complete"
+
+# ----------------------------------------------------------------------
+# 4. Register a runner via the GitLab API
+# ----------------------------------------------------------------------
+echo "==> Registering runner with ${GITLAB_URL} (project ${PROJECT_ID})"
+
+runner_json=$(gl_curl -X POST \
+  "${GITLAB_URL}/api/v4/user/runners" \
+  --data-urlencode "runner_type=project_type" \
+  --data-urlencode "project_id=${PROJECT_ID}" \
+  --data-urlencode "tag_list=${RUNNER_TAG}" \
+  --data-urlencode "description=${NAMESPACE}/${vm_name}" \
+  --data-urlencode "run_untagged=false" \
+  --data-urlencode "access_level=${RUNNER_ACCESS_LEVEL}" \
+  --data-urlencode "locked=true" 2>&1) || {
+  echo "ERROR: GitLab runner registration failed. Response: ${runner_json}" >&2
+  cleanup_vm
+  exit 1
+}
+
+if [ -z "${runner_json}" ]; then
+  echo "ERROR: GitLab runner registration returned empty response" >&2
+  cleanup_vm
+  exit 1
+fi
+
+# Set up rollback before extracting fields — a malformed API response would
+# orphan the runner if the trap weren't active yet.
+runner_id=""
+cleanup_runner() {
+  if [ -z "${runner_id}" ]; then
+    echo "ERROR: provisioning failed — runner may have been created but ID is unknown" >&2
+    echo "  Check ${GITLAB_URL} for orphaned runners in project ${PROJECT_ID}" >&2
+  else
+    echo "ERROR: provisioning failed — deregistering runner ${runner_id}" >&2
+    if gl_curl -X DELETE "${GITLAB_URL}/api/v4/runners/${runner_id}" >/dev/null 2>&1; then
+      echo "  OK: runner ${runner_id} deregistered" >&2
+    else
+      echo "  WARN: failed to deregister runner ${runner_id} — remove it manually at ${GITLAB_URL}" >&2
+    fi
+  fi
+  echo "  NOTE: VM ${vm_name} was not cleaned up — run: NAMESPACE=${NAMESPACE} GL_TOKEN=\$GL_TOKEN GITLAB_URL=${GITLAB_URL} ./delete-vm.sh ${vm_name}" >&2
+}
+trap cleanup_runner ERR
+# ERR does not fire on Ctrl-C, and the window below spans a ~20-minute setup
+# run — without this, an interrupt leaves the runner registered with nobody
+# tracking it.
+trap 'cleanup_runner; exit 130' INT
+trap 'cleanup_runner; exit 143' TERM
+
+REGISTRATION_TOKEN=$(echo "${runner_json}" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+runner_id=$(echo "${runner_json}" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+echo "  OK: runner ID ${runner_id} created"
+
+# ----------------------------------------------------------------------
+# 5. Copy setup files to the VM
+# ----------------------------------------------------------------------
+echo "==> Copying setup files to ${vm_name}"
+
+virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+  -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+  -c "mkdir -p ~/gitlab-runner-vm/executor ~/gitlab-runner-vm/.github/scripts"
+
+for file in setup.sh create-vm.sh vm.yaml gitlab-runner-version.sh; do
+  virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+    -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+    -c "cat > ~/gitlab-runner-vm/${file}" < "${SCRIPT_DIR}/${file}"
+done
+
+for file in job_id.sh prepare.sh run.sh cleanup.sh; do
+  virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+    -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+    -c "cat > ~/gitlab-runner-vm/executor/${file}" < "${SCRIPT_DIR}/executor/${file}"
+done
+
+# setup.sh's install_openshell() delegates to the repo's SHA-pinned installer.
+for file in install-openshell.sh openshell-version.sh; do
+  virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+    -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+    -c "cat > ~/gitlab-runner-vm/.github/scripts/${file}" < "${REPO_ROOT}/.github/scripts/${file}"
+done
+
+virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+  -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+  -c "chmod +x ~/gitlab-runner-vm/setup.sh ~/gitlab-runner-vm/create-vm.sh ~/gitlab-runner-vm/executor/*.sh ~/gitlab-runner-vm/.github/scripts/*.sh"
+
+# `cat > file` exits 0 on a short write, so a dropped SSH channel can leave a
+# truncated setup.sh that then executes an arbitrary prefix of provisioning.
+# Verify every copy against a locally computed manifest before running it.
+echo "==> Verifying copied files"
+{
+  (cd "${SCRIPT_DIR}" && sha256sum setup.sh create-vm.sh vm.yaml gitlab-runner-version.sh \
+    executor/job_id.sh executor/prepare.sh executor/run.sh executor/cleanup.sh)
+  (cd "${REPO_ROOT}/.github/scripts" \
+    && sha256sum install-openshell.sh openshell-version.sh \
+    | sed 's|  |  .github/scripts/|')
+} | virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+  -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+  -c "cd ~/gitlab-runner-vm && sha256sum -c --quiet -" || {
+  echo "ERROR: copied files failed checksum verification — transfer was truncated" >&2
+  cleanup_runner
+  exit 1
+}
+
+echo "  OK: files copied"
+
+# ----------------------------------------------------------------------
+# 6. Run setup.sh on the VM
+# ----------------------------------------------------------------------
+echo "==> Running setup.sh on ${vm_name}"
+
+# Write env vars to a file on the VM to avoid exposing secrets in the process list.
+# Values are single-quoted to prevent interpretation of special characters.
+for val in "${REGISTRATION_TOKEN}" "${GITLAB_URL}" "${RUNNER_TAG}" "${RUNNER_IMAGE}" "${OPENSHELL_VERSION}" "${GITLAB_RUNNER_VERSION}"; do
+  if [[ "${val}" == *"'"* ]]; then
+    echo "ERROR: environment variable values must not contain single quotes" >&2
+    cleanup_runner
+    exit 1
+  fi
+done
+# One remote session: install the .env removal trap first, receive the env
+# file on stdin, then run setup.sh. Doing this in one session means there is
+# no window where the token-bearing file exists without a trap covering it.
+# The signal handlers must terminate the shell (which then fires EXIT): a
+# handler that merely returns would swallow the SIGHUP from a dropped SSH
+# connection and let setup.sh keep running while the local side deregisters
+# the runner. Bounded at 20 minutes (image pulls and binary downloads are the
+# bottleneck).
+{
+  printf "REGISTRATION_TOKEN='%s'\n" "${REGISTRATION_TOKEN}"
+  printf "GITLAB_URL='%s'\n" "${GITLAB_URL}"
+  printf "RUNNER_TAG='%s'\n" "${RUNNER_TAG}"
+  printf "RUNNER_IMAGE='%s'\n" "${RUNNER_IMAGE}"
+  printf "OPENSHELL_VERSION='%s'\n" "${OPENSHELL_VERSION}"
+  printf "GITLAB_RUNNER_VERSION='%s'\n" "${GITLAB_RUNNER_VERSION}"
+} | timeout 1200 virtctl -n "${NAMESPACE}" ssh "${VM_USER}"@vm/"${vm_name}" \
+  -t "-o StrictHostKeyChecking=no" -t "-o UserKnownHostsFile=/dev/null" \
+  -c "trap 'rm -f ~/gitlab-runner-vm/.env' EXIT; trap 'exit 129' HUP; trap 'exit 130' INT; trap 'exit 143' TERM; umask 077 && cat > ~/gitlab-runner-vm/.env && set -a && . ~/gitlab-runner-vm/.env && set +a && bash ~/gitlab-runner-vm/setup.sh"
+
+# Setup succeeded — clear every rollback trap so a stray signal during the
+# final output cannot deregister a healthy runner.
+trap - ERR INT TERM
+
+echo ""
+echo "Done. Runner ${vm_name} (ID ${runner_id}) is ready."
+echo "  Tag:       ${RUNNER_TAG}"
+echo "  Namespace: ${NAMESPACE}"
+echo "  SSH:       virtctl -n ${NAMESPACE} ssh ${VM_USER}@vm/${vm_name}"

--- a/hack/gitlab-runner-vm/delete-vm.sh
+++ b/hack/gitlab-runner-vm/delete-vm.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# delete-vm.sh — Delete a GitLab Runner VM and deregister it from GitLab.
+#
+# This script:
+#   1. Finds the runner by description via the GitLab API
+#   2. Deregisters the runner from GitLab
+#   3. Deletes the VirtualMachine from OpenShift (and its DataVolume)
+#
+# Required environment variables:
+#   GL_TOKEN    — GitLab personal access token
+#   GITLAB_URL  — GitLab instance URL (e.g. https://gitlab.example.com)
+#   NAMESPACE   — OpenShift namespace
+#
+# Optional environment variables:
+#   RUNNER_TAG  — runner tag used for registration (default: fullsend-gitlab-runner)
+#
+# Usage:
+#   GL_TOKEN=glpat-xxx GITLAB_URL=https://gitlab.example.com NAMESPACE=my-ns \
+#     ./delete-vm.sh fullsend-gitlab-runner-01
+#
+#   # List existing runner VMs:
+#   NAMESPACE=my-ns ./delete-vm.sh --list
+#
+set -euo pipefail
+
+GITLAB_URL="${GITLAB_URL:-}"
+NAMESPACE="${NAMESPACE:-}"
+RUNNER_TAG="${RUNNER_TAG:-fullsend-gitlab-runner}"
+PREFIX="fullsend-gitlab-runner"
+
+gl_curl() {
+  local config old_umask rc
+  old_umask=$(umask)
+  umask 077
+  config=$(mktemp)
+  umask "${old_umask}"
+  printf 'header = "PRIVATE-TOKEN: %s"\n' "${GL_TOKEN}" > "${config}"
+  rc=0
+  curl --max-time 30 --connect-timeout 10 -sf -K "${config}" "$@" || rc=$?
+  rm -f "${config}"
+  return "${rc}"
+}
+
+usage() {
+  echo "Usage: GL_TOKEN=glpat-xxx $0 <vm-name> [vm-name ...]"
+  echo "       $0 --list"
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  head -24 "$0" | tail -22 | sed 's/^# \?//'
+  exit 0
+fi
+
+if [ "${1:-}" = "--list" ]; then
+  if [ -z "${NAMESPACE}" ]; then
+    echo "ERROR: NAMESPACE is required for --list" >&2
+    exit 1
+  fi
+  echo "Runner VMs in ${NAMESPACE}:"
+  oc -n "${NAMESPACE}" get vm --no-headers -o custom-columns=NAME:.metadata.name,STATUS:.status.printableStatus \
+    | grep "^${PREFIX}" || echo "  (none)"
+  exit 0
+fi
+
+if [ $# -eq 0 ]; then
+  echo "ERROR: specify at least one VM name to delete" >&2
+  usage >&2
+  exit 1
+fi
+
+if [ -z "${GL_TOKEN:-}" ]; then
+  echo "ERROR: GL_TOKEN is required (GitLab personal access token)" >&2
+  usage >&2
+  exit 1
+fi
+if ! [[ "${GL_TOKEN}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: GL_TOKEN contains invalid characters" >&2
+  exit 1
+fi
+
+if [ -z "${GITLAB_URL}" ]; then
+  echo "ERROR: GITLAB_URL is required (e.g. https://gitlab.example.com)" >&2
+  exit 1
+fi
+if ! [[ "${GITLAB_URL}" =~ ^https://[a-zA-Z0-9._-]+(:[0-9]+)?$ ]]; then
+  echo "ERROR: GITLAB_URL must start with https:// (got: ${GITLAB_URL})" >&2
+  exit 1
+fi
+
+if [ -z "${NAMESPACE}" ]; then
+  echo "ERROR: NAMESPACE is required (OpenShift namespace)" >&2
+  exit 1
+fi
+
+had_errors=false
+for vm_name in "$@"; do
+  if ! [[ "${vm_name}" =~ ^${PREFIX}-[0-9]+$ ]]; then
+    echo "ERROR: invalid VM name '${vm_name}' — expected format: ${PREFIX}-NN" >&2
+    had_errors=true
+    continue
+  fi
+
+  echo "==> Deleting ${vm_name}"
+
+  # ------------------------------------------------------------------
+  # 1. Find the runner ID via the GitLab API
+  # ------------------------------------------------------------------
+  runner_id=""
+  lookup_failed=false
+
+  # Look up the runner by description via the GitLab API (paginated).
+  # Uses /runners (user-scoped) instead of /runners/all (admin-only).
+  encoded_tag=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "${RUNNER_TAG}")
+  page=1
+  while [ -z "${runner_id}" ] && [ "${page}" -le 50 ]; do
+    if ! page_json=$(gl_curl \
+      "${GITLAB_URL}/api/v4/runners?per_page=100&page=${page}&tag_list=${encoded_tag}" 2>/dev/null); then
+      lookup_failed=true
+      break
+    fi
+    runner_id=$(echo "${page_json}" | python3 -c "
+import sys, json
+ns, vm = sys.argv[1], sys.argv[2]
+runners = json.load(sys.stdin)
+for r in runners:
+    desc = r.get('description', '')
+    if desc == ns + '/' + vm:
+        print(r['id'])
+        break
+" "${NAMESPACE}" "${vm_name}" 2>/dev/null) || true
+    [ -n "${runner_id}" ] && break
+    count=$(echo "${page_json}" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null) || { lookup_failed=true; break; }
+    [ "${count}" -lt 100 ] && break
+    page=$((page + 1))
+  done
+
+  if [ "${lookup_failed}" = true ]; then
+    echo "  ERROR: GitLab API request failed — refusing to delete VM without deregistering runner" >&2
+    echo "  Hint: check GL_TOKEN scopes (needs api + manage_runner) and network connectivity" >&2
+    echo "  To force: manually deregister at ${GITLAB_URL}, then: oc -n ${NAMESPACE} delete vm -- ${vm_name}" >&2
+    had_errors=true
+    continue
+  fi
+
+  # ------------------------------------------------------------------
+  # 2. Deregister from GitLab
+  # ------------------------------------------------------------------
+  if [ -n "${runner_id}" ]; then
+    if gl_curl -X DELETE \
+      "${GITLAB_URL}/api/v4/runners/${runner_id}" >/dev/null 2>&1; then
+      echo "  OK: deregistered runner ID ${runner_id}"
+    else
+      echo "  ERROR: failed to deregister runner ID ${runner_id} — refusing to delete VM (would orphan the registration)" >&2
+      echo "  Hint: deregister at ${GITLAB_URL}, then re-run, or use: oc -n ${NAMESPACE} delete vm -- ${vm_name}" >&2
+      had_errors=true
+      continue
+    fi
+  else
+    echo "  WARN: no matching runner found — skipping deregistration"
+  fi
+
+  # ------------------------------------------------------------------
+  # 3. Delete the VM
+  # ------------------------------------------------------------------
+  # Only a genuine NotFound is benign here. Anything else (RBAC, webhook
+  # rejection, API outage) must set had_errors — otherwise the script prints
+  # "Done." and exits 0 while the VM keeps running, and the runner has already
+  # been deregistered above, leaving nothing to find it by.
+  if delete_err=$(oc -n "${NAMESPACE}" delete vm --wait=false -- "${vm_name}" 2>&1); then
+    echo "  OK: VM ${vm_name} deletion initiated"
+  elif printf '%s' "${delete_err}" | grep -q '(NotFound)'; then
+    echo "  WARN: VM ${vm_name} not found — nothing to delete"
+  else
+    echo "  ERROR: failed to delete VM ${vm_name}: ${delete_err}" >&2
+    had_errors=true
+  fi
+
+  # DataVolume shares the VM name — delete it too, with the same
+  # NotFound-vs-error split as the VM above.
+  if delete_err=$(oc -n "${NAMESPACE}" delete dv --wait=false -- "${vm_name}" 2>&1); then
+    echo "  OK: DataVolume ${vm_name} deletion initiated"
+  elif printf '%s' "${delete_err}" | grep -q '(NotFound)'; then
+    : # no DataVolume — nothing to delete
+  else
+    echo "  ERROR: failed to delete DataVolume ${vm_name}: ${delete_err}" >&2
+    had_errors=true
+  fi
+
+  echo ""
+done
+
+if [ "${had_errors}" = true ]; then
+  echo "Done (with errors — some VMs were skipped)."
+  exit 1
+fi
+echo "Done."

--- a/hack/gitlab-runner-vm/executor/cleanup.sh
+++ b/hack/gitlab-runner-vm/executor/cleanup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# GitLab Runner custom executor — cleanup stage.
+# Stops and removes the job container. Always succeeds.
+# -e intentionally omitted — cleanup must not abort on individual failures.
+set -uo pipefail
+
+# shellcheck source=job_id.sh
+source "$(dirname "${BASH_SOURCE[0]}")/job_id.sh"
+JOB_ID=$(resolve_job_id) || {
+  echo "WARN: could not read job id from JOB_RESPONSE_FILE — nothing to clean up"
+  exit 0
+}
+
+STATE_DIR="${HOME}/.local/state/gitlab-runner"
+STATE_FILE="${STATE_DIR}/container-${JOB_ID}"
+
+if [ -f "${STATE_FILE}" ]; then
+  CONTAINER_NAME=$(cat "${STATE_FILE}")
+  if [[ "${CONTAINER_NAME}" =~ ^runner-[0-9]+$ ]]; then
+    echo "Cleaning up container: ${CONTAINER_NAME}"
+    podman stop --time 10 "${CONTAINER_NAME}" 2>/dev/null || true
+    podman rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+  else
+    # Skip only the podman calls — the staging copy of the gateway mTLS
+    # material below must still be removed.
+    echo "WARN: state file holds an unexpected container name (${CONTAINER_NAME}) — not touching podman"
+  fi
+  rm -f "${STATE_FILE}"
+fi
+
+OPENSHELL_STAGING="${STATE_DIR}/openshell-${JOB_ID}"
+rm -rf "${OPENSHELL_STAGING}" 2>/dev/null || true

--- a/hack/gitlab-runner-vm/executor/job_id.sh
+++ b/hack/gitlab-runner-vm/executor/job_id.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Shared helper for resolving the trusted job ID from JOB_RESPONSE_FILE.
+#
+# Job identity comes from the runner-written JOB_RESPONSE_FILE, never from
+# CUSTOM_ENV_CI_JOB_ID: CUSTOM_ENV_* values are job-controlled, so a job could
+# name a concurrent job's container/state file and have this stage act on it.
+# The runner sets JOB_RESPONSE_FILE for every stage and removes it only after
+# cleanup has run.
+#
+# Usage (source from each executor stage):
+#   source "$(dirname "${BASH_SOURCE[0]}")/job_id.sh"
+#   JOB_ID=$(resolve_job_id) || { echo "ERROR: ..." >&2; exit 1; }
+resolve_job_id() {
+  [ -n "${JOB_RESPONSE_FILE:-}" ] && [ -r "${JOB_RESPONSE_FILE}" ] || return 1
+  python3 -c '
+import json, sys
+v = json.load(open(sys.argv[1]))["id"]
+if not isinstance(v, int) or v <= 0:
+    sys.exit(1)
+print(v)
+' "${JOB_RESPONSE_FILE}"
+}

--- a/hack/gitlab-runner-vm/executor/prepare.sh
+++ b/hack/gitlab-runner-vm/executor/prepare.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# GitLab Runner custom executor — prepare stage.
+# Pulls the job image and creates a container for the build.
+set -euo pipefail
+
+IMAGE="${CUSTOM_ENV_CI_JOB_IMAGE:-}"
+if [ -z "${IMAGE}" ]; then
+  echo "ERROR: CUSTOM_ENV_CI_JOB_IMAGE is not set — job must specify an image"
+  exit 1
+fi
+if [[ "${IMAGE}" == -* ]]; then
+  echo "ERROR: CUSTOM_ENV_CI_JOB_IMAGE must not start with a dash (got: ${IMAGE})"
+  exit 1
+fi
+
+# shellcheck source=job_id.sh
+source "$(dirname "${BASH_SOURCE[0]}")/job_id.sh"
+JOB_ID=$(resolve_job_id) || {
+  echo "ERROR: could not read job id from JOB_RESPONSE_FILE" >&2
+  exit 1
+}
+CONTAINER_NAME="runner-${JOB_ID}"
+
+# CUSTOM_ENV_* values come from the job's own CI/CD variables, so they are
+# job-controlled and must be treated as untrusted. Resolve each path before
+# comparing: a plain prefix test accepts "${HOME}/builds-evil" and lets
+# "${HOME}/builds/../.config/openshell" escape the intended root, and the
+# resolved path is what podman bind-mounts (and relabels, via :z).
+# Roots are derived from ${HOME} so the executor works on any cloud image
+# whose default user is not "fedora".
+BUILDS_ROOT="${HOME}/builds"
+CACHE_ROOT="${HOME}/cache"
+
+require_under_root() {
+  local name="$1" root="$2" value="$3" resolved resolved_root
+  # Resolve both sides: comparing a resolved value against an unresolved root
+  # rejects legitimate paths whenever ${HOME} itself traverses a symlink.
+  resolved_root=$(realpath -m -- "${root}") || {
+    echo "ERROR: ${name} root could not be resolved (${root})" >&2
+    exit 1
+  }
+  resolved=$(realpath -m -- "${value}") || {
+    echo "ERROR: ${name} could not be resolved (got: ${value})" >&2
+    exit 1
+  }
+  if [[ "${resolved}" != "${resolved_root}" && "${resolved}" != "${resolved_root}"/* ]]; then
+    echo "ERROR: ${name} must be under ${resolved_root} (got: ${value} -> ${resolved})" >&2
+    exit 1
+  fi
+  # ':' and ',' are field separators in podman's -v spec; a path containing
+  # them would produce an opaque volume-parse error after the image pull.
+  if [[ "${resolved}" == *[:,]* || "${resolved}" == *[[:cntrl:]]* ]]; then
+    echo "ERROR: ${name} must not contain ':' ',' or control characters (got: ${resolved})" >&2
+    exit 1
+  fi
+  printf '%s' "${resolved}"
+}
+
+BUILDS_DIR=$(require_under_root BUILDS_DIR "${BUILDS_ROOT}" \
+  "${CUSTOM_ENV_CI_BUILDS_DIR:-${BUILDS_ROOT}}")
+CACHE_DIR=$(require_under_root CACHE_DIR "${CACHE_ROOT}" \
+  "${CUSTOM_ENV_CI_CACHE_DIR:-${CACHE_ROOT}}")
+STATE_DIR="${HOME}/.local/state/gitlab-runner"
+mkdir -p "${STATE_DIR}"
+STATE_FILE="${STATE_DIR}/container-${JOB_ID}"
+
+echo "Pulling image: ${IMAGE}"
+podman pull -- "${IMAGE}"
+
+mkdir -p "${BUILDS_DIR}" "${CACHE_DIR}"
+
+# --network=host is required so the container can reach the OpenShell gateway.
+# The host CA trust bundle is injected into containers via the OCI createRuntime
+# hook (install_ca_hook in setup.sh). Gateway mTLS credentials are mounted
+# read-only from the runner user's OpenShell config.
+OPENSHELL_CONFIG="${HOME}/.config/openshell"
+
+# Job ids are unique per runner, so a container of this name can only be a
+# stopped leftover from an earlier failed stage. Use plain `podman rm` (no -f):
+# it refuses a running container atomically, with no inspect/rm window.
+if podman container exists "${CONTAINER_NAME}" 2>/dev/null; then
+  if ! rm_err=$(podman rm "${CONTAINER_NAME}" 2>&1); then
+    if podman inspect --format '{{.State.Running}}' "${CONTAINER_NAME}" 2>/dev/null | grep -q true; then
+      echo "ERROR: container ${CONTAINER_NAME} exists and is running — refusing to reuse it" >&2
+    else
+      echo "ERROR: could not remove stale container ${CONTAINER_NAME}: ${rm_err}" >&2
+    fi
+    exit 1
+  fi
+fi
+
+OPENSHELL_MOUNT=()
+if [ -d "${OPENSHELL_CONFIG}" ]; then
+  OPENSHELL_STAGING="${STATE_DIR}/openshell-${JOB_ID}"
+  rm -rf "${OPENSHELL_STAGING}"
+  cp -a "${OPENSHELL_CONFIG}" "${OPENSHELL_STAGING}"
+  OPENSHELL_MOUNT=(-v "${OPENSHELL_STAGING}:/root/.config/openshell:ro,z")
+fi
+
+echo "Creating container: ${CONTAINER_NAME}"
+# Record the name before creating it: if prepare.sh dies between create and
+# the write, cleanup.sh has no way to find the container and it leaks.
+echo "${CONTAINER_NAME}" > "${STATE_FILE}"
+podman create \
+  --name "${CONTAINER_NAME}" \
+  --network=host \
+  --pids-limit 4096 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --env XDG_CACHE_HOME=/tmp/cache \
+  --entrypoint "" \
+  -v "${BUILDS_DIR}:${BUILDS_DIR}:z" \
+  -v "${CACHE_DIR}:${CACHE_DIR}:z" \
+  "${OPENSHELL_MOUNT[@]}" \
+  -- "${IMAGE}" \
+  sleep infinity
+
+podman start "${CONTAINER_NAME}"
+
+# Host CA trust is injected into all containers by the OCI createRuntime hook
+# installed by setup.sh (install_ca_hook). No per-container CA injection needed.
+
+echo "Container ${CONTAINER_NAME} started"

--- a/hack/gitlab-runner-vm/executor/prepare_validation_test.sh
+++ b/hack/gitlab-runner-vm/executor/prepare_validation_test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Fixture test for prepare.sh's bind-mount path validation.
+#
+# CUSTOM_ENV_CI_BUILDS_DIR and CUSTOM_ENV_CI_CACHE_DIR are job-controlled, and
+# their values are passed to `podman create -v` (which also relabels the host
+# tree via :z). A plain prefix test accepts "<root>-evil" and lets "<root>/.."
+# escape, so these cases are asserted directly.
+#
+# Usage: hack/gitlab-runner-vm/executor/prepare_validation_test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREPARE="${SCRIPT_DIR}/prepare.sh"
+
+# prepare.sh's path checks need GNU realpath (-m). Provide a shim when only
+# the BSD one is on PATH (macOS with coreutils installed as grealpath).
+SHIM_DIR=$(mktemp -d)
+trap 'rm -rf "${SHIM_DIR}"' EXIT
+if ! realpath -m / >/dev/null 2>&1; then
+  if command -v grealpath >/dev/null 2>&1; then
+    printf '#!/bin/sh\nexec grealpath "$@"\n' > "${SHIM_DIR}/realpath"
+    chmod +x "${SHIM_DIR}/realpath"
+  else
+    echo "SKIP: GNU realpath (or grealpath) is required to run this test" >&2
+    exit 0
+  fi
+fi
+
+# Stub podman so the test exercises validation only — no container runtime.
+printf '#!/bin/sh\nexit 0\n' > "${SHIM_DIR}/podman"
+chmod +x "${SHIM_DIR}/podman"
+
+FAKE_HOME=$(mktemp -d)
+trap 'rm -rf "${SHIM_DIR}" "${FAKE_HOME}"' EXIT
+
+# prepare.sh reads its job id from the runner-provided JOB_RESPONSE_FILE.
+JOB_RESPONSE="${FAKE_HOME}/job-response.json"
+printf '{"id": 1, "token": "x"}\n' > "${JOB_RESPONSE}"
+
+# A symlink under the allowed root that points outside it: realpath must
+# follow it and the resolved target must be rejected.
+mkdir -p "${FAKE_HOME}/builds"
+ln -s /etc "${FAKE_HOME}/builds/escape"
+
+failures=0
+
+# run_case <expected: accept|reject> <var> <value>
+# JOB_RESPONSE_OVERRIDE, when set, replaces the JOB_RESPONSE_FILE path.
+run_case() {
+  local expected="$1" var="$2" value="$3" rc=0 output
+  output=$(
+    cd "${FAKE_HOME}" && \
+    PATH="${SHIM_DIR}:${PATH}" \
+    HOME="${FAKE_HOME}" \
+    JOB_RESPONSE_FILE="${JOB_RESPONSE_OVERRIDE-${JOB_RESPONSE}}" \
+    CUSTOM_ENV_CI_JOB_IMAGE="registry.example.com/img:latest" \
+    env "${var}=${value}" bash "${PREPARE}" 2>&1
+  ) || rc=$?
+
+  # Classify on the actual validation message so an unrelated early failure
+  # in prepare.sh cannot masquerade as a rejection.
+  local short="${var#CUSTOM_ENV_CI_}"   # BUILDS_DIR / CACHE_DIR
+  local got
+  if [ "${rc}" -eq 0 ]; then
+    got="accept"
+  elif printf '%s' "${output}" | grep -Eq "ERROR: ${short} must (be under|not contain)"; then
+    got="reject"
+  elif printf '%s' "${output}" | grep -q "ERROR: could not read job id from JOB_RESPONSE_FILE"; then
+    got="reject-identity"
+  else
+    got="error(rc=${rc}): $(printf '%s' "${output}" | tail -1)"
+  fi
+
+  if [ "${got}" = "${expected}" ]; then
+    printf 'ok       %-22s %s\n' "${expected}" "${value}"
+  else
+    printf 'FAIL     want=%-8s got=%-8s %s=%s\n' "${expected}" "${got}" "${var}" "${value}"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "== BUILDS_DIR =="
+run_case accept CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds"
+run_case accept CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds/project/1"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds-evil"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/buildsX/y"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds/../../../etc"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds/../.config/openshell"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "/etc/pki"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds/escape"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds/escape/pki"
+run_case accept CUSTOM_ENV_CI_BUILDS_DIR "builds/relative"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "builds/../etc"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds/a:b"
+run_case reject CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds/a"$'\n'"b"
+
+echo "== CACHE_DIR =="
+run_case accept CUSTOM_ENV_CI_CACHE_DIR "${FAKE_HOME}/cache"
+run_case reject CUSTOM_ENV_CI_CACHE_DIR "${FAKE_HOME}/cache-evil"
+run_case reject CUSTOM_ENV_CI_CACHE_DIR "${FAKE_HOME}/cache/../../etc"
+
+echo "== job identity =="
+# A spoofed CUSTOM_ENV_CI_JOB_ID must be ignored: identity comes from the
+# runner-written JOB_RESPONSE_FILE, so this still accepts under the real id.
+run_case accept CUSTOM_ENV_CI_JOB_ID "999999"
+# Missing, unreadable, or malformed response files must fail before podman.
+JOB_RESPONSE_OVERRIDE="${FAKE_HOME}/does-not-exist.json" \
+  run_case reject-identity CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds"
+printf '{"id": "not-an-int"}\n' > "${FAKE_HOME}/bad-id.json"
+JOB_RESPONSE_OVERRIDE="${FAKE_HOME}/bad-id.json" \
+  run_case reject-identity CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds"
+printf 'not json' > "${FAKE_HOME}/bad-json.json"
+JOB_RESPONSE_OVERRIDE="${FAKE_HOME}/bad-json.json" \
+  run_case reject-identity CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds"
+JOB_RESPONSE_OVERRIDE="" \
+  run_case reject-identity CUSTOM_ENV_CI_BUILDS_DIR "${FAKE_HOME}/builds"
+
+if [ "${failures}" -ne 0 ]; then
+  echo "${failures} case(s) failed" >&2
+  exit 1
+fi
+echo "all cases passed"

--- a/hack/gitlab-runner-vm/executor/run.sh
+++ b/hack/gitlab-runner-vm/executor/run.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# GitLab Runner custom executor — run stage.
+# Executes each build script inside the container, forwarding CI env vars.
+set -uo pipefail
+
+SCRIPT_PATH="${1:-}"
+if [ -z "${SCRIPT_PATH}" ]; then
+  echo "ERROR: no script path provided" >&2
+  exit "${SYSTEM_FAILURE_EXIT_CODE}"
+fi
+# shellcheck source=job_id.sh
+source "$(dirname "${BASH_SOURCE[0]}")/job_id.sh"
+JOB_ID=$(resolve_job_id) || {
+  echo "ERROR: could not read job id from JOB_RESPONSE_FILE" >&2
+  exit "${SYSTEM_FAILURE_EXIT_CODE}"
+}
+STATE_FILE="${HOME}/.local/state/gitlab-runner/container-${JOB_ID}"
+
+if [ ! -f "${STATE_FILE}" ]; then
+  echo "ERROR: container state file not found — prepare stage may have failed" >&2
+  exit "${SYSTEM_FAILURE_EXIT_CODE}"
+fi
+
+CONTAINER_NAME=$(cat "${STATE_FILE}") || exit "${SYSTEM_FAILURE_EXIT_CODE}"
+if ! [[ "${CONTAINER_NAME}" =~ ^runner-[0-9]+$ ]]; then
+  echo "ERROR: container state file holds an unexpected name (got: ${CONTAINER_NAME})" >&2
+  exit "${SYSTEM_FAILURE_EXIT_CODE}"
+fi
+
+# Forward CI environment variables into the container.
+# GitLab Runner exposes job variables as CUSTOM_ENV_* — strip the prefix and
+# forward each one with `--env NAME` (no value). Podman then copies the value
+# from its own environment, so secrets never appear in argv or on disk. A
+# line-delimited --env-file cannot carry these safely: file-type CI/CD
+# variables (PEM material, keys) contain newlines, which an `env`-parsing loop
+# truncates to the first line, and a continuation line beginning with
+# CUSTOM_ENV_ would be re-parsed as an attacker-chosen assignment.
+# The exports happen in a subshell that execs podman, so a job variable
+# named PATH or HOME cannot alter this script's own environment. Names that
+# would change how the podman *process itself* behaves (locating conmon and
+# the OCI runtime, its storage/config, its home) are never secrets, so those
+# few are passed inline as NAME=VALUE instead of through podman's environ.
+PODMAN_BIN=$(command -v podman) || exit "${SYSTEM_FAILURE_EXIT_CODE}"
+is_process_critical() {
+  case "$1" in
+    PATH|HOME|TMPDIR|XDG_RUNTIME_DIR|XDG_CONFIG_HOME|XDG_DATA_HOME|\
+    LD_PRELOAD|LD_LIBRARY_PATH|CONTAINERS_CONF|CONTAINERS_CONF_OVERRIDE|\
+    CONTAINERS_STORAGE_CONF|CONTAINERS_REGISTRIES_CONF|CONTAINER_HOST|\
+    CONTAINER_CONNECTION|CONTAINER_SSHKEY|DOCKER_HOST) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+ENV_ARGS=()
+while IFS= read -r name; do
+  [ -n "${name}" ] || continue
+  short="${name#CUSTOM_ENV_}"
+  if is_process_critical "${short}"; then
+    ENV_ARGS+=(--env "${short}=${!name}")
+  else
+    ENV_ARGS+=(--env "${short}")
+  fi
+done < <(compgen -v | grep '^CUSTOM_ENV_')
+
+# run_in_container <podman exec args...>: exec podman with the job's variables
+# exported under their short names.
+run_in_container() {
+  (
+    while IFS= read -r name; do
+      [ -n "${name}" ] || continue
+      short="${name#CUSTOM_ENV_}"
+      is_process_critical "${short}" && continue
+      # Readonly shell names (UID, EUID, SHELLOPTS, ...) cannot be exported;
+      # a CI variable colliding with one is dropped rather than aborting.
+      export "${short}=${!name}" 2>/dev/null \
+        || echo "WARN: cannot forward job variable ${short}" >&2
+    done < <(compgen -v | grep '^CUSTOM_ENV_')
+    exec "${PODMAN_BIN}" exec "$@"
+  )
+}
+
+# The script lives on the host — copy it into the container before executing.
+BUILD_SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
+podman exec "${CONTAINER_NAME}" mkdir -p "${BUILD_SCRIPT_DIR}" || exit "${SYSTEM_FAILURE_EXIT_CODE}"
+podman cp "${SCRIPT_PATH}" "${CONTAINER_NAME}:${SCRIPT_PATH}" || exit "${SYSTEM_FAILURE_EXIT_CODE}"
+
+# Translate exit codes per the custom-executor contract.
+# podman reserves 125 for its own failures. 126/127 are NOT distinguishable
+# from the job: bash returns 127 for a command it cannot find and 126 for one
+# it cannot execute inside the job script, and podman propagates that verbatim,
+# so those stay build failures. 125 is ambiguous too (the script may exit
+# 125), so fall back to container liveness there.
+run_in_container \
+  "${ENV_ARGS[@]}" \
+  "${CONTAINER_NAME}" \
+  bash -- "${SCRIPT_PATH}"; rc=$?
+# Report the script's real status so `allow_failure:exit_codes` works. The
+# runner requires a bare integer here and treats anything else as an unknown
+# failure, so write nothing when the code did not come from the script.
+write_build_exit_code() {
+  [ -n "${BUILD_EXIT_CODE_FILE:-}" ] && printf '%s' "$1" > "${BUILD_EXIT_CODE_FILE}"
+}
+case $rc in
+  0)   ;;
+  125)
+    if podman inspect --format '{{.State.Running}}' "${CONTAINER_NAME}" 2>/dev/null | grep -q true; then
+      write_build_exit_code "$rc"
+      exit "${BUILD_FAILURE_EXIT_CODE}"
+    fi
+    exit "${SYSTEM_FAILURE_EXIT_CODE}"
+    ;;
+  *)
+    write_build_exit_code "$rc"
+    exit "${BUILD_FAILURE_EXIT_CODE}"
+    ;;
+esac

--- a/hack/gitlab-runner-vm/gitlab-runner-version.sh
+++ b/hack/gitlab-runner-vm/gitlab-runner-version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Central pin for the gitlab-runner version used by create-vm.sh and setup.sh.
+# Update this single file to change the version everywhere.
+GITLAB_RUNNER_VERSION="${GITLAB_RUNNER_VERSION:-19.2.1}"

--- a/hack/gitlab-runner-vm/setup.sh
+++ b/hack/gitlab-runner-vm/setup.sh
@@ -1,0 +1,832 @@
+#!/usr/bin/env bash
+# Reproducible setup for a GitLab Runner VM with Podman custom executor
+# and OpenShell gateway for fullsend agent jobs.
+#
+# Prerequisites:
+#   - VM created from vm.yaml (provides Fedora + podman + gitlab-runner)
+#   - sudo access for the running user
+#
+# Normally called by create-vm.sh. Can also be run standalone:
+#   GITLAB_URL=https://gitlab.example.com RUNNER_IMAGE=ghcr.io/org/runner:v1 \
+#     REGISTRATION_TOKEN=glrt-xxx ./setup.sh
+#
+# Environment variables:
+#   REGISTRATION_TOKEN    — GitLab runner token (required on first run)
+#   GITLAB_URL            — GitLab instance URL (required)
+#   RUNNER_IMAGE          — image pre-pulled as a warm cache (required);
+#                          jobs must set image: in .gitlab-ci.yml
+#   RUNNER_TAG            — runner tag for job matching (default: fullsend-gitlab-runner)
+#                          Note: for glrt-* tokens (GitLab 16+), tags are set at
+#                          token creation time and --tag-list is rejected (fatal) by
+#                          gitlab-runner register. Use the API/UI to set tags.
+#   GITLAB_RUNNER_VERSION — gitlab-runner version to install (default: 19.2.1)
+#
+# Note: The OpenShell version is pinned in .github/scripts/openshell-version.sh
+# (Renovate-tracked). The SHA-pinned installer installs the repo-pinned version.
+set -euo pipefail
+
+GITLAB_URL="${GITLAB_URL:-}"
+RUNNER_TAG="${RUNNER_TAG:-fullsend-gitlab-runner}"
+RUNNER_IMAGE="${RUNNER_IMAGE:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source the repo-wide OpenShell version pin (Renovate-tracked). The version is
+# not overridable — the SHA-pinned installer always installs the repo-pinned version.
+# Try VM layout first (.github/scripts/ as child), then repo layout (../../.github/scripts/).
+_openshell_version_sh="${SCRIPT_DIR}/.github/scripts/openshell-version.sh"
+if [ ! -f "${_openshell_version_sh}" ]; then
+  _openshell_version_sh="${SCRIPT_DIR}/../../.github/scripts/openshell-version.sh"
+fi
+if [ -f "${_openshell_version_sh}" ]; then
+  # shellcheck source=../../.github/scripts/openshell-version.sh
+  source "${_openshell_version_sh}"
+fi
+OPENSHELL_VERSION="${OPENSHELL_VERSION:-0.0.83}"
+
+EXECUTOR_DIR="${HOME}/gitlab-runner-executor"
+BUILDS_DIR="${HOME}/builds"
+CACHE_DIR="${HOME}/cache"
+CONFIG_TOML="/etc/gitlab-runner/config.toml"
+RUNNER_USER="${USER:-$(whoami)}"
+
+# Source the central gitlab-runner version pin.
+_runner_version_sh="${SCRIPT_DIR}/gitlab-runner-version.sh"
+if [ -f "${_runner_version_sh}" ]; then
+  # shellcheck source=gitlab-runner-version.sh
+  source "${_runner_version_sh}"
+fi
+GITLAB_RUNNER_VERSION="${GITLAB_RUNNER_VERSION:-19.2.1}"
+
+info()  { echo "==> $*"; }
+ok()    { echo "  OK: $*"; }
+fail()  { echo "  FAIL: $*" >&2; exit 1; }
+
+if [ -z "${GITLAB_URL}" ]; then
+  fail "GITLAB_URL is required (e.g. GITLAB_URL=https://gitlab.example.com)"
+fi
+if ! [[ "${GITLAB_URL}" =~ ^https://[a-zA-Z0-9._-]+(:[0-9]+)?$ ]]; then
+  fail "GITLAB_URL must start with https:// (got: ${GITLAB_URL})"
+fi
+if [ -z "${RUNNER_IMAGE}" ]; then
+  fail "RUNNER_IMAGE is required (e.g. RUNNER_IMAGE=ghcr.io/fullsend-ai/fullsend-runner:v1.2.3)"
+fi
+if ! [[ "${GITLAB_RUNNER_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  fail "GITLAB_RUNNER_VERSION must be semver (got: ${GITLAB_RUNNER_VERSION})"
+fi
+
+# --------------------------------------------------------------------------
+# 0a. Install internal CA certificates (internal GitLab instances often use
+#     a private CA that is not in the default Fedora trust store)
+# --------------------------------------------------------------------------
+install_ca_certs() {
+  info "Checking CA trust for ${GITLAB_URL}"
+
+  # curl exits 0 even on 401/403 without -f; exit 60 means untrusted cert.
+  # Branch on the exit code rather than treating every failure as a trust
+  # problem: with --max-time set, a slow instance (28) or a DNS/connect error
+  # (6/7) would otherwise fall through to TOFU and overwrite the trust anchor.
+  local probe_rc=0
+  curl --max-time 10 --connect-timeout 5 -so /dev/null "${GITLAB_URL}" 2>/dev/null || probe_rc=$?
+  case "${probe_rc}" in
+    0)
+      ok "CA already trusted"
+      return
+      ;;
+    35|51|58|59|60|66|77|80|82|83|91)
+      : # TLS/trust failures — continue to the TOFU path below
+      ;;
+    *)
+      fail "curl exit ${probe_rc} probing ${GITLAB_URL} is not a CA-trust failure that TOFU can fix — see 'man curl' EXIT CODES; check network/DNS"
+      ;;
+  esac
+
+  local host_port
+  host_port=$(echo "${GITLAB_URL}" | sed 's|https\?://||;s|/.*||')
+  local host="${host_port%%:*}"
+  local port="${host_port##*:}"
+  if [ "${port}" = "${host}" ]; then port=443; fi
+
+  # TOFU (trust-on-first-use): the CA chain is fetched from the server itself.
+  # For higher assurance, provide the CA bundle out-of-band via:
+  #   sudo cp /path/to/ca-bundle.pem /etc/pki/ca-trust/source/anchors/gitlab-chain.pem
+  #   sudo update-ca-trust
+  # Stage into a temp file first and validate it before touching the trust
+  # store: piping straight into `tee` truncates the anchor before we know
+  # whether openssl produced anything. The TOFU anchor also gets its own
+  # filename so it can never clobber an operator's out-of-band bundle at
+  # gitlab-chain.pem. `timeout` bounds the handshake — openssl has no
+  # equivalent of curl's --max-time here.
+  local tofu_anchor=/etc/pki/ca-trust/source/anchors/gitlab-chain-tofu.pem
+  local staged
+  staged=$(mktemp)
+  echo "  WARN: trust-on-first-use — fetching CA chain from ${host}:${port}"
+  timeout 15 openssl s_client -connect "${host}:${port}" -servername "${host}" -showcerts </dev/null 2>/dev/null \
+    | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' > "${staged}" || true
+
+  # crl2pkcs7 | pkcs7 -print_certs parses every certificate in the bundle,
+  # not just the first — a transfer that truncated mid-chain must not install.
+  if [ ! -s "${staged}" ] \
+    || ! openssl crl2pkcs7 -nocrl -certfile "${staged}" 2>/dev/null \
+      | openssl pkcs7 -print_certs -noout >/dev/null 2>&1; then
+    rm -f "${staged}"
+    fail "failed to retrieve a valid CA chain from ${host}:${port}"
+  fi
+
+  sudo install -m 0644 "${staged}" "${tofu_anchor}"
+  rm -f "${staged}"
+  sudo update-ca-trust
+
+  # Same branching as the first probe: only a trust-class failure means the
+  # anchor is wrong. A timeout or connect error here must not delete it.
+  probe_rc=0
+  curl --max-time 10 --connect-timeout 5 -so /dev/null "${GITLAB_URL}" 2>/dev/null || probe_rc=$?
+  case "${probe_rc}" in
+    0)
+      ok "CA certificates installed and trusted"
+      ;;
+    35|51|58|59|60|66|77|80|82|83|91)
+      sudo rm -f "${tofu_anchor}"
+      sudo update-ca-trust
+      fail "CA install failed — ${GITLAB_URL} still not trusted (anchor removed)"
+      ;;
+    *)
+      fail "cannot reach ${GITLAB_URL} after CA install (curl exit ${probe_rc}) — anchor left in place; check network/DNS"
+      ;;
+  esac
+}
+
+# --------------------------------------------------------------------------
+# 0b. Install gitlab-runner binary
+# --------------------------------------------------------------------------
+install_gitlab_runner() {
+  info "Checking gitlab-runner"
+
+  if command -v gitlab-runner &>/dev/null; then
+    local current
+    current=$(gitlab-runner --version 2>&1 | head -1 | awk '{print $2}')
+    if [ "${current}" = "${GITLAB_RUNNER_VERSION}" ]; then
+      ok "gitlab-runner ${GITLAB_RUNNER_VERSION}"
+      return
+    fi
+    info "upgrading gitlab-runner ${current} -> ${GITLAB_RUNNER_VERSION}"
+  fi
+
+  local arch
+  arch=$(uname -m)
+  case "${arch}" in
+    x86_64)  arch="amd64" ;;
+    aarch64) arch="arm64" ;;
+    *) fail "unsupported architecture: ${arch}" ;;
+  esac
+
+  local runner_url="https://gitlab-runner-downloads.s3.amazonaws.com/v${GITLAB_RUNNER_VERSION}/binaries/gitlab-runner-linux-${arch}"
+  local tmpbin
+  tmpbin=$(mktemp)
+  # Stall detection rather than a hard cap: the binary is tens of megabytes,
+  # so --max-time turns a slow-but-working link into a deterministic failure.
+  # Overall runtime is already bounded by create-vm.sh's `timeout`.
+  curl --connect-timeout 10 --speed-limit 10240 --speed-time 60 \
+    --retry 3 --retry-connrefused -fsSL -o "${tmpbin}" "${runner_url}"
+
+  local checksums_url="https://gitlab-runner-downloads.s3.amazonaws.com/v${GITLAB_RUNNER_VERSION}/release.sha256"
+  local expected
+  expected=$(curl --max-time 30 --connect-timeout 10 -fsSL "${checksums_url}" | grep "/gitlab-runner-linux-${arch}$" | awk '{print $1}') || true
+  if [ -z "${expected}" ]; then
+    rm -f "${tmpbin}"
+    fail "could not retrieve checksum for gitlab-runner-linux-${arch} from ${checksums_url}"
+  fi
+  local actual
+  actual=$(sha256sum "${tmpbin}" | awk '{print $1}')
+  if [ "${actual}" != "${expected}" ]; then
+    rm -f "${tmpbin}"
+    fail "gitlab-runner checksum mismatch (expected ${expected}, got ${actual})"
+  fi
+
+  sudo install -m 0755 "${tmpbin}" /usr/local/bin/gitlab-runner
+  rm -f "${tmpbin}"
+  if [ ! -f /etc/systemd/system/gitlab-runner.service ]; then
+    sudo gitlab-runner install --user "${RUNNER_USER}" --working-directory "${HOME}"
+  else
+    sudo systemctl daemon-reload
+  fi
+  sudo mkdir -p /etc/gitlab-runner
+  sudo chown -R "${RUNNER_USER}:${RUNNER_USER}" /etc/gitlab-runner
+
+  ok "gitlab-runner ${GITLAB_RUNNER_VERSION} installed"
+}
+
+# --------------------------------------------------------------------------
+# 0c. Register runner with GitLab (first-time only)
+# --------------------------------------------------------------------------
+register_runner() {
+  info "Checking runner registration"
+
+  if [ -f "${CONFIG_TOML}" ] && grep -q '^\[\[runners\]\]' "${CONFIG_TOML}"; then
+    ok "runner already registered"
+    return
+  fi
+
+  if [ -z "${REGISTRATION_TOKEN:-}" ]; then
+    fail "REGISTRATION_TOKEN required for first-time registration"
+  fi
+
+  sudo mkdir -p "$(dirname "${CONFIG_TOML}")"
+  sudo chown -R "${RUNNER_USER}:${RUNNER_USER}" "$(dirname "${CONFIG_TOML}")"
+
+  gitlab-runner register \
+    --non-interactive \
+    --config "${CONFIG_TOML}" \
+    --url "${GITLAB_URL}" \
+    --token "${REGISTRATION_TOKEN}" \
+    --executor shell
+
+  ok "runner registered with ${GITLAB_URL}"
+}
+
+# --------------------------------------------------------------------------
+# 1. Switch gitlab-runner to run as the current user
+# --------------------------------------------------------------------------
+setup_runner_user() {
+  info "Configuring gitlab-runner to run as ${RUNNER_USER}"
+
+  local override_dir="/etc/systemd/system/gitlab-runner.service.d"
+  local override_file="${override_dir}/user.conf"
+
+  if [ -f "${override_file}" ] && grep -q "User=${RUNNER_USER}" "${override_file}"; then
+    ok "systemd override already in place"
+    return
+  fi
+
+  sudo mkdir -p "${override_dir}"
+  sudo tee "${override_file}" > /dev/null <<EOF
+[Service]
+User=${RUNNER_USER}
+Group=${RUNNER_USER}
+WorkingDirectory=${HOME}
+ExecStart=
+ExecStart=/usr/local/bin/gitlab-runner run --config ${CONFIG_TOML} --working-directory ${HOME} --service gitlab-runner
+EOF
+
+  sudo systemctl daemon-reload
+  ok "gitlab-runner systemd override installed for ${RUNNER_USER}"
+}
+
+# --------------------------------------------------------------------------
+# 2. Enable rootless Podman prerequisites
+# --------------------------------------------------------------------------
+setup_podman() {
+  info "Configuring rootless Podman"
+
+  if ! test -f /sys/fs/cgroup/cgroup.controllers; then
+    fail "cgroups v2 required but not available"
+  fi
+
+  if ! grep -q "^${RUNNER_USER}:" /etc/subuid 2>/dev/null; then
+    sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "${RUNNER_USER}"
+    podman system migrate
+    ok "added subuid/subgid mapping"
+  else
+    ok "subuid/subgid already configured"
+  fi
+
+  sudo loginctl enable-linger "${RUNNER_USER}"
+  ok "linger enabled for ${RUNNER_USER}"
+
+  systemctl --user enable --now podman.socket
+  ok "podman socket enabled"
+}
+
+# --------------------------------------------------------------------------
+# 3. Install OpenShell CLI
+# --------------------------------------------------------------------------
+install_openshell() {
+  info "Installing OpenShell ${OPENSHELL_VERSION}"
+
+  if command -v openshell &>/dev/null && systemctl --user cat openshell-gateway.service &>/dev/null; then
+    local current
+    current=$(openshell --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+' | head -1 || echo "")
+    if [ "${current}" = "${OPENSHELL_VERSION}" ]; then
+      ok "OpenShell ${OPENSHELL_VERSION} already installed"
+      return
+    fi
+  fi
+
+  # Reuse the repo's SHA-pinned installer for supply-chain integrity.
+  # Try VM layout first (.github/scripts/ as child), then repo layout.
+  local install_sh
+  install_sh="${SCRIPT_DIR}/.github/scripts/install-openshell.sh"
+  if [ ! -f "${install_sh}" ]; then
+    install_sh="${SCRIPT_DIR}/../../.github/scripts/install-openshell.sh"
+  fi
+  if [ -f "${install_sh}" ]; then
+    bash "${install_sh}"
+  else
+    fail "install-openshell.sh not found — run from the VM layout or repo checkout"
+  fi
+
+  if ! command -v openshell &>/dev/null; then
+    fail "openshell binary not found after install"
+  fi
+  if ! systemctl --user cat openshell-gateway.service &>/dev/null; then
+    fail "openshell-gateway.service not found after RPM install"
+  fi
+
+  openshell --version
+  ok "OpenShell ${OPENSHELL_VERSION} installed"
+}
+
+# --------------------------------------------------------------------------
+# 4. Configure OpenShell gateway
+# --------------------------------------------------------------------------
+configure_gateway() {
+  info "Configuring OpenShell gateway"
+
+  mkdir -p "${HOME}/.config/openshell"
+
+  # Bind the gateway to all interfaces — required for the Podman compute driver.
+  # Sandbox containers use bridge networking on the 'openshell' network and
+  # register back via host.containers.internal:17670, which arrives on a
+  # non-loopback address. mTLS protects the wider bind.
+  if [ -f "${HOME}/.config/openshell/gateway.env" ] && grep -q '^OPENSHELL_BIND_ADDRESS=0\.0\.0\.0$' "${HOME}/.config/openshell/gateway.env"; then
+    ok "gateway binding already at 0.0.0.0"
+  elif [ -f "${HOME}/.config/openshell/gateway.env" ]; then
+    if grep -q '^OPENSHELL_BIND_ADDRESS=' "${HOME}/.config/openshell/gateway.env"; then
+      sed -i 's/^OPENSHELL_BIND_ADDRESS=.*/OPENSHELL_BIND_ADDRESS=0.0.0.0/' "${HOME}/.config/openshell/gateway.env"
+    else
+      echo 'OPENSHELL_BIND_ADDRESS=0.0.0.0' >> "${HOME}/.config/openshell/gateway.env"
+    fi
+    ok "gateway binding set to 0.0.0.0"
+  else
+    echo 'OPENSHELL_BIND_ADDRESS=0.0.0.0' > "${HOME}/.config/openshell/gateway.env"
+    ok "gateway binding set to 0.0.0.0"
+  fi
+
+  # Pin supervisor_image to the Renovate-tracked version (matching action.yml).
+  local gateway_toml="${HOME}/.config/openshell/gateway.toml"
+  local supervisor_image="ghcr.io/nvidia/openshell/supervisor:${OPENSHELL_VERSION}"
+  if [ -f "${gateway_toml}" ] && grep -qF "supervisor_image = \"${supervisor_image}\"" "${gateway_toml}"; then
+    ok "supervisor_image already pinned to ${supervisor_image}"
+  elif [ -f "${gateway_toml}" ] && grep -q "supervisor_image" "${gateway_toml}"; then
+    sed -i "s|supervisor_image = .*|supervisor_image = \"${supervisor_image}\"|" "${gateway_toml}"
+    ok "supervisor_image updated to ${supervisor_image}"
+  else
+    mkdir -p "$(dirname "${gateway_toml}")"
+    if [ -f "${gateway_toml}" ] && grep -q '^\[openshell\.gateway\]' "${gateway_toml}"; then
+      sed -i "/^\[openshell\.gateway\]/a supervisor_image = \"${supervisor_image}\"" "${gateway_toml}"
+    elif [ -f "${gateway_toml}" ]; then
+      printf '\n[openshell]\nversion = 1\n\n[openshell.gateway]\nsupervisor_image = "%s"\n' "${supervisor_image}" >> "${gateway_toml}"
+    else
+      # The RPM's user unit only seeds gateway.toml.default when no config
+      # exists, and this function runs before the first start — so writing a
+      # bare stub here would permanently drop the packaged defaults (without
+      # compute_drivers the gateway auto-detects Kubernetes before Podman).
+      # Seed from the packaged default so the values track the installed RPM;
+      # the literal fallback mirrors v0.0.83's gateway.toml.default.
+      local packaged_default=/usr/share/openshell-gateway/gateway.toml.default
+      if [ -f "${packaged_default}" ]; then
+        install -m 0644 "${packaged_default}" "${gateway_toml}"
+        if grep -q '^\[openshell\.gateway\]' "${gateway_toml}"; then
+          sed -i "/^\[openshell\.gateway\]/a supervisor_image = \"${supervisor_image}\"" "${gateway_toml}"
+        else
+          printf '\n[openshell.gateway]\nsupervisor_image = "%s"\n' "${supervisor_image}" >> "${gateway_toml}"
+        fi
+      else
+        printf '[openshell]\nversion = 1\n\n[openshell.gateway]\nbind_address = "0.0.0.0:17670"\ncompute_drivers = ["podman"]\nsupervisor_image = "%s"\n' "${supervisor_image}" > "${gateway_toml}"
+      fi
+    fi
+    ok "supervisor_image pinned to ${supervisor_image}"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 4b. Inject host CA trust into sandbox containers (OCI hook)
+# --------------------------------------------------------------------------
+install_ca_hook() {
+  info "Installing OCI hook for sandbox CA trust"
+
+  # The OpenShell supervisor (PID 1 inside sandbox containers) reads the
+  # system CA bundle from a fixed list — /etc/ssl/certs/ca-certificates.crt,
+  # /etc/pki/tls/certs/ca-bundle.crt, /etc/ssl/ca-bundle.pem, /etc/ssl/cert.pem
+  # (SYSTEM_CA_PATHS, first non-empty wins) — to build the L7 egress proxy's
+  # upstream trust and the SSL_CERT_FILE bundle handed to sandboxed processes.
+  # The default sandbox image ships standard Mozilla CAs but not the
+  # internal CA installed by install_ca_certs(). An OCI createRuntime
+  # hook copies the host trust bundle into every container's rootfs
+  # before PID 1 starts, so the supervisor trusts internal endpoints.
+  # The candidate list below must stay a subset of SYSTEM_CA_PATHS: writing
+  # only to a path OpenShell never reads leaves the CA invisible to it.
+
+  # Stage the host CA bundle in a user-writable location.
+  mkdir -p "${HOME}/.local/share/ca-trust"
+  cp /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+     "${HOME}/.local/share/ca-trust/ca-bundle.pem"
+  chmod 644 "${HOME}/.local/share/ca-trust/ca-bundle.pem"
+
+  # Install the hook script ($HOME expands at install time via unquoted heredoc).
+  local ca_src="${HOME}/.local/share/ca-trust/ca-bundle.pem"
+  sudo tee /usr/local/bin/inject-ca-certs.sh > /dev/null <<HOOKSCRIPT
+#!/bin/bash
+STATE=\$(cat)
+# Resolve rootfs from OCI hook state. Primary: bundle + config.json (OCI spec).
+# Fallback: 'root' string if emitted by the runtime (non-standard extension).
+ROOTFS=\$(echo "\$STATE" | python3 -c "
+import json, sys, os
+state = json.load(sys.stdin)
+bundle = state.get('bundle', '')
+if bundle:
+    cfg = os.path.join(bundle, 'config.json')
+    if os.path.isfile(cfg):
+        with open(cfg) as f:
+            root_path = json.load(f).get('root', {}).get('path', '')
+            if root_path and not os.path.isabs(root_path):
+                root_path = os.path.join(bundle, root_path)
+            if root_path:
+                print(root_path)
+                sys.exit(0)
+root = state.get('root', '')
+if isinstance(root, str) and root:
+    print(root)
+")
+CA_SRC="${ca_src}"
+
+if [ -z "\$ROOTFS" ]; then
+  echo "inject-ca-certs: no rootfs from container state" >&2
+  exit 0
+fi
+if [ ! -f "\$CA_SRC" ]; then
+  echo "inject-ca-certs: CA source not found: \$CA_SRC" >&2
+  exit 0
+fi
+
+# Resolve a path inside the rootfs, following symlinks relative to the rootfs
+# (not the host root). Resolves to a fixpoint with a hop limit to defeat
+# chained symlinks. The final path must not itself be a symlink.
+resolve_in_rootfs() {
+  python3 -c "
+import os, sys
+rootfs, rel = sys.argv[1], sys.argv[2]
+parts = rel.strip('/').split('/')
+cur = rootfs
+hops = 0
+for p in parts:
+    cur = os.path.join(cur, p)
+    while os.path.islink(cur):
+        if hops >= 40:
+            sys.exit(1)
+        t = os.readlink(cur)
+        cur = os.path.join(rootfs, t.lstrip('/')) if os.path.isabs(t) else os.path.join(os.path.dirname(cur), t)
+        cur = os.path.normpath(cur)
+        if not cur.startswith(rootfs + '/') and cur != rootfs:
+            sys.exit(1)
+        hops += 1
+    cur = os.path.normpath(cur)
+    if not cur.startswith(rootfs + '/') and cur != rootfs:
+        sys.exit(1)
+if os.path.islink(cur):
+    sys.exit(1)
+print(cur)
+" "\$1" "\$2"
+}
+
+# Known CA bundle paths, in OpenShell's own SYSTEM_CA_PATHS order:
+# Debian/Ubuntu, RHEL/CentOS, SUSE, then Alpine. Keep this list aligned with
+# upstream — a path outside it is not read by the supervisor.
+for ca_rel in \\
+  etc/ssl/certs/ca-certificates.crt \\
+  etc/pki/tls/certs/ca-bundle.crt \\
+  etc/ssl/ca-bundle.pem \\
+  etc/ssl/cert.pem; do
+  resolved=\$(resolve_in_rootfs "\$ROOTFS" "\$ca_rel") || continue
+  [ -f "\$resolved" ] || continue
+  # Write to a sibling temp file and atomically replace the target so a
+  # mid-write failure (ENOSPC/EDQUOT) never truncates the original bundle.
+  # O_NOFOLLOW on the temp prevents symlink-following.
+  python3 -c "
+import os, sys, tempfile
+target, src_path = sys.argv[1], sys.argv[2]
+target_dir = os.path.dirname(target)
+try:
+    with open(src_path, 'rb') as src:
+        data = src.read()
+    fd, tmp = tempfile.mkstemp(dir=target_dir, prefix='.ca-inject-')
+    try:
+        with os.fdopen(fd, 'wb') as f:
+            f.write(data)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, target)
+    except BaseException:
+        os.unlink(tmp)
+        raise
+except OSError:
+    sys.exit(1)
+" "\$resolved" "\$CA_SRC" && {
+    echo "inject-ca-certs: injected CA bundle to \${ca_rel}" >&2
+    exit 0
+  }
+done
+
+echo "inject-ca-certs: no writable CA bundle path found in rootfs" >&2
+exit 0
+HOOKSCRIPT
+  sudo chmod +x /usr/local/bin/inject-ca-certs.sh
+
+  # Install the hook JSON.
+  sudo mkdir -p /etc/containers/oci/hooks.d
+  sudo tee /etc/containers/oci/hooks.d/inject-ca-certs.json > /dev/null <<'HOOKJSON'
+{
+  "version": "1.0.0",
+  "hook": {
+    "path": "/usr/local/bin/inject-ca-certs.sh"
+  },
+  "when": {
+    "always": true
+  },
+  "stages": ["createRuntime"]
+}
+HOOKJSON
+
+  # Tell Podman where to find hooks (required for rootless mode).
+  mkdir -p "${HOME}/.config/containers"
+  local conf="${HOME}/.config/containers/containers.conf"
+  if [ -f "${conf}" ] && grep -q '/etc/containers/oci/hooks.d' "${conf}"; then
+    ok "hooks_dir already configured in containers.conf"
+  else
+    if [ -f "${conf}" ]; then
+      if grep -q '^\[engine\]' "${conf}"; then
+        sed -i '/^\[engine\]/a hooks_dir = ["/etc/containers/oci/hooks.d"]' "${conf}"
+      else
+        printf '\n[engine]\nhooks_dir = ["/etc/containers/oci/hooks.d"]\n' >> "${conf}"
+      fi
+    else
+      cat > "${conf}" <<EOF
+[engine]
+hooks_dir = ["/etc/containers/oci/hooks.d"]
+EOF
+    fi
+  fi
+
+  # Restart the Podman socket so it picks up the hooks_dir config.
+  systemctl --user restart podman.socket
+
+  ok "OCI hook installed for CA trust injection"
+}
+
+# --------------------------------------------------------------------------
+# 5. Start gateway via RPM-provided systemd service
+# --------------------------------------------------------------------------
+start_gateway() {
+  info "Starting OpenShell gateway"
+
+  # Use the RPM-provided service which handles config seeding, PKI
+  # generation, and environment loading automatically.
+  systemctl --user daemon-reload
+  systemctl --user enable openshell-gateway.service
+  systemctl --user restart openshell-gateway.service
+
+  local i
+  for i in $(seq 1 10); do
+    if systemctl --user is-active --quiet openshell-gateway.service; then
+      break
+    fi
+    if [ "${i}" -eq 10 ]; then
+      fail "gateway did not start after 10s — check: journalctl --user -u openshell-gateway"
+    fi
+    sleep 1
+  done
+
+  # Register the gateway with the CLI so openshell commands can find it.
+  # Check for an active gateway (line starting with *).
+  if ! openshell gateway list 2>/dev/null | grep -Eq '^[[:space:]]*\*'; then
+    # `gateway add` is not idempotent — it refuses when metadata for the
+    # canonical "openshell" loopback name already exists — so fall back to
+    # selecting that name. Both failing must fail setup: every job's agent
+    # depends on this registration, and verify() only checks the systemd unit.
+    local add_err
+    if ! add_err=$(openshell gateway add --local https://127.0.0.1:17670 2>&1) \
+      && ! openshell gateway select openshell >/dev/null 2>&1; then
+      fail "could not register or select the OpenShell gateway: ${add_err}"
+    fi
+    if ! openshell gateway list 2>/dev/null | grep -Eq '^[[:space:]]*\*'; then
+      fail "no active OpenShell gateway after add/select"
+    fi
+    ok "gateway registered and selected"
+  else
+    ok "gateway already registered"
+  fi
+
+  ok "gateway is running"
+}
+
+# --------------------------------------------------------------------------
+# 6. Install custom executor scripts
+# --------------------------------------------------------------------------
+install_executor() {
+  info "Installing custom executor scripts to ${EXECUTOR_DIR}"
+
+  mkdir -p "${EXECUTOR_DIR}"
+
+  for script in job_id.sh prepare.sh run.sh cleanup.sh; do
+    local src="${SCRIPT_DIR}/executor/${script}"
+    if [ ! -f "${src}" ]; then
+      fail "executor script not found: ${src}"
+    fi
+    cp "${src}" "${EXECUTOR_DIR}/${script}"
+    chmod +x "${EXECUTOR_DIR}/${script}"
+  done
+
+  ok "executor scripts installed"
+}
+
+# --------------------------------------------------------------------------
+# 7. Patch gitlab-runner config.toml
+# --------------------------------------------------------------------------
+patch_config() {
+  info "Patching ${CONFIG_TOML}"
+
+  # Ensure the config dir and file are accessible to the runner user.
+  # The default RPM install creates these as root-owned 700/600.
+  if [ -d "$(dirname "${CONFIG_TOML}")" ]; then
+    sudo chown -R "${RUNNER_USER}:${RUNNER_USER}" "$(dirname "${CONFIG_TOML}")"
+    sudo chmod 700 "$(dirname "${CONFIG_TOML}")"
+  fi
+
+  if ! [ -f "${CONFIG_TOML}" ]; then
+    fail "config.toml not found at ${CONFIG_TOML}"
+  fi
+
+  if grep -q 'executor = "custom"' "${CONFIG_TOML}"; then
+    ok "already using custom executor"
+    return
+  fi
+
+  local runner_count
+  runner_count=$(grep -c '^\[\[runners\]\]' "${CONFIG_TOML}")
+  if [ "${runner_count}" -ne 1 ]; then
+    fail "expected exactly 1 [[runners]] block in config.toml, found ${runner_count} — patch manually"
+  fi
+
+  cp "${CONFIG_TOML}" "${CONFIG_TOML}.bak.$(date +%Y%m%d%H%M%S)"
+  ok "backed up config.toml"
+
+  # Build the replacement block
+  local custom_block
+  custom_block=$(cat <<EOF
+  executor = "custom"
+  builds_dir = "${BUILDS_DIR}"
+  cache_dir = "${CACHE_DIR}"
+  [runners.custom]
+    prepare_exec = "${EXECUTOR_DIR}/prepare.sh"
+    prepare_exec_timeout = 300
+    run_exec = "${EXECUTOR_DIR}/run.sh"
+    cleanup_exec = "${EXECUTOR_DIR}/cleanup.sh"
+    cleanup_exec_timeout = 120
+EOF
+  )
+
+  # Replace the executor line and inject the custom block.
+  local tmp
+  tmp=$(mktemp)
+  awk -v block="${custom_block}" '
+    /executor = "shell"/ { print block; next }
+    { print }
+  ' "${CONFIG_TOML}" > "${tmp}"
+
+  cp "${tmp}" "${CONFIG_TOML}"
+  rm -f "${tmp}"
+
+  if ! grep -q 'executor = "custom"' "${CONFIG_TOML}"; then
+    fail "failed to patch config.toml — 'executor = \"shell\"' not found in original config"
+  fi
+
+  mkdir -p "${BUILDS_DIR}" "${CACHE_DIR}"
+
+  ok "config.toml patched"
+}
+
+# --------------------------------------------------------------------------
+# 8. Pre-pull images
+# --------------------------------------------------------------------------
+prepull_images() {
+  info "Pre-pulling images"
+
+  podman pull -- "${RUNNER_IMAGE}"
+  ok "pulled ${RUNNER_IMAGE}"
+
+  podman pull -- "ghcr.io/nvidia/openshell/supervisor:${OPENSHELL_VERSION}"
+  ok "pulled supervisor image"
+
+  # The sandbox image is project-specific (set in .fullsend/ config) and pulled
+  # on demand by the gateway — no pre-pull needed here.
+}
+
+# --------------------------------------------------------------------------
+# 9. Verify
+# --------------------------------------------------------------------------
+verify() {
+  info "Verifying setup"
+
+  local errors=0
+
+  if openshell --version | grep -q "${OPENSHELL_VERSION}"; then
+    ok "openshell version ${OPENSHELL_VERSION}"
+  else
+    echo "  WARN: openshell version mismatch"; errors=$((errors + 1))
+  fi
+
+  if systemctl --user is-active --quiet openshell-gateway.service; then
+    ok "gateway running"
+  else
+    echo "  WARN: gateway not running"; errors=$((errors + 1))
+  fi
+
+  # The unit being active says nothing about CLI registration, which is what
+  # the agent inside job containers actually resolves the gateway through.
+  if openshell gateway list 2>/dev/null | grep -Eq '^[[:space:]]*\*'; then
+    ok "gateway registered with the CLI"
+  else
+    echo "  WARN: no active gateway in 'openshell gateway list'"; errors=$((errors + 1))
+  fi
+
+  if systemctl --user is-active --quiet podman.socket; then
+    ok "podman socket active"
+  else
+    echo "  WARN: podman socket not active"; errors=$((errors + 1))
+  fi
+
+  if systemctl is-active --quiet gitlab-runner; then
+    ok "gitlab-runner service running"
+  else
+    echo "  WARN: gitlab-runner service not running"; errors=$((errors + 1))
+  fi
+
+  if grep -q 'executor = "custom"' "${CONFIG_TOML}"; then
+    ok "custom executor configured"
+  else
+    echo "  WARN: custom executor not in config"; errors=$((errors + 1))
+  fi
+
+  # Smoke-test internal CA injection: verify a container can reach the internal
+  # GitLab instance using the host CA bundle injected by the OCI hook.
+  if podman run --rm --entrypoint sh --network=host -- "${RUNNER_IMAGE}" \
+    -c 'command -v curl' >/dev/null 2>&1; then
+    if podman run --rm --entrypoint "" --network=host "${RUNNER_IMAGE}" \
+      curl -sf --max-time 10 --connect-timeout 5 -o /dev/null "${GITLAB_URL}" 2>/dev/null; then
+      ok "container CA trust verified (${GITLAB_URL} reachable)"
+    else
+      echo "  WARN: container cannot reach ${GITLAB_URL} — CA hook may be broken"; errors=$((errors + 1))
+    fi
+  else
+    echo "  INFO: container CA trust smoke test skipped (image lacks curl)"
+  fi
+
+  for script in job_id.sh prepare.sh run.sh cleanup.sh; do
+    if test -x "${EXECUTOR_DIR}/${script}"; then
+      ok "${script} executable"
+    else
+      echo "  WARN: ${script} not executable"; errors=$((errors + 1))
+    fi
+  done
+
+  if [ "${errors}" -eq 0 ]; then
+    echo ""
+    echo "Setup complete. The runner is ready to accept fullsend-agent jobs."
+    echo "Image: ${RUNNER_IMAGE}"
+  else
+    echo ""
+    echo "Setup finished with ${errors} error(s) — review above."
+    exit 1
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+echo "GitLab Runner VM Setup"
+echo "======================"
+echo "GitLab:       ${GITLAB_URL}"
+echo "Runner tag:   ${RUNNER_TAG}"
+echo "Runner image: ${RUNNER_IMAGE}"
+echo "OpenShell:    ${OPENSHELL_VERSION}"
+echo ""
+
+install_gitlab_runner
+install_ca_certs
+register_runner
+# Stop the runner while we configure the sandbox — it currently has
+# executor = "shell" and would accept jobs before the custom executor is ready.
+if sudo systemctl is-active --quiet gitlab-runner 2>/dev/null; then
+  sudo systemctl stop gitlab-runner
+  if sudo systemctl is-active --quiet gitlab-runner 2>/dev/null; then
+    fail "gitlab-runner is still active after stop — refusing to continue with unsandboxed executor"
+  fi
+fi
+setup_runner_user
+setup_podman
+install_openshell
+configure_gateway
+install_ca_hook
+start_gateway
+install_executor
+patch_config
+prepull_images
+sudo systemctl restart gitlab-runner
+verify

--- a/hack/gitlab-runner-vm/vm.yaml
+++ b/hack/gitlab-runner-vm/vm.yaml
@@ -1,0 +1,97 @@
+---
+# VirtualMachine template for a GitLab Runner on OpenShift Virtualization.
+#
+# Creates a Fedora VM with podman, curl, git, and python3 pre-installed
+# via cloud-init. After the VM boots, run setup.sh to register and configure
+# the runner.
+#
+# Usage: ./create-vm.sh (auto-numbers and applies this template)
+#
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: __VM_NAME__
+  labels:
+    app: fullsend-gitlab-runner
+    kubevirt.io/dynamic-credentials-support: "true"
+    vm.kubevirt.io/template: fedora-server-medium
+spec:
+  runStrategy: Always
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: __VM_NAME__
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 20Gi
+  template:
+    metadata:
+      annotations:
+        vm.kubevirt.io/flavor: medium
+        vm.kubevirt.io/os: fedora
+        vm.kubevirt.io/workload: server
+      labels:
+        kubevirt.io/domain: __VM_NAME__
+        kubevirt.io/size: medium
+    spec:
+      architecture: amd64
+      domain:
+        cpu:
+          cores: 4
+          sockets: 1
+          threads: 1
+        memory:
+          guest: 14Gi
+        resources:
+          requests:
+            memory: 14848Mi
+          limits:
+            memory: 15Gi
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade:
+                ports:
+                  - port: 22
+              model: virtio
+              name: default
+          rng: {}
+        features:
+          smm:
+            enabled: true
+        firmware:
+          bootloader:
+            efi: {}
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: __VM_NAME__
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: __VM_USER__
+              ssh_authorized_keys:
+                - __SSH_PUBLIC_KEY__
+              packages:
+                - podman
+                - curl
+                - git
+                - python3
+                - openssl
+          name: cloudinitdisk


### PR DESCRIPTION
## Summary

- Adds `hack/gitlab-runner-vm/` with scripts to provision GitLab Runner VMs on OpenShift Virtualization: `vm.yaml` manifest, `setup.sh` for end-to-end configuration, `create-vm.sh`/`delete-vm.sh` lifecycle helpers, and Podman custom executor scripts (`prepare.sh`, `run.sh`, `cleanup.sh`).
- Installs an OCI `createRuntime` hook that injects the VM's host CA trust bundle into every container's `/etc/ssl/certs/ca-certificates.crt` before PID 1 starts, so the OpenShell supervisor trusts internal CAs (e.g. corporate GitLab) without requiring a custom sandbox image.
- Usage: `oc apply -f vm.yaml`, then `REGISTRATION_TOKEN=glrt-xxx ./setup.sh` — two steps to a fully working runner.

## Test plan

- [x] Deployed runner-01 (ID 65846) and runner-02 (ID 65847) in `fullsend--runtime-int` namespace
- [x] Verified OCI hook injects 148 CAs (including Red Hat internal CA) into sandbox containers
- [x] Verified `curl https://gitlab.cee.redhat.com/api/v4/projects` returns HTTP 200 from inside sandboxes on both runners
- [x] All pre-commit hooks pass (shellcheck, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)