### PR TITLE
feat(#3697): add emoji reaction status notifications

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -204,4 +204,5 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(inputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -575,7 +575,7 @@ jobs:
             pull_request: (.pull_request // null | if . then {number, html_url,
               head: {ref: .head.ref, sha: .head.sha, repo: {full_name: .head.repo.full_name}},
               base: {ref: .base.ref, repo: {full_name: .base.repo.full_name}}} else null end),
-            comment: (.comment // null | if . then {body: .body[:4096]} else null end)
+            comment: (.comment // null | if . then {id, body: .body[:4096]} else null end)
           }' "$GITHUB_EVENT_PATH") || {
             echo "::error::Failed to extract event payload from GITHUB_EVENT_PATH"
             exit 1

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -695,6 +695,7 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(needs.route.outputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}
           pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
@@ -824,6 +825,7 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(needs.route.outputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}
           pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
@@ -943,6 +945,7 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.number || fromJSON(needs.route.outputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(needs.route.outputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}
           pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
@@ -1213,6 +1216,7 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ github.repository }}
           status-number: ${{ steps.context.outputs.pr_number }}
+          status-comment-id: ${{ fromJSON(needs.route.outputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}
           pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
@@ -1315,6 +1319,7 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.number || fromJSON(needs.route.outputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(needs.route.outputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}
           pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
@@ -1730,5 +1735,6 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ matrix.status_repo }}
           status-number: ${{ matrix.status_number }}
+          status-comment-id: ${{ fromJSON(matrix.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}
           pr-head-sha: ${{ fromJSON(matrix.event_payload).pull_request.head.sha || '' }}

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -381,4 +381,5 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ steps.context.outputs.pr_number }}
+          status-comment-id: ${{ fromJSON(inputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -176,4 +176,5 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).pull_request.number || fromJSON(inputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(inputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -192,4 +192,5 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).pull_request.number || fromJSON(inputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(inputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -182,4 +182,5 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).issue.number }}
+          status-comment-id: ${{ fromJSON(inputs.event_payload).comment.id }}
           mint-url: ${{ inputs.mint_url }}

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,12 @@ inputs:
   status-number:
     description: Issue/PR number for status comments (optional).
     default: ""
+  status-comment-id:
+    description: >-
+      ID of the comment that triggered this run via a slash command
+      (optional). When set, status reactions target that comment instead
+      of the issue/PR.
+    default: ""
   mint-url:
     description: >-
       Mint service URL for on-demand GitHub App tokens. Used for both
@@ -380,6 +386,7 @@ runs:
         STATUS_RUN_URL: ${{ inputs.run-url }}
         STATUS_REPO: ${{ inputs.status-repo }}
         STATUS_NUMBER: ${{ inputs.status-number }}
+        STATUS_COMMENT_ID: ${{ inputs.status-comment-id }}
         MINT_URL: ${{ inputs.mint-url }}
         PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
       run: |
@@ -396,6 +403,9 @@ runs:
           STATUS_FLAGS+=(--status-repo "${STATUS_REPO}" --status-number "${STATUS_NUMBER}")
           if [[ -n "${STATUS_RUN_URL}" ]]; then
             STATUS_FLAGS+=(--run-url "${STATUS_RUN_URL}")
+          fi
+          if [[ -n "${STATUS_COMMENT_ID}" ]]; then
+            STATUS_FLAGS+=(--status-comment-id "${STATUS_COMMENT_ID}")
           fi
         fi
         MINT_FLAGS=()

--- a/docs/guides/getting-started/operations.md
+++ b/docs/guides/getting-started/operations.md
@@ -171,15 +171,16 @@ gcloud services enable \
 
 ## Status notifications
 
-See [Status Notifications](../user/customizing-agents.md#status-notifications) for configuring start and completion comments.
+See [Status Notifications](../user/customizing-agents.md#status-notifications) for configuring start/completion comments and reactions.
 
-The composite action accepts four optional inputs for status notifications:
+The composite action accepts five optional inputs for status notifications:
 
 | Input | Description |
 |-------|-------------|
 | `run-url` | URL of the CI/CD run shown in the status comment |
 | `status-repo` | Repository (`owner/repo`) to post status comments on |
 | `status-number` | Issue or PR number for status comments |
+| `status-comment-id` | ID of the comment that triggered a slash-command run; when set, reactions target that comment instead of the issue/PR |
 | `mint-url` | URL of the token mint service used to obtain fresh tokens for posting comments |
 
 All reusable workflows pass these inputs automatically.

--- a/docs/guides/user/customizing-agents.md
+++ b/docs/guides/user/customizing-agents.md
@@ -444,6 +444,32 @@ When `status_notifications` is omitted entirely, both start and completion comme
 
 In `enabled` mode (the default), a hard crash or cancellation that happens before the agent could post anything at all is also surfaced after the fact: a post-job cleanup step synthesizes an "Interrupted" comment so the run doesn't silently vanish.
 
+### Reactions
+
+As an alternative (or supplement) to comments, agents can signal status with emoji reactions on the issue/PR itself. Reactions don't generate a GitHub notification, so they're a lower-noise way to show that an agent is working on something and how it turned out.
+
+```yaml
+defaults:
+  status_notifications:
+    reaction:
+      start: enabled       # "enabled" | "disabled" (default)
+      completion: enabled  # "enabled" | "on_failure" | "disabled" (default)
+```
+
+Unlike comments, reactions default to `disabled` — they're an opt-in addition, not a default-on behavior. When `start` is enabled, a 👀 reaction is added when the agent begins.
+
+At completion, the start reaction (if any) is removed, and — depending on `completion` — replaced with an outcome reaction:
+
+| Value | Behavior |
+|-------|----------|
+| `enabled` | Always add a completion reaction: 👍 on success, 👎 on failure/cancelled/skipped |
+| `on_failure` | Add a 👎 reaction only on failure/cancelled/skipped; leave no reaction on success |
+| `disabled` | Never add a completion reaction (default) |
+
+Because reactions carry no notification cost, `on_failure` here simply means "leave no reaction on success," with no start-suppression workaround needed.
+
+Reactions are currently GitHub-only.
+
 ## Disabling Agents
 
 To disable an agent (including built-in scaffold agents) without removing

--- a/docs/guides/user/customizing-agents.md
+++ b/docs/guides/user/customizing-agents.md
@@ -446,7 +446,7 @@ In `enabled` mode (the default), a hard crash or cancellation that happens befor
 
 ### Reactions
 
-As an alternative (or supplement) to comments, agents can signal status with emoji reactions on the issue/PR itself. Reactions don't generate a GitHub notification, so they're a lower-noise way to show that an agent is working on something and how it turned out.
+As an alternative (or supplement) to comments, agents can signal status with emoji reactions. Reactions don't generate a GitHub notification, so they're a lower-noise way to show that an agent is working on something and how it turned out.
 
 ```yaml
 defaults:
@@ -462,13 +462,20 @@ At completion, the start reaction (if any) is removed, and — depending on `com
 
 | Value | Behavior |
 |-------|----------|
-| `enabled` | Always add a completion reaction: 👍 on success, 👎 on failure/cancelled/skipped |
-| `on_failure` | Add a 👎 reaction only on failure/cancelled/skipped; leave no reaction on success |
+| `enabled` | Always add a completion reaction: 👍 on success, 😕 on failure/cancelled/skipped |
+| `on_failure` | Add a 😕 reaction only on failure/cancelled/skipped; leave no reaction on success |
 | `disabled` | Never add a completion reaction (default) |
+
+👎 is deliberately avoided for failures — it overloads GitHub's native up/down-vote convention, so a routine agent failure could be misread as the bot disliking the issue.
 
 Because reactions carry no notification cost, `on_failure` here simply means "leave no reaction on success," with no start-suppression workaround needed.
 
-Reactions are currently GitHub-only.
+**Where the reaction lands:** for runs triggered by an issue or PR event, the reaction is added to the issue/PR itself. For runs triggered by a slash command comment (e.g. `/fs-fix`), the reaction is added to the triggering comment instead, so it's clear which command the reaction is responding to.
+
+**Known limitations:**
+
+- Reactions are currently GitHub-only. Enabling `reaction.*` on a GitLab-backed repo is silently a no-op today ([#5998](https://github.com/fullsend-ai/fullsend/issues/5998)).
+- If a run is hard-killed before it can post its completion reaction, the start reaction (👀) can be left behind indefinitely — unlike status comments, there's no out-of-process reconciler for orphaned reactions yet.
 
 ## Disabling Agents
 

--- a/e2e/behaviour/features/dispatch/reaction-notifications.feature
+++ b/e2e/behaviour/features/dispatch/reaction-notifications.feature
@@ -1,0 +1,31 @@
+Feature: Emoji reaction status notifications
+
+  Reaction notifications post emoji reactions on issues/PRs at start and
+  completion, as a supplementary/alternative signal to status comments.
+  Reactions do not generate GitHub notifications.
+
+  Background:
+    Given the enrolled test repository
+
+  Scenario: Triage with reactions enabled posts completion reaction
+    Given status notification reactions are enabled
+    And a custom harness "reaction-ping" with:
+      """
+      agent: agents/triage.md
+      role: triage
+      slug: fullsend-ai-reaction-ping
+      model: opus
+      image: ghcr.io/fullsend-ai/fullsend-sandbox:latest
+      trigger: |
+        event.entity.kind == "work_item"
+        && event.transition.kind == "label_changed"
+        && event.transition.label.name == "ready-for-reaction-test"
+      """
+    And a dummy agent that would:
+      | description              | op           | args                                                      |
+      | Emit triage JSON         | write_fixture| output/agent-result.json, fixtures/triage/sufficient.json |
+    And an issue
+    When the issue is labeled "ready-for-reaction-test"
+    Then the harness "reaction-ping" workflow completes successfully
+    And the agent will succeed to Emit triage JSON
+    And the issue has a "+1" reaction

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -139,10 +139,11 @@ type resolveFlags struct {
 
 // statusOpts holds the optional status notification parameters for a run.
 type statusOpts struct {
-	runURL     string
-	statusRepo string
-	statusNum  int
-	mintURL    string
+	runURL        string
+	statusRepo    string
+	statusNum     int
+	statusComment int
+	mintURL       string
 }
 
 // aggregateMetrics holds accumulated behavioral metrics across retry iterations.
@@ -302,6 +303,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&sOpts.runURL, "run-url", "", "URL of the CI/CD run for status comments")
 	cmd.Flags().StringVar(&sOpts.statusRepo, "status-repo", "", "repository (owner/repo) for status comments")
 	cmd.Flags().IntVar(&sOpts.statusNum, "status-number", 0, "issue/PR number for status comments")
+	cmd.Flags().IntVar(&sOpts.statusComment, "status-comment-id", 0, "ID of the triggering comment, for comment-scoped reactions on slash-command runs (optional)")
 	cmd.Flags().StringVar(&sOpts.mintURL, "mint-url", "", "mint service URL for on-demand status tokens (default: $FULLSEND_MINT_URL)")
 	cmd.Flags().StringVar(&oFlags.runtime, "runtime", "", "override the agent runtime from config.yaml for this run (claude, pi or dummy; also $FULLSEND_RUNTIME)")
 	cmd.Flags().StringVar(&oFlags.model, "model", "", "override the harness/agent model for this run (alias such as opus/sonnet/haiku, a model id, or provider/id on pi; also $FULLSEND_MODEL)")
@@ -3849,6 +3851,9 @@ func setupStatusNotifierGitHub(notifyCfg config.StatusNotificationConfig, owner,
 	n.SetWarnFunc(func(format string, args ...any) {
 		printer.StepWarn(fmt.Sprintf(format, args...))
 	})
+	if sOpts.statusComment != 0 {
+		n.SetTriggerCommentID(sOpts.statusComment)
+	}
 
 	canonRole := resolveRole(role)
 	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,16 +117,28 @@ type PerRepoInferenceConfig struct {
 	WIFProvider string `yaml:"wif_provider,omitempty"`
 }
 
-// StatusNotificationConfig controls status comments posted on issues/PRs
-// when agents start and complete.
+// StatusNotificationConfig controls status comments and reactions posted
+// on issues/PRs when agents start and complete.
 type StatusNotificationConfig struct {
-	Comment CommentNotificationConfig `yaml:"comment,omitempty"`
+	Comment  CommentNotificationConfig  `yaml:"comment,omitempty"`
+	Reaction ReactionNotificationConfig `yaml:"reaction,omitempty"`
 }
 
 // CommentNotificationConfig controls start/completion comments.
 // Valid start values: "enabled" (default), "disabled".
 // Valid completion values: "enabled" (default), "on_failure", "disabled".
 type CommentNotificationConfig struct {
+	Start      string `yaml:"start,omitempty"`
+	Completion string `yaml:"completion,omitempty"`
+}
+
+// ReactionNotificationConfig controls start/completion emoji reactions,
+// an alternative to comments that doesn't generate a GitHub notification.
+// Unlike comments, both fields default to "disabled" — reactions are an
+// opt-in addition rather than a default-on behavior.
+// Valid start values: "enabled", "disabled" (default).
+// Valid completion values: "enabled", "on_failure", "disabled" (default).
+type ReactionNotificationConfig struct {
 	Start      string `yaml:"start,omitempty"`
 	Completion string `yaml:"completion,omitempty"`
 }
@@ -464,17 +476,33 @@ func ValidateAgentEntries(agents []AgentEntry, allowlist []string) error {
 	return nil
 }
 
+var (
+	validNotificationStartValues      = []string{"", "enabled", "disabled"}
+	validNotificationCompletionValues = []string{"", "enabled", "disabled", "on_failure"}
+)
+
 func validateStatusNotifications(cfg *StatusNotificationConfig) error {
 	if cfg == nil {
 		return nil
 	}
-	validStartValues := []string{"", "enabled", "disabled"}
-	if !slices.Contains(validStartValues, cfg.Comment.Start) {
-		return fmt.Errorf("invalid status_notifications.comment.start %q: must be \"enabled\" or \"disabled\"", cfg.Comment.Start)
+	if err := validateNotificationValue("status_notifications.comment.start", cfg.Comment.Start, validNotificationStartValues, "\"enabled\" or \"disabled\""); err != nil {
+		return err
 	}
-	validCompletionValues := []string{"", "enabled", "disabled", "on_failure"}
-	if !slices.Contains(validCompletionValues, cfg.Comment.Completion) {
-		return fmt.Errorf("invalid status_notifications.comment.completion %q: must be \"enabled\", \"on_failure\", or \"disabled\"", cfg.Comment.Completion)
+	if err := validateNotificationValue("status_notifications.comment.completion", cfg.Comment.Completion, validNotificationCompletionValues, "\"enabled\", \"on_failure\", or \"disabled\""); err != nil {
+		return err
+	}
+	if err := validateNotificationValue("status_notifications.reaction.start", cfg.Reaction.Start, validNotificationStartValues, "\"enabled\" or \"disabled\""); err != nil {
+		return err
+	}
+	if err := validateNotificationValue("status_notifications.reaction.completion", cfg.Reaction.Completion, validNotificationCompletionValues, "\"enabled\", \"on_failure\", or \"disabled\""); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateNotificationValue(field, val string, allowed []string, description string) error {
+	if !slices.Contains(allowed, val) {
+		return fmt.Errorf("invalid %s %q: must be %s", field, val, description)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -974,6 +974,131 @@ repos: {}
 	assert.Equal(t, "on_failure", cfg.StatusNotifications().Comment.Completion)
 }
 
+// --- Reaction notification tests ---
+
+func TestParseOrgConfig_WithReactionNotifications(t *testing.T) {
+	yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+  status_notifications:
+    reaction:
+      start: enabled
+      completion: on_failure
+agents: []
+repos: {}
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.StatusNotifications())
+	assert.Equal(t, "enabled", cfg.StatusNotifications().Reaction.Start)
+	assert.Equal(t, "on_failure", cfg.StatusNotifications().Reaction.Completion)
+}
+
+func TestOrgConfigValidate_ValidReactionNotifications(t *testing.T) {
+	cfg := &orgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Reaction: ReactionNotificationConfig{Start: "enabled", Completion: "disabled"},
+			},
+		},
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestOrgConfigValidate_InvalidReactionStart(t *testing.T) {
+	cfg := &orgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Reaction: ReactionNotificationConfig{Start: "bogus"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status_notifications.reaction.start")
+}
+
+func TestOrgConfigValidate_InvalidReactionCompletion(t *testing.T) {
+	cfg := &orgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Reaction: ReactionNotificationConfig{Completion: "bogus"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status_notifications.reaction.completion")
+}
+
+func TestOrgConfigValidate_OnFailureReactionCompletion(t *testing.T) {
+	cfg := &orgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Reaction: ReactionNotificationConfig{Completion: "on_failure"},
+			},
+		},
+	}
+	assert.NoError(t, cfg.Validate(), "on_failure should be valid for reaction.completion")
+}
+
+func TestOrgConfigValidate_OnFailureReactionStart_Rejected(t *testing.T) {
+	cfg := &orgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Reaction: ReactionNotificationConfig{Start: "on_failure"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(t, err, "on_failure should be rejected for reaction.start")
+	assert.Contains(t, err.Error(), "status_notifications.reaction.start")
+}
+
+func TestOrgConfigMarshal_WithReactionNotifications(t *testing.T) {
+	cfg := &orgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Reaction: ReactionNotificationConfig{Start: "enabled"},
+			},
+		},
+		Repos: map[string]RepoConfig{},
+	}
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "reaction:")
+	assert.Contains(t, string(data), "start: enabled")
+}
+
 func TestOrgConfigMarshal_WithStatusNotifications(t *testing.T) {
 	cfg := &orgConfig{
 		Version:  "1",

--- a/internal/config/interfaces.go
+++ b/internal/config/interfaces.go
@@ -92,6 +92,7 @@ type ConfigWriter interface {
 	SetKillSwitch(bool)
 	SetAgents([]AgentEntry)
 	SetAllowedRemoteResources([]string)
+	SetStatusNotifications(*StatusNotificationConfig)
 	Marshal() ([]byte, error)
 	Validate() error
 }
@@ -193,6 +194,11 @@ func (c *orgConfig) SetInference(i InferenceConfig) { c.Inference = i }
 
 // SetDefaultRuntime replaces the default agent runtime.
 func (c *orgConfig) SetDefaultRuntime(rt string) { c.Defaults.Runtime = rt }
+
+// SetStatusNotifications sets the status notification configuration.
+func (c *orgConfig) SetStatusNotifications(sn *StatusNotificationConfig) {
+	c.Defaults.StatusNotifications = sn
+}
 
 // SetRepo adds or replaces a per-repo configuration entry.
 // Callers should use this method instead of mutating the map returned
@@ -507,6 +513,11 @@ func (c *perRepoConfig) SetInferenceProject(project string) { c.ensureInference(
 
 // SetInferenceRegion sets the GCP region for inference.
 func (c *perRepoConfig) SetInferenceRegion(region string) { c.ensureInference().Region = region }
+
+// SetStatusNotifications sets the status notification configuration.
+func (c *perRepoConfig) SetStatusNotifications(sn *StatusNotificationConfig) {
+	c.Notifications = sn
+}
 
 // SetInferenceWIFProvider sets the WIF provider resource name.
 func (c *perRepoConfig) SetInferenceWIFProvider(wifProvider string) {

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -92,6 +92,13 @@ type ReactionRecord struct {
 	Content     string
 }
 
+// CommentReactionRecord records an AddIssueCommentReaction call.
+type CommentReactionRecord struct {
+	Owner, Repo string
+	CommentID   int
+	Content     string
+}
+
 // ReviewRecord records a pull request review creation call.
 type ReviewRecord struct {
 	Owner, Repo string
@@ -265,40 +272,42 @@ type FakeClient struct {
 	Annotations []Annotation
 
 	// Call recorders
-	CreatedRepos           []Repository
-	CreatedFiles           []FileRecord
-	CreatedBranches        []string // "owner/repo/branch"
-	CreatedBranchSHAs      []BranchSHARecord
-	DeletedRefs            []string // "owner/repo/refPath"
-	CreatedProposals       []ChangeProposal
-	DeletedRepos           []string // "owner/repo"
-	DeletedFiles           []FileRecord
-	CreatedSecrets         []SecretRecord
-	DeletedSecrets         []SecretRecord
-	Variables              []VariableRecord
-	DeletedVariables       []VariableRecord
-	DeletedOrgSecrets      []string // "org/name"
-	CreatedOrgSecrets      []OrgSecretRecord
-	CreatedOrgVariables    []OrgVariableRecord
-	DeletedOrgVariables    []string // "org/name"
-	CreatedIssues          []CreatedIssueRecord
-	UpdatedComments        []UpdatedCommentRecord
-	MinimizedComments      []MinimizedCommentRecord
-	AddedReactions         []ReactionRecord
-	DeletedReactions       []int64
-	CreatedReviews         []ReviewRecord
-	DismissedReviews       []DismissedReviewRecord
-	CommittedFiles         []CommitFilesRecord
-	CommittedFilesToBranch []CommitFilesToBranchRecord
-	CreatedForks           []string // "owner/repo"
-	ClosedProposals        []int    // PR numbers
-	DeletedComments        []int    // comment IDs
-	CreatedPipelines       []Pipeline
-	PipelineCalls          []PipelineCallRecord
-	CreatedSchedules       []PipelineSchedule
-	DeletedScheduleIDs     []int64
-	UpdatedVariables       []VariableRecord
-	CreatedProtectedVars   []VariableRecord
+	CreatedRepos            []Repository
+	CreatedFiles            []FileRecord
+	CreatedBranches         []string // "owner/repo/branch"
+	CreatedBranchSHAs       []BranchSHARecord
+	DeletedRefs             []string // "owner/repo/refPath"
+	CreatedProposals        []ChangeProposal
+	DeletedRepos            []string // "owner/repo"
+	DeletedFiles            []FileRecord
+	CreatedSecrets          []SecretRecord
+	DeletedSecrets          []SecretRecord
+	Variables               []VariableRecord
+	DeletedVariables        []VariableRecord
+	DeletedOrgSecrets       []string // "org/name"
+	CreatedOrgSecrets       []OrgSecretRecord
+	CreatedOrgVariables     []OrgVariableRecord
+	DeletedOrgVariables     []string // "org/name"
+	CreatedIssues           []CreatedIssueRecord
+	UpdatedComments         []UpdatedCommentRecord
+	MinimizedComments       []MinimizedCommentRecord
+	AddedReactions          []ReactionRecord
+	DeletedReactions        []int64
+	AddedCommentReactions   []CommentReactionRecord
+	DeletedCommentReactions []int64
+	CreatedReviews          []ReviewRecord
+	DismissedReviews        []DismissedReviewRecord
+	CommittedFiles          []CommitFilesRecord
+	CommittedFilesToBranch  []CommitFilesToBranchRecord
+	CreatedForks            []string // "owner/repo"
+	ClosedProposals         []int    // PR numbers
+	DeletedComments         []int    // comment IDs
+	CreatedPipelines        []Pipeline
+	PipelineCalls           []PipelineCallRecord
+	CreatedSchedules        []PipelineSchedule
+	DeletedScheduleIDs      []int64
+	UpdatedVariables        []VariableRecord
+	CreatedProtectedVars    []VariableRecord
 
 	// CommitAncestry maps "owner/repo/base/head" to a comparison status
 	// string ("ahead", "behind", "identical", "diverged") for CompareCommits.
@@ -1466,6 +1475,32 @@ func (f *FakeClient) DeleteIssueReaction(_ context.Context, _, _ string, _ int, 
 		return e
 	}
 	f.DeletedReactions = append(f.DeletedReactions, reactionID)
+	return nil
+}
+
+func (f *FakeClient) AddIssueCommentReaction(_ context.Context, owner, repo string, commentID int, content string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("AddIssueCommentReaction"); e != nil {
+		return 0, e
+	}
+	f.reactionCounter++
+	f.AddedCommentReactions = append(f.AddedCommentReactions, CommentReactionRecord{
+		Owner:     owner,
+		Repo:      repo,
+		CommentID: commentID,
+		Content:   content,
+	})
+	return f.reactionCounter, nil
+}
+
+func (f *FakeClient) DeleteIssueCommentReaction(_ context.Context, _, _ string, _ int, reactionID int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("DeleteIssueCommentReaction"); e != nil {
+		return e
+	}
+	f.DeletedCommentReactions = append(f.DeletedCommentReactions, reactionID)
 	return nil
 }
 

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -85,6 +85,13 @@ type MinimizedCommentRecord struct {
 	Reason string
 }
 
+// ReactionRecord records an AddIssueReaction call.
+type ReactionRecord struct {
+	Owner, Repo string
+	Number      int
+	Content     string
+}
+
 // ReviewRecord records a pull request review creation call.
 type ReviewRecord struct {
 	Owner, Repo string
@@ -277,6 +284,8 @@ type FakeClient struct {
 	CreatedIssues          []CreatedIssueRecord
 	UpdatedComments        []UpdatedCommentRecord
 	MinimizedComments      []MinimizedCommentRecord
+	AddedReactions         []ReactionRecord
+	DeletedReactions       []int64
 	CreatedReviews         []ReviewRecord
 	DismissedReviews       []DismissedReviewRecord
 	CommittedFiles         []CommitFilesRecord
@@ -299,6 +308,7 @@ type FakeClient struct {
 	proposalCounter int
 	commentCounter  int
 	issueCounter    int
+	reactionCounter int64
 }
 
 // err checks for an injected error for the given method name.
@@ -1430,6 +1440,32 @@ func (f *FakeClient) MinimizeComment(_ context.Context, nodeID, reason string) e
 		NodeID: nodeID,
 		Reason: reason,
 	})
+	return nil
+}
+
+func (f *FakeClient) AddIssueReaction(_ context.Context, owner, repo string, number int, content string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("AddIssueReaction"); e != nil {
+		return 0, e
+	}
+	f.reactionCounter++
+	f.AddedReactions = append(f.AddedReactions, ReactionRecord{
+		Owner:   owner,
+		Repo:    repo,
+		Number:  number,
+		Content: content,
+	})
+	return f.reactionCounter, nil
+}
+
+func (f *FakeClient) DeleteIssueReaction(_ context.Context, _, _ string, _ int, reactionID int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("DeleteIssueReaction"); e != nil {
+		return e
+	}
+	f.DeletedReactions = append(f.DeletedReactions, reactionID)
 	return nil
 }
 

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -87,6 +87,7 @@ type MinimizedCommentRecord struct {
 
 // ReactionRecord records an AddIssueReaction call.
 type ReactionRecord struct {
+	ID          int64
 	Owner, Repo string
 	Number      int
 	Content     string
@@ -1460,6 +1461,7 @@ func (f *FakeClient) AddIssueReaction(_ context.Context, owner, repo string, num
 	}
 	f.reactionCounter++
 	f.AddedReactions = append(f.AddedReactions, ReactionRecord{
+		ID:      f.reactionCounter,
 		Owner:   owner,
 		Repo:    repo,
 		Number:  number,
@@ -1510,9 +1512,13 @@ func (f *FakeClient) ListIssueReactions(_ context.Context, owner, repo string, n
 	if e := f.err("ListIssueReactions"); e != nil {
 		return nil, e
 	}
+	deleted := make(map[int64]bool, len(f.DeletedReactions))
+	for _, id := range f.DeletedReactions {
+		deleted[id] = true
+	}
 	var reactions []Reaction
 	for _, r := range f.AddedReactions {
-		if r.Owner == owner && r.Repo == repo && r.Number == number {
+		if r.Owner == owner && r.Repo == repo && r.Number == number && !deleted[r.ID] {
 			reactions = append(reactions, Reaction{
 				Content: r.Content,
 				User:    f.AuthenticatedUser,

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -1504,6 +1504,24 @@ func (f *FakeClient) DeleteIssueCommentReaction(_ context.Context, _, _ string, 
 	return nil
 }
 
+func (f *FakeClient) ListIssueReactions(_ context.Context, owner, repo string, number int) ([]Reaction, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("ListIssueReactions"); e != nil {
+		return nil, e
+	}
+	var reactions []Reaction
+	for _, r := range f.AddedReactions {
+		if r.Owner == owner && r.Repo == repo && r.Number == number {
+			reactions = append(reactions, Reaction{
+				Content: r.Content,
+				User:    f.AuthenticatedUser,
+			})
+		}
+	}
+	return reactions, nil
+}
+
 func (f *FakeClient) GetPullRequestInfo(_ context.Context, owner, repo string, number int) (*PullRequestInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -1208,8 +1208,8 @@ func TestFakeClient_AddIssueReaction(t *testing.T) {
 	assert.NotZero(t, id1)
 	assert.NotEqual(t, id1, id2)
 	require.Len(t, fc.AddedReactions, 2)
-	assert.Equal(t, ReactionRecord{Owner: "org", Repo: "repo", Number: 7, Content: "eyes"}, fc.AddedReactions[0])
-	assert.Equal(t, ReactionRecord{Owner: "org", Repo: "repo", Number: 7, Content: "+1"}, fc.AddedReactions[1])
+	assert.Equal(t, ReactionRecord{ID: id1, Owner: "org", Repo: "repo", Number: 7, Content: "eyes"}, fc.AddedReactions[0])
+	assert.Equal(t, ReactionRecord{ID: id2, Owner: "org", Repo: "repo", Number: 7, Content: "+1"}, fc.AddedReactions[1])
 }
 
 func TestFakeClient_DeleteIssueReaction(t *testing.T) {

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -1229,6 +1229,38 @@ func TestFakeClient_ReactionErrorInjection(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestFakeClient_AddIssueCommentReaction(t *testing.T) {
+	fc := NewFakeClient()
+
+	id1, err := fc.AddIssueCommentReaction(context.Background(), "org", "repo", 555, "eyes")
+	require.NoError(t, err)
+	id2, err := fc.AddIssueCommentReaction(context.Background(), "org", "repo", 555, "+1")
+	require.NoError(t, err)
+
+	assert.NotZero(t, id1)
+	assert.NotEqual(t, id1, id2)
+	require.Len(t, fc.AddedCommentReactions, 2)
+	assert.Equal(t, CommentReactionRecord{Owner: "org", Repo: "repo", CommentID: 555, Content: "eyes"}, fc.AddedCommentReactions[0])
+	assert.Equal(t, CommentReactionRecord{Owner: "org", Repo: "repo", CommentID: 555, Content: "+1"}, fc.AddedCommentReactions[1])
+}
+
+func TestFakeClient_DeleteIssueCommentReaction(t *testing.T) {
+	fc := NewFakeClient()
+	id, err := fc.AddIssueCommentReaction(context.Background(), "org", "repo", 555, "eyes")
+	require.NoError(t, err)
+
+	require.NoError(t, fc.DeleteIssueCommentReaction(context.Background(), "org", "repo", 555, id))
+	assert.Equal(t, []int64{id}, fc.DeletedCommentReactions)
+}
+
+func TestFakeClient_CommentReactionErrorInjection(t *testing.T) {
+	fc := NewFakeClient()
+	fc.Errors = map[string]error{"AddIssueCommentReaction": errors.New("boom")}
+
+	_, err := fc.AddIssueCommentReaction(context.Background(), "org", "repo", 555, "eyes")
+	assert.Error(t, err)
+}
+
 func TestFakeClient_ListRecentWorkflowRuns(t *testing.T) {
 	fc := NewFakeClient()
 	fc.RecentWorkflowRuns = map[string][]WorkflowRun{

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -1197,6 +1197,38 @@ func TestFakeClient_AddIssueLabels(t *testing.T) {
 	require.Error(t, fc.AddIssueLabels(context.Background(), "org", "repo", 999, "x"))
 }
 
+func TestFakeClient_AddIssueReaction(t *testing.T) {
+	fc := NewFakeClient()
+
+	id1, err := fc.AddIssueReaction(context.Background(), "org", "repo", 7, "eyes")
+	require.NoError(t, err)
+	id2, err := fc.AddIssueReaction(context.Background(), "org", "repo", 7, "+1")
+	require.NoError(t, err)
+
+	assert.NotZero(t, id1)
+	assert.NotEqual(t, id1, id2)
+	require.Len(t, fc.AddedReactions, 2)
+	assert.Equal(t, ReactionRecord{Owner: "org", Repo: "repo", Number: 7, Content: "eyes"}, fc.AddedReactions[0])
+	assert.Equal(t, ReactionRecord{Owner: "org", Repo: "repo", Number: 7, Content: "+1"}, fc.AddedReactions[1])
+}
+
+func TestFakeClient_DeleteIssueReaction(t *testing.T) {
+	fc := NewFakeClient()
+	id, err := fc.AddIssueReaction(context.Background(), "org", "repo", 7, "eyes")
+	require.NoError(t, err)
+
+	require.NoError(t, fc.DeleteIssueReaction(context.Background(), "org", "repo", 7, id))
+	assert.Equal(t, []int64{id}, fc.DeletedReactions)
+}
+
+func TestFakeClient_ReactionErrorInjection(t *testing.T) {
+	fc := NewFakeClient()
+	fc.Errors = map[string]error{"AddIssueReaction": errors.New("boom")}
+
+	_, err := fc.AddIssueReaction(context.Background(), "org", "repo", 7, "eyes")
+	assert.Error(t, err)
+}
+
 func TestFakeClient_ListRecentWorkflowRuns(t *testing.T) {
 	fc := NewFakeClient()
 	fc.RecentWorkflowRuns = map[string][]WorkflowRun{

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -600,6 +600,20 @@ type Client interface {
 	DeleteIssueComment(ctx context.Context, owner, repo string, commentID int) error
 	MinimizeComment(ctx context.Context, nodeID, reason string) error
 
+	// AddIssueReaction adds an emoji reaction to an issue or pull request.
+	// content must be one of the values accepted by the forge: on GitHub,
+	// "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes".
+	// It returns the reaction's ID, used to remove it later via
+	// DeleteIssueReaction. Unlike comments, reactions do not generate
+	// GitHub notifications, making them useful for low-noise status
+	// signaling. Returns forge.ErrNotSupported if the forge has no
+	// equivalent concept.
+	AddIssueReaction(ctx context.Context, owner, repo string, number int, content string) (id int64, err error)
+
+	// DeleteIssueReaction removes a previously added reaction by ID.
+	// Returns forge.ErrNotSupported if the forge has no equivalent concept.
+	DeleteIssueReaction(ctx context.Context, owner, repo string, number int, reactionID int64) error
+
 	// Pull request operations
 	GetPullRequestInfo(ctx context.Context, owner, repo string, number int) (*PullRequestInfo, error)
 	GetPullRequestHeadSHA(ctx context.Context, owner, repo string, number int) (string, error)

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -614,6 +614,19 @@ type Client interface {
 	// Returns forge.ErrNotSupported if the forge has no equivalent concept.
 	DeleteIssueReaction(ctx context.Context, owner, repo string, number int, reactionID int64) error
 
+	// AddIssueCommentReaction adds an emoji reaction to a specific comment,
+	// rather than the issue/PR itself. Used when a run was triggered by a
+	// slash command, so the reaction targets the comment that invoked the
+	// agent instead of the issue/PR. See AddIssueReaction for content
+	// values. Returns forge.ErrNotSupported if the forge has no equivalent
+	// concept.
+	AddIssueCommentReaction(ctx context.Context, owner, repo string, commentID int, content string) (id int64, err error)
+
+	// DeleteIssueCommentReaction removes a previously added comment
+	// reaction by ID. Returns forge.ErrNotSupported if the forge has no
+	// equivalent concept.
+	DeleteIssueCommentReaction(ctx context.Context, owner, repo string, commentID int, reactionID int64) error
+
 	// Pull request operations
 	GetPullRequestInfo(ctx context.Context, owner, repo string, number int) (*PullRequestInfo, error)
 	GetPullRequestHeadSHA(ctx context.Context, owner, repo string, number int) (string, error)

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -251,6 +251,14 @@ type IssueComment struct {
 	CreatedAt string
 }
 
+// Reaction represents an emoji reaction on an issue, pull request,
+// or comment.
+type Reaction struct {
+	ID      int64
+	Content string // e.g. "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
+	User    string // login of the user who added the reaction
+}
+
 // PullRequestReview represents a formal review on a pull request.
 type PullRequestReview struct {
 	ID          int
@@ -626,6 +634,11 @@ type Client interface {
 	// reaction by ID. Returns forge.ErrNotSupported if the forge has no
 	// equivalent concept.
 	DeleteIssueCommentReaction(ctx context.Context, owner, repo string, commentID int, reactionID int64) error
+
+	// ListIssueReactions returns the emoji reactions on an issue or
+	// pull request. Returns forge.ErrNotSupported if the forge has no
+	// equivalent concept.
+	ListIssueReactions(ctx context.Context, owner, repo string, number int) ([]Reaction, error)
 
 	// Pull request operations
 	GetPullRequestInfo(ctx context.Context, owner, repo string, number int) (*PullRequestInfo, error)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -2855,29 +2855,35 @@ func (c *LiveClient) DeleteIssueCommentReaction(ctx context.Context, owner, repo
 
 // ListIssueReactions returns the emoji reactions on an issue or pull request.
 func (c *LiveClient) ListIssueReactions(ctx context.Context, owner, repo string, number int) ([]forge.Reaction, error) {
-	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/reactions", owner, repo, number))
-	if err != nil {
-		return nil, fmt.Errorf("list issue reactions on #%d: %w", number, err)
-	}
-	var items []struct {
-		ID      int64  `json:"id"`
-		Content string `json:"content"`
-		User    struct {
-			Login string `json:"login"`
-		} `json:"user"`
-	}
-	if err := decodeJSON(resp, &items); err != nil {
-		return nil, fmt.Errorf("decode issue reactions: %w", err)
-	}
-	reactions := make([]forge.Reaction, len(items))
-	for i, item := range items {
-		reactions[i] = forge.Reaction{
-			ID:      item.ID,
-			Content: item.Content,
-			User:    item.User.Login,
+	var result []forge.Reaction
+
+	for page := 1; page <= 100; page++ {
+		resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/reactions?per_page=100&page=%d", owner, repo, number, page))
+		if err != nil {
+			return nil, fmt.Errorf("list issue reactions on #%d page %d: %w", number, page, err)
+		}
+		var items []struct {
+			ID      int64  `json:"id"`
+			Content string `json:"content"`
+			User    struct {
+				Login string `json:"login"`
+			} `json:"user"`
+		}
+		if err := decodeJSON(resp, &items); err != nil {
+			return nil, fmt.Errorf("decode issue reactions page %d: %w", page, err)
+		}
+		for _, item := range items {
+			result = append(result, forge.Reaction{
+				ID:      item.ID,
+				Content: item.Content,
+				User:    item.User.Login,
+			})
+		}
+		if len(items) < 100 {
+			break
 		}
 	}
-	return reactions, nil
+	return result, nil
 }
 
 // GetPullRequestInfo returns branch/repo context for a pull request.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -15,6 +15,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -2800,6 +2801,33 @@ func (c *LiveClient) MinimizeComment(ctx context.Context, nodeID, reason string)
 		return fmt.Errorf("minimize comment %s: %s", nodeID, gqlResult.Errors[0].Message)
 	}
 	return nil
+}
+
+// validReactionContent lists the emoji reaction values accepted by the
+// GitHub reactions API.
+var validReactionContent = []string{"+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"}
+
+// AddIssueReaction adds an emoji reaction to an issue or pull request.
+func (c *LiveClient) AddIssueReaction(ctx context.Context, owner, repo string, number int, content string) (int64, error) {
+	if !slices.Contains(validReactionContent, content) {
+		return 0, fmt.Errorf("add issue reaction: invalid content %q", content)
+	}
+	resp, err := c.post(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/reactions", owner, repo, number), map[string]string{"content": content})
+	if err != nil {
+		return 0, fmt.Errorf("add issue reaction on #%d: %w", number, err)
+	}
+	var result struct {
+		ID int64 `json:"id"`
+	}
+	if err := decodeJSON(resp, &result); err != nil {
+		return 0, fmt.Errorf("decode issue reaction: %w", err)
+	}
+	return result.ID, nil
+}
+
+// DeleteIssueReaction removes a previously added reaction by ID.
+func (c *LiveClient) DeleteIssueReaction(ctx context.Context, owner, repo string, number int, reactionID int64) error {
+	return c.delete_(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/reactions/%d", owner, repo, number, reactionID))
 }
 
 // GetPullRequestInfo returns branch/repo context for a pull request.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -2830,6 +2830,29 @@ func (c *LiveClient) DeleteIssueReaction(ctx context.Context, owner, repo string
 	return c.delete_(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/reactions/%d", owner, repo, number, reactionID))
 }
 
+// AddIssueCommentReaction adds an emoji reaction to an issue/PR comment.
+func (c *LiveClient) AddIssueCommentReaction(ctx context.Context, owner, repo string, commentID int, content string) (int64, error) {
+	if !slices.Contains(validReactionContent, content) {
+		return 0, fmt.Errorf("add issue comment reaction: invalid content %q", content)
+	}
+	resp, err := c.post(ctx, fmt.Sprintf("/repos/%s/%s/issues/comments/%d/reactions", owner, repo, commentID), map[string]string{"content": content})
+	if err != nil {
+		return 0, fmt.Errorf("add issue comment reaction on comment %d: %w", commentID, err)
+	}
+	var result struct {
+		ID int64 `json:"id"`
+	}
+	if err := decodeJSON(resp, &result); err != nil {
+		return 0, fmt.Errorf("decode issue comment reaction: %w", err)
+	}
+	return result.ID, nil
+}
+
+// DeleteIssueCommentReaction removes a previously added comment reaction by ID.
+func (c *LiveClient) DeleteIssueCommentReaction(ctx context.Context, owner, repo string, commentID int, reactionID int64) error {
+	return c.delete_(ctx, fmt.Sprintf("/repos/%s/%s/issues/comments/%d/reactions/%d", owner, repo, commentID, reactionID))
+}
+
 // GetPullRequestInfo returns branch/repo context for a pull request.
 func (c *LiveClient) GetPullRequestInfo(ctx context.Context, owner, repo string, number int) (*forge.PullRequestInfo, error) {
 	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number))

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -2853,6 +2853,33 @@ func (c *LiveClient) DeleteIssueCommentReaction(ctx context.Context, owner, repo
 	return c.delete_(ctx, fmt.Sprintf("/repos/%s/%s/issues/comments/%d/reactions/%d", owner, repo, commentID, reactionID))
 }
 
+// ListIssueReactions returns the emoji reactions on an issue or pull request.
+func (c *LiveClient) ListIssueReactions(ctx context.Context, owner, repo string, number int) ([]forge.Reaction, error) {
+	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/reactions", owner, repo, number))
+	if err != nil {
+		return nil, fmt.Errorf("list issue reactions on #%d: %w", number, err)
+	}
+	var items []struct {
+		ID      int64  `json:"id"`
+		Content string `json:"content"`
+		User    struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := decodeJSON(resp, &items); err != nil {
+		return nil, fmt.Errorf("decode issue reactions: %w", err)
+	}
+	reactions := make([]forge.Reaction, len(items))
+	for i, item := range items {
+		reactions[i] = forge.Reaction{
+			ID:      item.ID,
+			Content: item.Content,
+			User:    item.User.Login,
+		}
+	}
+	return reactions, nil
+}
+
 // GetPullRequestInfo returns branch/repo context for a pull request.
 func (c *LiveClient) GetPullRequestInfo(ctx context.Context, owner, repo string, number int) (*forge.PullRequestInfo, error) {
 	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number))

--- a/internal/forge/github/github_comment_test.go
+++ b/internal/forge/github/github_comment_test.go
@@ -534,3 +534,47 @@ func TestListPullRequestReviews(t *testing.T) {
 	assert.Equal(t, "APPROVED", reviews[0].State)
 	assert.Equal(t, "LGTM", reviews[0].Body)
 }
+
+func TestAddIssueReaction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/42/reactions", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "eyes", body["content"])
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": 789})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	id, err := client.AddIssueReaction(context.Background(), "owner", "repo", 42, "eyes")
+	require.NoError(t, err)
+	assert.Equal(t, int64(789), id)
+}
+
+func TestAddIssueReaction_InvalidContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("request should not be sent for invalid content")
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.AddIssueReaction(context.Background(), "owner", "repo", 42, "bogus")
+	assert.Error(t, err)
+}
+
+func TestDeleteIssueReaction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/42/reactions/789", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.DeleteIssueReaction(context.Background(), "owner", "repo", 42, 789)
+	require.NoError(t, err)
+}

--- a/internal/forge/github/github_comment_test.go
+++ b/internal/forge/github/github_comment_test.go
@@ -578,3 +578,47 @@ func TestDeleteIssueReaction(t *testing.T) {
 	err := client.DeleteIssueReaction(context.Background(), "owner", "repo", 42, 789)
 	require.NoError(t, err)
 }
+
+func TestAddIssueCommentReaction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/comments/555/reactions", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "eyes", body["content"])
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": 789})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	id, err := client.AddIssueCommentReaction(context.Background(), "owner", "repo", 555, "eyes")
+	require.NoError(t, err)
+	assert.Equal(t, int64(789), id)
+}
+
+func TestAddIssueCommentReaction_InvalidContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("request should not be sent for invalid content")
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.AddIssueCommentReaction(context.Background(), "owner", "repo", 555, "bogus")
+	assert.Error(t, err)
+}
+
+func TestDeleteIssueCommentReaction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/comments/555/reactions/789", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.DeleteIssueCommentReaction(context.Background(), "owner", "repo", 555, 789)
+	require.NoError(t, err)
+}

--- a/internal/forge/gitlab/issue.go
+++ b/internal/forge/gitlab/issue.go
@@ -381,6 +381,16 @@ func (c *LiveClient) DeleteIssueReaction(_ context.Context, _, _ string, _ int, 
 	return forge.ErrNotSupported
 }
 
+// AddIssueCommentReaction is not yet implemented for GitLab. See AddIssueReaction.
+func (c *LiveClient) AddIssueCommentReaction(_ context.Context, _, _ string, _ int, _ string) (int64, error) {
+	return 0, forge.ErrNotSupported
+}
+
+// DeleteIssueCommentReaction is not yet implemented for GitLab. See AddIssueReaction.
+func (c *LiveClient) DeleteIssueCommentReaction(_ context.Context, _, _ string, _ int, _ int64) error {
+	return forge.ErrNotSupported
+}
+
 // projectWebURL returns the web URL for a project (without trailing slash).
 func (c *LiveClient) projectWebURL(owner, repo string) string {
 	return c.baseURL + "/" + owner + "/" + repo

--- a/internal/forge/gitlab/issue.go
+++ b/internal/forge/gitlab/issue.go
@@ -369,6 +369,18 @@ func (c *LiveClient) MinimizeComment(_ context.Context, _, _ string) error {
 	return forge.ErrNotSupported
 }
 
+// AddIssueReaction is not yet implemented for GitLab. GitLab has an
+// equivalent "award emoji" API, but no caller currently exercises this
+// path on GitLab, so it is left unimplemented rather than guessed at.
+func (c *LiveClient) AddIssueReaction(_ context.Context, _, _ string, _ int, _ string) (int64, error) {
+	return 0, forge.ErrNotSupported
+}
+
+// DeleteIssueReaction is not yet implemented for GitLab. See AddIssueReaction.
+func (c *LiveClient) DeleteIssueReaction(_ context.Context, _, _ string, _ int, _ int64) error {
+	return forge.ErrNotSupported
+}
+
 // projectWebURL returns the web URL for a project (without trailing slash).
 func (c *LiveClient) projectWebURL(owner, repo string) string {
 	return c.baseURL + "/" + owner + "/" + repo

--- a/internal/forge/gitlab/issue.go
+++ b/internal/forge/gitlab/issue.go
@@ -369,6 +369,11 @@ func (c *LiveClient) MinimizeComment(_ context.Context, _, _ string) error {
 	return forge.ErrNotSupported
 }
 
+// ListIssueReactions is not yet implemented for GitLab. See AddIssueReaction.
+func (c *LiveClient) ListIssueReactions(_ context.Context, _, _ string, _ int) ([]forge.Reaction, error) {
+	return nil, forge.ErrNotSupported
+}
+
 // AddIssueReaction is not yet implemented for GitLab. GitLab has an
 // equivalent "award emoji" API, but no caller currently exercises this
 // path on GitLab, so it is left unimplemented rather than guessed at.

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -521,7 +521,7 @@ jobs:
             pull_request: (.pull_request // null | if . then {number, html_url,
               head: {ref: .head.ref, sha: .head.sha, repo: {full_name: .head.repo.full_name}},
               base: {ref: .base.ref, repo: {full_name: .base.repo.full_name}}} else null end),
-            comment: (.comment // null | if . then {body: .body[:4096]} else null end)
+            comment: (.comment // null | if . then {id, body: .body[:4096]} else null end)
           }' "$GITHUB_EVENT_PATH")
 
           # For issue_comment events on PRs, the raw event has no top-level

--- a/internal/statuscomment/statuscomment.go
+++ b/internal/statuscomment/statuscomment.go
@@ -77,11 +77,12 @@ type Notifier struct {
 	sha           string
 	marker        string
 
-	startCommentID int
-	startTime      time.Time
-	now            func() time.Time
-	warnf          func(string, ...any)
-	runInfo        *RunInfo
+	startCommentID  int
+	startReactionID int64
+	startTime       time.Time
+	now             func() time.Time
+	warnf           func(string, ...any)
+	runInfo         *RunInfo
 }
 
 // New creates a Notifier. The runID is embedded in the HTML marker comment
@@ -154,15 +155,46 @@ func commentEnabled(val string) bool {
 	return val == "" || val == "enabled"
 }
 
+// reactionEnabled reports whether a reaction setting is turned on. Unlike
+// commentEnabled, the empty value means disabled: reactions are an opt-in
+// addition rather than a default-on behavior.
+func reactionEnabled(val string) bool {
+	return val == "enabled"
+}
+
+// isFailureStatus reports whether status represents a non-success outcome,
+// used by the "on_failure" completion mode shared by comments and reactions.
+func isFailureStatus(status string) bool {
+	return status == "failure" || status == "cancelled" || status == "skipped"
+}
+
 // shouldPostCompletion reports whether a completion comment should be
 // posted given the configured value and the agent outcome status.
 func shouldPostCompletion(val, status string) bool {
-	switch val {
-	case "on_failure":
-		return status == "failure" || status == "cancelled" || status == "skipped"
-	default:
-		return commentEnabled(val)
+	if val == "on_failure" {
+		return isFailureStatus(status)
 	}
+	return commentEnabled(val)
+}
+
+// shouldPostReactionCompletion reports whether a completion reaction
+// should be posted given the configured value and the agent outcome
+// status. Mirrors shouldPostCompletion, but defaults to disabled.
+func shouldPostReactionCompletion(val, status string) bool {
+	if val == "on_failure" {
+		return isFailureStatus(status)
+	}
+	return reactionEnabled(val)
+}
+
+// reactionForStatus maps an agent outcome status to a GitHub reaction
+// content value. success gets a thumbs-up; anything else (failure,
+// cancelled, skipped, or unrecognized) gets a thumbs-down.
+func reactionForStatus(status string) string {
+	if status == "success" {
+		return "+1"
+	}
+	return "-1"
 }
 
 // PostStart posts a start comment on the issue/PR.
@@ -174,16 +206,39 @@ func shouldPostCompletion(val, status string) bool {
 func (n *Notifier) PostStart(ctx context.Context, description string) error {
 	n.startTime = n.now().UTC()
 
-	if commentEnabled(n.cfg.Comment.Start) && n.cfg.Comment.Completion != "on_failure" {
+	postComment := commentEnabled(n.cfg.Comment.Start) && n.cfg.Comment.Completion != "on_failure"
+	postReaction := reactionEnabled(n.cfg.Reaction.Start)
+
+	if postComment || postReaction {
 		if err := n.refreshClient(ctx); err != nil {
-			return err
+			if postComment {
+				return err
+			}
+			// Only the reaction was requested; fail open — a reaction is a
+			// nice-to-have signal, not something that should abort the run.
+			n.warnf("failed to mint token for start reaction: %v", err)
+			return nil
 		}
+	}
+
+	if postComment {
 		body := n.buildStartBody(description)
 		comment, err := n.client.CreateIssueComment(ctx, n.owner, n.repo, n.number, body)
 		if err != nil {
 			return fmt.Errorf("posting start comment: %w", err)
 		}
 		n.startCommentID = comment.ID
+	}
+
+	if postReaction {
+		id, err := n.client.AddIssueReaction(ctx, n.owner, n.repo, n.number, "eyes")
+		if err != nil {
+			// Fail open: a reaction is a nice-to-have signal, not something
+			// that should abort the agent run.
+			n.warnf("failed to add start reaction: %v", err)
+		} else {
+			n.startReactionID = id
+		}
 	}
 
 	return nil
@@ -215,22 +270,33 @@ func (n *Notifier) PostCompletion(ctx context.Context, description, status strin
 func (n *Notifier) PostCompletionWithDetail(ctx context.Context, description, status, detail string) error {
 	completionTime := n.now().UTC()
 
-	if !shouldPostCompletion(n.cfg.Comment.Completion, status) {
+	postComment := shouldPostCompletion(n.cfg.Comment.Completion, status)
+	cleanupComment := !postComment && n.startCommentID != 0
+	cleanupReaction := n.startReactionID != 0
+	postReaction := shouldPostReactionCompletion(n.cfg.Reaction.Completion, status)
+
+	if postComment || cleanupComment || cleanupReaction || postReaction {
+		if err := n.refreshClient(ctx); err != nil {
+			if postComment {
+				return err
+			}
+			n.warnf("failed to mint token for completion: %v", err)
+			return nil
+		}
+	}
+
+	n.postCompletionReaction(ctx, status, cleanupReaction, postReaction)
+
+	if !postComment {
 		// Completion comment suppressed (disabled or on_failure with success) —
 		// clean up the start comment so it doesn't remain orphaned in its
 		// "Started" state.
-		if n.startCommentID != 0 {
-			if err := n.refreshClient(ctx); err != nil {
-				n.warnf("failed to mint token for start comment cleanup: %v", err)
-			} else if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
+		if cleanupComment {
+			if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
 				n.warnf("failed to delete start comment when completion suppressed: %v", err)
 			}
 		}
 		return nil
-	}
-
-	if err := n.refreshClient(ctx); err != nil {
-		return err
 	}
 
 	body := n.buildCompletionBody(description, status, detail, completionTime)
@@ -258,6 +324,27 @@ func (n *Notifier) PostCompletionWithDetail(ctx context.Context, description, st
 	}
 
 	return nil
+}
+
+// postCompletionReaction manages the reaction lifecycle at run completion:
+// the start reaction (if any) is removed — it no longer reflects the
+// run's state — and, if post is true, a new reaction reflecting the
+// outcome is added. Unlike comments, reactions generate no GitHub
+// notification, so there's no notification-noise reason to keep the start
+// reaction around across this swap. Errors are logged, not returned: a
+// reaction is a nice-to-have signal, not something that should fail the
+// run. Assumes the caller has already refreshed n.client if needed.
+func (n *Notifier) postCompletionReaction(ctx context.Context, status string, cleanup, post bool) {
+	if cleanup {
+		if err := n.client.DeleteIssueReaction(ctx, n.owner, n.repo, n.number, n.startReactionID); err != nil {
+			n.warnf("failed to remove start reaction: %v", err)
+		}
+	}
+	if post {
+		if _, err := n.client.AddIssueReaction(ctx, n.owner, n.repo, n.number, reactionForStatus(status)); err != nil {
+			n.warnf("failed to add completion reaction: %v", err)
+		}
+	}
 }
 
 // analyzeTimeline lists comments and determines two things:

--- a/internal/statuscomment/statuscomment.go
+++ b/internal/statuscomment/statuscomment.go
@@ -77,12 +77,19 @@ type Notifier struct {
 	sha           string
 	marker        string
 
-	startCommentID  int
-	startReactionID int64
-	startTime       time.Time
-	now             func() time.Time
-	warnf           func(string, ...any)
-	runInfo         *RunInfo
+	startCommentID int
+	// startReactionID is in-memory only, unlike startCommentID which can be
+	// recovered by ReconcileOrphaned via the HTML marker embedded in the
+	// comment body. If the process is hard-killed between PostStart and
+	// PostCompletionWithDetail, this ID is lost and the start reaction is
+	// never cleaned up — there is no equivalent out-of-process reconciler
+	// for reactions. See ReconcileOrphaned's doc comment.
+	startReactionID  int64
+	triggerCommentID int
+	startTime        time.Time
+	now              func() time.Time
+	warnf            func(string, ...any)
+	runInfo          *RunInfo
 }
 
 // New creates a Notifier. The runID is embedded in the HTML marker comment
@@ -121,6 +128,16 @@ func (n *Notifier) SetRunInfo(info RunInfo) {
 // used if the factory is nil.
 func (n *Notifier) SetClientFactory(f ClientFactory) {
 	n.clientFactory = f
+}
+
+// SetTriggerCommentID records the ID of the comment that triggered this
+// run via a slash command. When set, start/completion reactions target
+// that comment instead of the issue/PR itself — matching the behavior a
+// human collaborator would expect from a reply, not a reaction to the
+// whole thread. Has no effect on comments, which always post to the
+// issue/PR regardless of what triggered the run.
+func (n *Notifier) SetTriggerCommentID(id int) {
+	n.triggerCommentID = id
 }
 
 // HasClientFactory reports whether a client factory has been configured.
@@ -189,12 +206,15 @@ func shouldPostReactionCompletion(val, status string) bool {
 
 // reactionForStatus maps an agent outcome status to a GitHub reaction
 // content value. success gets a thumbs-up; anything else (failure,
-// cancelled, skipped, or unrecognized) gets a thumbs-down.
+// cancelled, skipped, or unrecognized) gets a "confused" face. Thumbs-down
+// is deliberately avoided: it overloads GitHub's native up/down-vote
+// convention, so a routine failure could be misread as the bot disliking
+// the issue. Rocket is reserved for future use.
 func reactionForStatus(status string) string {
 	if status == "success" {
 		return "+1"
 	}
-	return "-1"
+	return "confused"
 }
 
 // PostStart posts a start comment on the issue/PR.
@@ -231,7 +251,7 @@ func (n *Notifier) PostStart(ctx context.Context, description string) error {
 	}
 
 	if postReaction {
-		id, err := n.client.AddIssueReaction(ctx, n.owner, n.repo, n.number, "eyes")
+		id, err := n.addReaction(ctx, "eyes")
 		if err != nil {
 			// Fail open: a reaction is a nice-to-have signal, not something
 			// that should abort the agent run.
@@ -242,6 +262,25 @@ func (n *Notifier) PostStart(ctx context.Context, description string) error {
 	}
 
 	return nil
+}
+
+// addReaction adds an emoji reaction, targeting the triggering comment
+// instead of the issue/PR when this run was invoked by a slash command.
+// See SetTriggerCommentID.
+func (n *Notifier) addReaction(ctx context.Context, content string) (int64, error) {
+	if n.triggerCommentID != 0 {
+		return n.client.AddIssueCommentReaction(ctx, n.owner, n.repo, n.triggerCommentID, content)
+	}
+	return n.client.AddIssueReaction(ctx, n.owner, n.repo, n.number, content)
+}
+
+// deleteReaction removes a previously added reaction, mirroring the
+// comment-vs-issue targeting addReaction uses to add it.
+func (n *Notifier) deleteReaction(ctx context.Context, reactionID int64) error {
+	if n.triggerCommentID != 0 {
+		return n.client.DeleteIssueCommentReaction(ctx, n.owner, n.repo, n.triggerCommentID, reactionID)
+	}
+	return n.client.DeleteIssueReaction(ctx, n.owner, n.repo, n.number, reactionID)
 }
 
 // PostCompletion posts or edits a completion comment with no extra
@@ -285,12 +324,12 @@ func (n *Notifier) PostCompletionWithDetail(ctx context.Context, description, st
 		}
 	}
 
-	n.postCompletionReaction(ctx, status, cleanupReaction, postReaction)
-
 	if !postComment {
 		// Completion comment suppressed (disabled or on_failure with success) —
 		// clean up the start comment so it doesn't remain orphaned in its
-		// "Started" state.
+		// "Started" state. Reactions have no equivalent "orphaned" risk, so
+		// the swap can happen unconditionally here.
+		n.postCompletionReaction(ctx, status, cleanupReaction, postReaction)
 		if cleanupComment {
 			if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
 				n.warnf("failed to delete start comment when completion suppressed: %v", err)
@@ -323,6 +362,12 @@ func (n *Notifier) PostCompletionWithDetail(ctx context.Context, description, st
 		}
 	}
 
+	// Only swap the reaction once the completion comment has been
+	// successfully recorded — otherwise a transient comment API failure
+	// could leave a completion reaction pointing at a run the comment
+	// still shows as "Started".
+	n.postCompletionReaction(ctx, status, cleanupReaction, postReaction)
+
 	return nil
 }
 
@@ -336,12 +381,13 @@ func (n *Notifier) PostCompletionWithDetail(ctx context.Context, description, st
 // run. Assumes the caller has already refreshed n.client if needed.
 func (n *Notifier) postCompletionReaction(ctx context.Context, status string, cleanup, post bool) {
 	if cleanup {
-		if err := n.client.DeleteIssueReaction(ctx, n.owner, n.repo, n.number, n.startReactionID); err != nil {
+		if err := n.deleteReaction(ctx, n.startReactionID); err != nil {
 			n.warnf("failed to remove start reaction: %v", err)
 		}
+		n.startReactionID = 0
 	}
 	if post {
-		if _, err := n.client.AddIssueReaction(ctx, n.owner, n.repo, n.number, reactionForStatus(status)); err != nil {
+		if _, err := n.addReaction(ctx, reactionForStatus(status)); err != nil {
 			n.warnf("failed to add completion reaction: %v", err)
 		}
 	}
@@ -643,6 +689,11 @@ func statusEmoji(status string) string {
 // mechanism (e.g., a GitHub Actions post-job step) that runs even when the
 // fullsend process is killed. It does not require a Notifier instance since
 // the process that created it is gone.
+//
+// Known limitation: this does not reconcile an orphaned start reaction
+// (see Notifier.startReactionID). Comments carry a recoverable HTML marker;
+// reactions have no equivalent identity that survives the process, so a
+// hard-killed run can leave a stray 👀 reaction behind indefinitely.
 //
 // Returns an error if runID contains characters outside [a-zA-Z0-9_-].
 func ReconcileOrphaned(ctx context.Context, client forge.Client, owner, repo string, number int, runID, runURL, sha string, reason TerminationReason, completionMode, jobStatus string, wasSkipped bool, agentDescription string) error {

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -1568,7 +1568,6 @@ func TestParagraphBreak_BetweenStatusAndMetadata(t *testing.T) {
 	})
 }
 
-}
 
 func TestBuildRunInfoFooter_DifferentModels(t *testing.T) {
 	// When requested != reported, show arrow format.
@@ -1684,7 +1683,7 @@ func TestPostStart_ReactionEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, fc.AddedReactions, 1)
-	assert.Equal(t, forge.ReactionRecord{Owner: "org", Repo: "repo", Number: 7, Content: "eyes"}, fc.AddedReactions[0])
+	assert.Equal(t, forge.ReactionRecord{ID: 1, Owner: "org", Repo: "repo", Number: 7, Content: "eyes"}, fc.AddedReactions[0])
 }
 
 func TestPostStart_ReactionDisabledByDefault(t *testing.T) {

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -1568,6 +1568,8 @@ func TestParagraphBreak_BetweenStatusAndMetadata(t *testing.T) {
 	})
 }
 
+}
+
 func TestBuildRunInfoFooter_DifferentModels(t *testing.T) {
 	// When requested != reported, show arrow format.
 	info := &RunInfo{
@@ -1667,4 +1669,138 @@ func TestCompletionBody_RunInfoFooterWithModelDiff(t *testing.T) {
 	require.Len(t, fc.UpdatedComments, 1)
 	body := fc.UpdatedComments[0].Body
 	assert.Contains(t, body, "Runtime: pi · Model: haiku → gemini-2.5-pro · Effort: medium · Cost: $0.42")
+}
+
+// --- Reaction tests ---
+
+func TestPostStart_ReactionEnabled(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Reaction: config.ReactionNotificationConfig{Start: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	require.Len(t, fc.AddedReactions, 1)
+	assert.Equal(t, forge.ReactionRecord{Owner: "org", Repo: "repo", Number: 7, Content: "eyes"}, fc.AddedReactions[0])
+}
+
+func TestPostStart_ReactionDisabledByDefault(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	assert.Empty(t, fc.AddedReactions, "reactions are opt-in, unlike comments")
+}
+
+func TestPostCompletion_ReactionSuccess(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment:  config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+		Reaction: config.ReactionNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.Len(t, fc.AddedReactions, 1)
+	startReactionID := int64(1)
+
+	require.NoError(t, n.PostCompletion(context.Background(), "Working", "success"))
+
+	assert.Equal(t, []int64{startReactionID}, fc.DeletedReactions, "start reaction is replaced, not stacked")
+	require.Len(t, fc.AddedReactions, 2)
+	assert.Equal(t, "+1", fc.AddedReactions[1].Content)
+}
+
+func TestPostCompletion_ReactionFailure(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment:  config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+		Reaction: config.ReactionNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.NoError(t, n.PostCompletion(context.Background(), "Working", "failure"))
+
+	require.Len(t, fc.AddedReactions, 2)
+	assert.Equal(t, "-1", fc.AddedReactions[1].Content)
+}
+
+func TestPostCompletion_ReactionOnFailure_SuppressedOnSuccess(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment:  config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+		Reaction: config.ReactionNotificationConfig{Start: "enabled", Completion: "on_failure"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.NoError(t, n.PostCompletion(context.Background(), "Working", "success"))
+
+	assert.Len(t, fc.AddedReactions, 1, "no completion reaction added on success")
+	assert.Equal(t, []int64{1}, fc.DeletedReactions, "start reaction is cleaned up, leaving no trace")
+}
+
+func TestPostCompletion_ReactionOnFailure_FiresOnFailure(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment:  config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+		Reaction: config.ReactionNotificationConfig{Start: "enabled", Completion: "on_failure"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.NoError(t, n.PostCompletion(context.Background(), "Working", "failure"))
+
+	require.Len(t, fc.AddedReactions, 2)
+	assert.Equal(t, "-1", fc.AddedReactions[1].Content)
+}
+
+func TestPostCompletion_ReactionDisabled_CleansUpStartReaction(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment:  config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+		Reaction: config.ReactionNotificationConfig{Start: "enabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.NoError(t, n.PostCompletion(context.Background(), "Working", "success"))
+
+	assert.Empty(t, fc.AddedReactions[1:], "no completion reaction posted")
+	assert.Equal(t, []int64{1}, fc.DeletedReactions)
+}
+
+func TestPostCompletion_ReactionNoStartReaction(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment:  config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+		Reaction: config.ReactionNotificationConfig{Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.NoError(t, n.PostCompletion(context.Background(), "Working", "success"))
+
+	assert.Empty(t, fc.DeletedReactions, "nothing to clean up when start reaction was never posted")
+	require.Len(t, fc.AddedReactions, 1)
+	assert.Equal(t, "+1", fc.AddedReactions[0].Content)
+}
+
+func TestPostStart_ReactionErrorIsNonFatal(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.Errors = map[string]error{"AddIssueReaction": fmt.Errorf("boom")}
+	cfg := config.StatusNotificationConfig{
+		Reaction: config.ReactionNotificationConfig{Start: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err, "a failed reaction should not fail the run")
 }

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -1729,7 +1729,7 @@ func TestPostCompletion_ReactionFailure(t *testing.T) {
 	require.NoError(t, n.PostCompletion(context.Background(), "Working", "failure"))
 
 	require.Len(t, fc.AddedReactions, 2)
-	assert.Equal(t, "-1", fc.AddedReactions[1].Content)
+	assert.Equal(t, "confused", fc.AddedReactions[1].Content)
 }
 
 func TestPostCompletion_ReactionOnFailure_SuppressedOnSuccess(t *testing.T) {
@@ -1759,7 +1759,7 @@ func TestPostCompletion_ReactionOnFailure_FiresOnFailure(t *testing.T) {
 	require.NoError(t, n.PostCompletion(context.Background(), "Working", "failure"))
 
 	require.Len(t, fc.AddedReactions, 2)
-	assert.Equal(t, "-1", fc.AddedReactions[1].Content)
+	assert.Equal(t, "confused", fc.AddedReactions[1].Content)
 }
 
 func TestPostCompletion_ReactionDisabled_CleansUpStartReaction(t *testing.T) {
@@ -1803,4 +1803,62 @@ func TestPostStart_ReactionErrorIsNonFatal(t *testing.T) {
 
 	err := n.PostStart(context.Background(), "Working")
 	require.NoError(t, err, "a failed reaction should not fail the run")
+}
+
+// A comment API failure should leave the start reaction in place rather
+// than swapping it to reflect a completion that was never successfully
+// recorded — otherwise the reaction and comment tell contradictory stories.
+func TestPostCompletion_ReactionNotSwappedWhenCommentFails(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment:  config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+		Reaction: config.ReactionNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.Len(t, fc.AddedReactions, 1)
+
+	fc.Errors = map[string]error{"UpdateIssueComment": fmt.Errorf("boom")}
+
+	err := n.PostCompletion(context.Background(), "Working", "success")
+	require.Error(t, err)
+
+	assert.Empty(t, fc.DeletedReactions, "start reaction should survive a failed completion comment")
+	assert.Len(t, fc.AddedReactions, 1, "no completion reaction should be posted when the comment fails")
+}
+
+// --- Comment-targeted reaction tests (slash-command triggered runs) ---
+
+func TestPostStart_ReactionTargetsTriggeringComment(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Reaction: config.ReactionNotificationConfig{Start: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+	n.SetTriggerCommentID(555)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+
+	assert.Empty(t, fc.AddedReactions, "should not react to the issue/PR when triggered by a slash command")
+	require.Len(t, fc.AddedCommentReactions, 1)
+	assert.Equal(t, forge.CommentReactionRecord{Owner: "org", Repo: "repo", CommentID: 555, Content: "eyes"}, fc.AddedCommentReactions[0])
+}
+
+func TestPostCompletion_ReactionTargetsTriggeringComment(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Reaction: config.ReactionNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+	n.SetTriggerCommentID(555)
+
+	require.NoError(t, n.PostStart(context.Background(), "Working"))
+	require.NoError(t, n.PostCompletion(context.Background(), "Working", "success"))
+
+	assert.Empty(t, fc.DeletedReactions, "cleanup should target the comment reaction, not the issue reaction")
+	require.Len(t, fc.DeletedCommentReactions, 1)
+	assert.Empty(t, fc.AddedReactions)
+	require.Len(t, fc.AddedCommentReactions, 2)
+	assert.Equal(t, "+1", fc.AddedCommentReactions[1].Content)
 }

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -1568,7 +1568,6 @@ func TestParagraphBreak_BetweenStatusAndMetadata(t *testing.T) {
 	})
 }
 
-
 func TestBuildRunInfoFooter_DifferentModels(t *testing.T) {
 	// When requested != reported, show arrow format.
 	info := &RunInfo{

--- a/pkg/behaviourtest/drivers/scm/driver.go
+++ b/pkg/behaviourtest/drivers/scm/driver.go
@@ -38,6 +38,9 @@ type Driver interface {
 	ListOpenChangeProposals(ctx context.Context, owner, repo string) ([]forge.ChangeProposal, error)
 	// ListComments returns the comments on an issue or pull request.
 	ListComments(ctx context.Context, owner, repo string, number int) ([]forge.IssueComment, error)
+	// ListIssueReactions returns the emoji reactions on an issue or
+	// pull request. Used by reaction notification assertions.
+	ListIssueReactions(ctx context.Context, owner, repo string, number int) ([]forge.Reaction, error)
 
 	// CreateRepo creates a new repository in the given org. It is
 	// idempotent — if a repo with the given name already exists,

--- a/pkg/behaviourtest/drivers/scm/github/github.go
+++ b/pkg/behaviourtest/drivers/scm/github/github.go
@@ -74,6 +74,10 @@ func (d *Driver) ListComments(ctx context.Context, owner, repo string, number in
 	return d.Client.ListIssueComments(ctx, owner, repo, number)
 }
 
+func (d *Driver) ListIssueReactions(ctx context.Context, owner, repo string, number int) ([]forge.Reaction, error) {
+	return d.Client.ListIssueReactions(ctx, owner, repo, number)
+}
+
 func (d *Driver) SubmitPullRequestReview(ctx context.Context, owner, repo string, number int, event string) error {
 	sha, err := d.Client.GetPullRequestHeadSHA(ctx, owner, repo, number)
 	if err != nil {

--- a/pkg/behaviourtest/steps/branch_test.go
+++ b/pkg/behaviourtest/steps/branch_test.go
@@ -88,6 +88,9 @@ func (f *fakeBranchSCM) AddComment(_ context.Context, _, _ string, _ int, body s
 	f.addedComments = append(f.addedComments, body)
 	return &forge.IssueComment{Body: body}, nil
 }
+func (f *fakeBranchSCM) ListIssueReactions(context.Context, string, string, int) ([]forge.Reaction, error) {
+	return nil, nil
+}
 
 // fakeBranchCI implements WaitForFailedHarnessAgent; other ci.Driver
 // methods come from the embedded interface and panic when called.

--- a/pkg/behaviourtest/steps/cleanup.go
+++ b/pkg/behaviourtest/steps/cleanup.go
@@ -206,6 +206,7 @@ func CleanupScenario(w *world.World) {
 		}
 	}
 
+<<<<<<< HEAD
 	// --- Runtime override cleanup ---
 	// Restore the install-time runtime so a later scenario on this slot
 	// does not silently run under pi (or whatever this one selected).
@@ -241,6 +242,17 @@ func CleanupScenario(w *world.World) {
 			return RestoreAgents(w)
 		}); err != nil {
 			worldLogf(w, "behaviour cleanup: restore agents: %v", err)
+		}
+	}
+
+	// --- Reaction notification cleanup ---
+	// Disable reaction notifications so the next scenario on this slot
+	// is not affected by sticky config state.
+	if reactionsEnabledInConfig(w) {
+		if err := DisableReactionNotifications(w); err != nil {
+			worldLogf(w, "behaviour cleanup: disable reaction notifications: %v", err)
+		}
+	}
 		}
 	}
 

--- a/pkg/behaviourtest/steps/cleanup.go
+++ b/pkg/behaviourtest/steps/cleanup.go
@@ -206,7 +206,6 @@ func CleanupScenario(w *world.World) {
 		}
 	}
 
-<<<<<<< HEAD
 	// --- Runtime override cleanup ---
 	// Restore the install-time runtime so a later scenario on this slot
 	// does not silently run under pi (or whatever this one selected).
@@ -251,8 +250,6 @@ func CleanupScenario(w *world.World) {
 	if reactionsEnabledInConfig(w) {
 		if err := DisableReactionNotifications(w); err != nil {
 			worldLogf(w, "behaviour cleanup: disable reaction notifications: %v", err)
-		}
-	}
 		}
 	}
 

--- a/pkg/behaviourtest/steps/cleanup_test.go
+++ b/pkg/behaviourtest/steps/cleanup_test.go
@@ -555,6 +555,10 @@ func (f *fakeCleanupSCM) CreateForkChangeProposal(context.Context, string, strin
 	return nil, nil
 }
 
+func (f *fakeCleanupSCM) ListIssueReactions(context.Context, string, string, int) ([]forge.Reaction, error) {
+	return nil, nil
+}
+
 // --- Issue cleanup tests ---
 
 func TestCleanupScenario_ClosesIssue(t *testing.T) {

--- a/pkg/behaviourtest/steps/cleanup_test.go
+++ b/pkg/behaviourtest/steps/cleanup_test.go
@@ -1142,6 +1142,10 @@ func (f *fakeRetryCleanupSCM) ListComments(context.Context, string, string, int)
 	return nil, nil
 }
 
+func (f *fakeRetryCleanupSCM) ListIssueReactions(context.Context, string, string, int) ([]forge.Reaction, error) {
+	return nil, nil
+}
+
 func (f *fakeRetryCleanupSCM) EnsureRepoPublic(context.Context, string, string) error {
 	return nil
 }

--- a/pkg/behaviourtest/steps/dispatch_test.go
+++ b/pkg/behaviourtest/steps/dispatch_test.go
@@ -249,6 +249,9 @@ func (f *fakeDispatchSCM) GetDefaultBranch(context.Context, string, string) (str
 func (f *fakeDispatchSCM) GetBranchRef(context.Context, string, string, string) (string, error) {
 	return "abc123", nil
 }
+func (f *fakeDispatchSCM) ListIssueReactions(context.Context, string, string, int) ([]forge.Reaction, error) {
+	return nil, nil
+}
 
 func TestNegativeSettleDuration(t *testing.T) {
 	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)

--- a/pkg/behaviourtest/steps/fork_test.go
+++ b/pkg/behaviourtest/steps/fork_test.go
@@ -560,3 +560,6 @@ func (f *fakeForkSCM) GetBranchRef(context.Context, string, string, string) (str
 	}
 	return "abc123", nil
 }
+func (f *fakeForkSCM) ListIssueReactions(context.Context, string, string, int) ([]forge.Reaction, error) {
+	return nil, nil
+}

--- a/pkg/behaviourtest/steps/reaction.go
+++ b/pkg/behaviourtest/steps/reaction.go
@@ -28,7 +28,7 @@ func registerReactionSteps(sc *godog.ScenarioContext) {
 // causes the runner to post emoji reactions on start and completion.
 func givenReactionsEnabled(w *world.World) error {
 	cfgPath := filepath.Join(".fullsend", "config.yaml")
-	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath)
+	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Org, w.RepoName, cfgPath)
 	if err != nil {
 		return fmt.Errorf("reading config: %w", err)
 	}
@@ -50,7 +50,7 @@ func givenReactionsEnabled(w *world.World) error {
 	if err != nil {
 		return err
 	}
-	if err := w.SCM.CommitFile(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath, "behaviour: enable reaction notifications", merged); err != nil {
+	if err := w.SCM.CommitFile(context.Background(), w.Org, w.RepoName, cfgPath, "behaviour: enable reaction notifications", merged); err != nil {
 		return fmt.Errorf("updating config: %w", err)
 	}
 	return nil
@@ -61,7 +61,7 @@ func givenReactionsEnabled(w *world.World) error {
 // call it during scenario teardown.
 func DisableReactionNotifications(w *world.World) error {
 	cfgPath := filepath.Join(".fullsend", "config.yaml")
-	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath)
+	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Org, w.RepoName, cfgPath)
 	if err != nil {
 		return fmt.Errorf("reading config: %w", err)
 	}
@@ -74,7 +74,7 @@ func DisableReactionNotifications(w *world.World) error {
 	if err != nil {
 		return err
 	}
-	if err := w.SCM.CommitFile(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath, "behaviour: disable reaction notifications", merged); err != nil {
+	if err := w.SCM.CommitFile(context.Background(), w.Org, w.RepoName, cfgPath, "behaviour: disable reaction notifications", merged); err != nil {
 		return fmt.Errorf("updating config: %w", err)
 	}
 	return nil
@@ -119,11 +119,11 @@ func thenIssueDoesNotHaveReaction(w *world.World, content string) error {
 // reactionsEnabledInConfig checks if status_notifications.reaction is
 // set in the repo config. Used by cleanup to decide whether to reset.
 func reactionsEnabledInConfig(w *world.World) bool {
-	if w.SCM == nil || w.Install == nil {
+	if w.SCM == nil || w.Org == "" || w.RepoName == "" {
 		return false
 	}
 	cfgPath := filepath.Join(".fullsend", "config.yaml")
-	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath)
+	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Org, w.RepoName, cfgPath)
 	if err != nil {
 		return false
 	}

--- a/pkg/behaviourtest/steps/reaction.go
+++ b/pkg/behaviourtest/steps/reaction.go
@@ -135,5 +135,6 @@ func reactionsEnabledInConfig(w *world.World) bool {
 	if sn == nil {
 		return false
 	}
-	return sn.Reaction.Start != "" && sn.Reaction.Start != "disabled"
+	return (sn.Reaction.Start != "" && sn.Reaction.Start != "disabled") ||
+		(sn.Reaction.Completion != "" && sn.Reaction.Completion != "disabled")
 }

--- a/pkg/behaviourtest/steps/reaction.go
+++ b/pkg/behaviourtest/steps/reaction.go
@@ -1,0 +1,139 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cucumber/godog"
+
+	"github.com/fullsend-ai/fullsend/internal/config"
+	"github.com/fullsend-ai/fullsend/pkg/behaviourtest/world"
+)
+
+func registerReactionSteps(sc *godog.ScenarioContext) {
+	sc.Step(`^status notification reactions are enabled$`, func(ctx context.Context) (context.Context, error) {
+		return ctx, givenReactionsEnabled(world.FromContext(ctx))
+	})
+	sc.Step(`^the issue has a "([^"]+)" reaction$`, func(ctx context.Context, content string) (context.Context, error) {
+		return ctx, thenIssueHasReaction(world.FromContext(ctx), content)
+	})
+	sc.Step(`^the issue does not have a "([^"]+)" reaction$`, func(ctx context.Context, content string) (context.Context, error) {
+		return ctx, thenIssueDoesNotHaveReaction(world.FromContext(ctx), content)
+	})
+}
+
+// givenReactionsEnabled sets status_notifications.reaction.start and
+// .completion to "enabled" in the enrolled repo's config.yaml. This
+// causes the runner to post emoji reactions on start and completion.
+func givenReactionsEnabled(w *world.World) error {
+	cfgPath := filepath.Join(".fullsend", "config.yaml")
+	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+	cfg, err := config.ParsePerRepoConfigWriter(cfgData)
+	if err != nil {
+		return fmt.Errorf("parsing config: %w", err)
+	}
+	cfg.SetStatusNotifications(&config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{
+			Start:      "enabled",
+			Completion: "enabled",
+		},
+		Reaction: config.ReactionNotificationConfig{
+			Start:      "enabled",
+			Completion: "enabled",
+		},
+	})
+	merged, err := cfg.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := w.SCM.CommitFile(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath, "behaviour: enable reaction notifications", merged); err != nil {
+		return fmt.Errorf("updating config: %w", err)
+	}
+	return nil
+}
+
+// DisableReactionNotifications removes the status_notifications from
+// the enrolled repo's config.yaml. Exported so CleanupScenario can
+// call it during scenario teardown.
+func DisableReactionNotifications(w *world.World) error {
+	cfgPath := filepath.Join(".fullsend", "config.yaml")
+	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+	cfg, err := config.ParsePerRepoConfigWriter(cfgData)
+	if err != nil {
+		return fmt.Errorf("parsing config: %w", err)
+	}
+	cfg.SetStatusNotifications(nil)
+	merged, err := cfg.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := w.SCM.CommitFile(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath, "behaviour: disable reaction notifications", merged); err != nil {
+		return fmt.Errorf("updating config: %w", err)
+	}
+	return nil
+}
+
+func thenIssueHasReaction(w *world.World, content string) error {
+	if w.IssueNumber == 0 {
+		return fmt.Errorf("no issue created")
+	}
+	reactions, err := w.SCM.ListIssueReactions(context.Background(), w.RepoOwner, w.RepoName, w.IssueNumber)
+	if err != nil {
+		return fmt.Errorf("listing reactions: %w", err)
+	}
+	for _, r := range reactions {
+		if r.Content == content {
+			return nil
+		}
+	}
+	var found []string
+	for _, r := range reactions {
+		found = append(found, r.Content)
+	}
+	return fmt.Errorf("issue #%d reactions %v do not include %q", w.IssueNumber, found, content)
+}
+
+func thenIssueDoesNotHaveReaction(w *world.World, content string) error {
+	if w.IssueNumber == 0 {
+		return fmt.Errorf("no issue created")
+	}
+	reactions, err := w.SCM.ListIssueReactions(context.Background(), w.RepoOwner, w.RepoName, w.IssueNumber)
+	if err != nil {
+		return fmt.Errorf("listing reactions: %w", err)
+	}
+	for _, r := range reactions {
+		if r.Content == content {
+			return fmt.Errorf("issue #%d unexpectedly has %q reaction", w.IssueNumber, content)
+		}
+	}
+	return nil
+}
+
+// reactionsEnabledInConfig checks if status_notifications.reaction is
+// set in the repo config. Used by cleanup to decide whether to reset.
+func reactionsEnabledInConfig(w *world.World) bool {
+	if w.SCM == nil || w.Install == nil {
+		return false
+	}
+	cfgPath := filepath.Join(".fullsend", "config.yaml")
+	cfgData, err := w.SCM.GetFileContent(context.Background(), w.Install.ConfigOwner(), w.Install.ConfigRepo(), cfgPath)
+	if err != nil {
+		return false
+	}
+	cfg, err := config.ParsePerRepoConfigWriter(cfgData)
+	if err != nil {
+		return false
+	}
+	sn := cfg.StatusNotifications()
+	if sn == nil {
+		return false
+	}
+	return sn.Reaction.Start != "" && sn.Reaction.Start != "disabled"
+}

--- a/pkg/behaviourtest/steps/registry.go
+++ b/pkg/behaviourtest/steps/registry.go
@@ -17,4 +17,5 @@ func Register(sc *godog.ScenarioContext) {
 	registerForkSteps(sc)
 	registerJiraPollSteps(sc)
 	registerBranchSteps(sc)
+	registerReactionSteps(sc)
 }

--- a/pkg/behaviourtest/steps/url_dispatch_test.go
+++ b/pkg/behaviourtest/steps/url_dispatch_test.go
@@ -1145,3 +1145,6 @@ func (f *fakeURLSCM) CommitFileToFork(context.Context, string, string, string, s
 func (f *fakeURLSCM) CreateForkChangeProposal(context.Context, string, string, string, string, string, string, string, string) (*forge.ChangeProposal, error) {
 	return nil, nil
 }
+func (f *fakeURLSCM) ListIssueReactions(context.Context, string, string, int) ([]forge.Reaction, error) {
+	return nil, nil
+}

--- a/pkg/behaviourtest/suite/init_test.go
+++ b/pkg/behaviourtest/suite/init_test.go
@@ -80,6 +80,9 @@ func (p *panickingSCM) CommitFileToFork(context.Context, string, string, string,
 func (p *panickingSCM) CreateForkChangeProposal(context.Context, string, string, string, string, string, string, string, string) (*forge.ChangeProposal, error) {
 	return nil, nil
 }
+func (p *panickingSCM) ListIssueReactions(context.Context, string, string, int) ([]forge.Reaction, error) {
+	return nil, nil
+}
 
 // fakeDriver is a minimal install.Driver for unit testing suite hooks.
 type fakeDriver struct {


### PR DESCRIPTION
## Summary

Stacked on #5736 — this adds the "react to the issue with an emoji" alternative from #3697, as a supplement/alternative to status comments.

**Blocked on:** #5994 — `perRepoConfig` has no `status_notifications` field, and the live `pkg/behaviourtest` e2e suite only supports per-repo installs, so there is currently no test harness that can enable reactions to exercise the maintainer-mandated behavior test below.

- New `AddIssueReaction`/`DeleteIssueReaction` on `forge.Client`, implemented for GitHub (GitLab returns `ErrNotSupported` — no caller exercises that path yet)
- New `AddIssueCommentReaction`/`DeleteIssueCommentReaction` on `forge.Client` so reactions can target the triggering comment for slash-command-invoked runs, per #3697's explicit requirement
- New `status_notifications.reaction` config block (`start`/`completion`, same `enabled`/`on_failure`/`disabled` values as `comment`), defaulting to `disabled` since it's an opt-in addition
- `Notifier.PostStart` adds a 👀 reaction when `reaction.start: enabled`; `PostCompletionWithDetail` swaps it for 👍 (success) or 😕 (failure/cancelled/skipped/unrecognized) depending on `reaction.completion`
- Reactions target the triggering comment (via `--status-comment-id`, wired through `action.yml` and all reusable workflow call sites) when the run was invoked by a slash command, and the issue/PR otherwise
- Reactions generate no GitHub notification, so unlike comments they don't need the `on_failure` start-suppression workaround
- Docs updated under "Status Notifications" in `docs/guides/user/customizing-agents.md`

Out of scope:
- `ReconcileOrphaned` does not yet reconcile orphaned reaction state on hard-killed runs — plumbing a reaction ID across process boundaries would need more design than is justified here.
- Reactions have no per-run identity (GitHub's reactions API is keyed by actor+subject+content), so concurrent same-role runs can collide on the same reaction. Documented as a known limitation with inline code comments; not fixable without GitHub API support.
- GitLab silently no-ops on reaction calls (`ErrNotSupported`) with no config-time validation warning users their `reaction` settings do nothing. Documented as a known limitation; follow-up needed (also applies to the new JIRA poll input driver).
- **Live e2e behavior test for "slash command targets the comment, not the issue"** — blocked on #5994. Covered today by unit tests only (`TestPostStart_ReactionTargetsTriggeringComment`, `TestPostCompletion_ReactionTargetsTriggeringComment` in `internal/statuscomment/statuscomment_test.go`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./...` — all green except pre-existing, unrelated `internal/runtime` failures (verified present on base branch too)
- [x] New unit tests for config parsing/validation, `FakeClient`, GitHub REST calls, and `Notifier` reaction lifecycle (start/completion/on_failure/cleanup, comment-scoped targeting)
- [x] Vendor a binary built off this branch and try it against a real test repo
- [ ] Live e2e behavior test for comment-scoped reactions — blocked on #5994

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
