### PR TITLE
fix: resolve relative plugin paths from URL-sourced harnesses

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -763,6 +763,15 @@ func resolveFromLock(h *harness.Harness, entry *lock.HarnessLock, workspaceRoot 
 							return resolve.ResolveResult{}, fmt.Errorf("%s: URL must point to a directory inside the repo, not the repo root", lockDep.Field)
 						}
 						dirName = filepath.Base(forgeInfo.Path)
+					} else if rawInfo, rawErr := forge.ParseRawContentURL(lockDep.URL); rawErr == nil {
+						// Base-composed plugins use raw.githubusercontent.com
+						// URLs ending in /plugin.json (the marker file). Strip
+						// the marker to get the plugin directory name.
+						pluginDir := path.Dir(rawInfo.Path)
+						if pluginDir == "" || pluginDir == "." {
+							return resolve.ResolveResult{}, fmt.Errorf("%s: URL must point to a file inside a plugin directory, not the repo root", lockDep.Field)
+						}
+						dirName = filepath.Base(pluginDir)
 					}
 					if !harness.ValidPluginBasename(dirName) {
 						return resolve.ResolveResult{}, fmt.Errorf("%s: cached basename %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -)", lockDep.Field, dirName)

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -754,28 +754,13 @@ func resolveFromLock(h *harness.Harness, entry *lock.HarnessLock, workspaceRoot 
 					return resolve.ResolveResult{}, fmt.Errorf("naming cached script dir for %s: %w", lockDep.Field, symlinkErr)
 				}
 				localPath = filepath.Join(namedPath, scriptName)
-			} else if strings.HasPrefix(lockDep.Field, "skills[") || strings.HasPrefix(lockDep.Field, "plugins[") {
-				dirName := path.Base(lockDep.URL)
-				if strings.HasPrefix(lockDep.Field, "plugins[") {
-					forgeInfo, parseErr := forge.ParseForgeURL(lockDep.URL)
-					if parseErr == nil {
-						if forgeInfo.Path == "" {
-							return resolve.ResolveResult{}, fmt.Errorf("%s: URL must point to a directory inside the repo, not the repo root", lockDep.Field)
-						}
-						dirName = filepath.Base(forgeInfo.Path)
-					} else if rawInfo, rawErr := forge.ParseRawContentURL(lockDep.URL); rawErr == nil {
-						// Base-composed plugins use raw.githubusercontent.com
-						// URLs ending in /plugin.json (the marker file). Strip
-						// the marker to get the plugin directory name.
-						pluginDir := path.Dir(rawInfo.Path)
-						if pluginDir == "" || pluginDir == "." {
-							return resolve.ResolveResult{}, fmt.Errorf("%s: URL must point to a file inside a plugin directory, not the repo root", lockDep.Field)
-						}
-						dirName = filepath.Base(pluginDir)
-					}
-					if !harness.ValidPluginBasename(dirName) {
-						return resolve.ResolveResult{}, fmt.Errorf("%s: cached basename %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -)", lockDep.Field, dirName)
-					}
+			} else if isTreeLockField(lockDep.Field) {
+				dirName, dirErr := lockTreeDirName(lockDep.Field, lockDep.URL)
+				if dirErr != nil {
+					return resolve.ResolveResult{}, dirErr
+				}
+				if strings.HasPrefix(lockDep.Field, "plugins[") && !harness.ValidPluginBasename(dirName) {
+					return resolve.ResolveResult{}, fmt.Errorf("%s: cached basename %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -)", lockDep.Field, dirName)
 				}
 				namedPath, symlinkErr := fetch.CacheNamedSymlink(treePath, dirName)
 				if symlinkErr != nil {
@@ -967,6 +952,12 @@ func resolveFromLock(h *harness.Harness, entry *lock.HarnessLock, workspaceRoot 
 			fmt.Sscanf(m.field, "plugins[%d]", &idx)
 			h.Plugins[idx] = m.localPath
 			urlResolvedPlugins[m.localPath] = true
+		case strings.HasPrefix(m.field, "forge.") && strings.Contains(m.field, ".skills["):
+			// Forge-scoped skills are resolved during LoadWithBase and merged
+			// into h.Skills by ResolveForge before resolveFromLock runs; the
+			// correctly named path is already in place. This entry exists for
+			// cache verification only — appending it via the default case
+			// would duplicate the skill under the cache's internal tree name.
 		default:
 			var idx int
 			if _, err := fmt.Sscanf(m.field, "skills[%d]", &idx); err == nil && idx >= 0 && idx < len(h.Skills) {
@@ -1059,6 +1050,45 @@ func resolveFromLock(h *harness.Harness, entry *lock.HarnessLock, workspaceRoot 
 		Profiles:  profiles,
 		Providers: providers,
 	}, nil
+}
+
+// isTreeLockField reports whether a lock dependency field names a cached
+// directory tree whose local basename must be derived from the recorded URL:
+// skills[N] and plugins[N] slots, plus forge-scoped skills
+// (forge.<platform>.skills[N], see resolveBaseResources in
+// internal/harness/compose.go). ForgeConfig has no plugins field.
+func isTreeLockField(field string) bool {
+	return strings.HasPrefix(field, "skills[") ||
+		strings.HasPrefix(field, "plugins[") ||
+		(strings.HasPrefix(field, "forge.") && strings.Contains(field, ".skills["))
+}
+
+// lockTreeDirName derives the local directory basename for a tree lock
+// dependency (see isTreeLockField) from its recorded URL. Direct URL entries
+// use forge tree URLs whose deepest path segment is the directory name.
+// Base-composed entries (see fetchBaseSkill/fetchBasePlugin in
+// internal/harness/compose.go) record raw.githubusercontent.com URLs pointing
+// at the marker file (SKILL.md or plugin.json); only those two names are
+// treated as markers and stripped — any other raw URL keeps its last segment
+// as the directory name.
+func lockTreeDirName(field, lockURL string) (string, error) {
+	if forgeInfo, err := forge.ParseForgeURL(lockURL); err == nil {
+		if forgeInfo.Path == "" {
+			return "", fmt.Errorf("%s: URL must point to a directory inside the repo, not the repo root", field)
+		}
+		return filepath.Base(forgeInfo.Path), nil
+	}
+	if rawInfo, err := forge.ParseRawContentURL(lockURL); err == nil {
+		if last := path.Base(rawInfo.Path); last == "SKILL.md" || last == "plugin.json" {
+			dir := path.Dir(rawInfo.Path)
+			if dir == "." {
+				return "", fmt.Errorf("%s: URL must point to a marker file inside a directory, not the repo root", field)
+			}
+			return filepath.Base(dir), nil
+		}
+		return path.Base(rawInfo.Path), nil
+	}
+	return path.Base(lockURL), nil
 }
 
 func isScriptLockField(field string) bool {

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -1942,6 +1942,253 @@ func TestResolveFromLock_PluginRawContentURL(t *testing.T) {
 	assert.FileExists(t, filepath.Join(h.Plugins[0], "plugin.json"))
 }
 
+func TestResolveFromLock_SkillRawContentURL(t *testing.T) {
+	// Base-composed skills use raw.githubusercontent.com URLs ending in
+	// /SKILL.md (see fetchBaseSkill). resolveFromLock must strip the marker
+	// file to derive the skill directory name — otherwise every skill is
+	// materialized under a directory literally named "SKILL.md", which
+	// becomes the sandbox upload basename and collides across skills. Two
+	// skills reproduce the collision the fix exists to prevent.
+	putSkill := func(t *testing.T, root, slug string) lock.DependencyEntry {
+		t.Helper()
+		skillMD := []byte("---\nname: " + slug + "\n---\n")
+		skillFiles := map[string][]byte{"SKILL.md": skillMD}
+		skillFileURL := "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/skills/" + slug + "/SKILL.md"
+		_, err := fetch.CachePutDir(root, skillFileURL, skillFiles)
+		require.NoError(t, err)
+		return lock.DependencyEntry{
+			URL:    skillFileURL,
+			SHA256: fetch.ComputeTreeHash(skillFiles),
+			Type:   "directory",
+			Files: []lock.FileEntry{
+				{Path: "SKILL.md", SHA256: fetch.ComputeSHA256(skillMD)},
+			},
+		}
+	}
+
+	root := t.TempDir()
+	depA := putSkill(t, root, "pr-review")
+	depA.Field = "skills[0]"
+	depB := putSkill(t, root, "code-review")
+	depB.Field = "skills[1]"
+
+	entry := &lock.HarnessLock{
+		Dependencies: []lock.DependencyEntry{depA, depB},
+	}
+
+	h := &harness.Harness{
+		Agent:                  "agents/code.md",
+		Skills:                 []string{"skills/pr-review", "skills/code-review"},
+		AllowedRemoteResources: []string{"https://raw.githubusercontent.com/fullsend-ai/"},
+	}
+
+	printer := ui.New(os.Stdout)
+	lockResult, err := resolveFromLock(h, entry, root, printer)
+	require.NoError(t, err)
+	require.Len(t, lockResult.Deps, 2)
+	require.Len(t, h.Skills, 2)
+
+	assert.Equal(t, "pr-review", filepath.Base(h.Skills[0]),
+		"skill basename must be derived from the URL directory, not the SKILL.md marker file")
+	assert.Equal(t, "code-review", filepath.Base(h.Skills[1]),
+		"skills must keep distinct basenames — identical ones collide on sandbox upload")
+	for _, s := range h.Skills {
+		assert.False(t, harness.IsURL(s))
+		assert.FileExists(t, filepath.Join(s, "SKILL.md"))
+	}
+}
+
+func TestResolveFromLock_ForgeScopedSkillNoMutation(t *testing.T) {
+	// Forge-scoped base skills are locked under forge.<platform>.skills[N]
+	// (see resolveBaseResources). Their paths were already merged into
+	// h.Skills by ResolveForge during LoadWithBase, so resolveFromLock must
+	// verify the cache entry but leave h.Skills alone — appending would
+	// duplicate the skill under the cache's internal tree name.
+	skillMD := []byte("---\nname: pr-review\n---\n")
+	skillFiles := map[string][]byte{"SKILL.md": skillMD}
+	treeHash := fetch.ComputeTreeHash(skillFiles)
+
+	root := t.TempDir()
+	skillFileURL := "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/skills/pr-review/SKILL.md"
+	_, err := fetch.CachePutDir(root, skillFileURL, skillFiles)
+	require.NoError(t, err)
+	treePath, _, err := fetch.CacheGetDir(root, treeHash)
+	require.NoError(t, err)
+	mergedPath, err := fetch.CacheNamedSymlink(treePath, "pr-review")
+	require.NoError(t, err)
+	require.True(t, filepath.IsAbs(mergedPath),
+		"merged path must live in the cache, not the test working directory")
+
+	entry := &lock.HarnessLock{
+		Dependencies: []lock.DependencyEntry{
+			{
+				Field:  "forge.github.skills[0]",
+				URL:    skillFileURL,
+				SHA256: treeHash,
+				Type:   "directory",
+				Files: []lock.FileEntry{
+					{Path: "SKILL.md", SHA256: fetch.ComputeSHA256(skillMD)},
+				},
+			},
+		},
+	}
+
+	h := &harness.Harness{
+		Agent:                  "agents/code.md",
+		Skills:                 []string{mergedPath},
+		AllowedRemoteResources: []string{"https://raw.githubusercontent.com/fullsend-ai/"},
+	}
+
+	printer := ui.New(os.Stdout)
+	lockResult, err := resolveFromLock(h, entry, root, printer)
+	require.NoError(t, err)
+	require.Len(t, lockResult.Deps, 1)
+
+	require.Len(t, h.Skills, 1, "forge-scoped skill lock entries must not append to h.Skills")
+	assert.Equal(t, mergedPath, h.Skills[0])
+}
+
+func TestResolveFromLock_SkillRepoRootURLRejected(t *testing.T) {
+	// A skills[N] lock entry whose URL is a forge repo root has no directory
+	// segment to name the skill after; resolveFromLock must surface the
+	// lockTreeDirName error instead of materializing a misnamed skill.
+	skillMD := []byte("---\nname: x\n---\n")
+	skillFiles := map[string][]byte{"SKILL.md": skillMD}
+
+	root := t.TempDir()
+	repoRootURL := "https://github.com/fullsend-ai/agents/tree/main"
+	_, err := fetch.CachePutDir(root, repoRootURL, skillFiles)
+	require.NoError(t, err)
+
+	entry := &lock.HarnessLock{
+		Dependencies: []lock.DependencyEntry{
+			{
+				Field:  "skills[0]",
+				URL:    repoRootURL,
+				SHA256: fetch.ComputeTreeHash(skillFiles),
+				Type:   "directory",
+				Files: []lock.FileEntry{
+					{Path: "SKILL.md", SHA256: fetch.ComputeSHA256(skillMD)},
+				},
+			},
+		},
+	}
+
+	h := &harness.Harness{
+		Agent:                  "agents/code.md",
+		Skills:                 []string{"skills/x"},
+		AllowedRemoteResources: []string{"https://github.com/fullsend-ai/"},
+	}
+
+	printer := ui.New(os.Stdout)
+	_, err = resolveFromLock(h, entry, root, printer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills[0]: URL must point to a directory inside the repo, not the repo root")
+}
+
+func TestResolveFromLock_PluginInvalidBasenameRejected(t *testing.T) {
+	// A plugins[N] lock entry whose derived directory name fails
+	// ValidPluginBasename must be rejected — CacheNamedSymlink would
+	// otherwise silently substitute a reserved internal name.
+	manifest := []byte(`{"name": "bad"}`)
+	pluginFiles := map[string][]byte{"plugin.json": manifest}
+
+	root := t.TempDir()
+	pluginFileURL := "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/plugins/bad.name/plugin.json"
+	_, err := fetch.CachePutDir(root, pluginFileURL, pluginFiles)
+	require.NoError(t, err)
+
+	entry := &lock.HarnessLock{
+		Dependencies: []lock.DependencyEntry{
+			{
+				Field:  "plugins[0]",
+				URL:    pluginFileURL,
+				SHA256: fetch.ComputeTreeHash(pluginFiles),
+				Type:   "directory",
+				Files: []lock.FileEntry{
+					{Path: "plugin.json", SHA256: fetch.ComputeSHA256(manifest)},
+				},
+			},
+		},
+	}
+
+	h := &harness.Harness{
+		Agent:                  "agents/code.md",
+		Plugins:                []string{"plugins/bad.name"},
+		AllowedRemoteResources: []string{"https://raw.githubusercontent.com/fullsend-ai/"},
+	}
+
+	printer := ui.New(os.Stdout)
+	_, err = resolveFromLock(h, entry, root, printer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contains invalid characters")
+}
+
+func TestLockTreeDirName(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		url     string
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "forge tree URL uses deepest path segment",
+			field: "skills[0]",
+			url:   "https://github.com/org/repo/tree/main/skills/pr-review",
+			want:  "pr-review",
+		},
+		{
+			name:    "forge repo root rejected",
+			field:   "skills[0]",
+			url:     "https://github.com/org/repo/tree/main",
+			wantErr: "must point to a directory inside the repo",
+		},
+		{
+			name:  "raw SKILL.md marker stripped",
+			field: "skills[0]",
+			url:   "https://raw.githubusercontent.com/org/repo/abc123/skills/pr-review/SKILL.md",
+			want:  "pr-review",
+		},
+		{
+			name:  "raw plugin.json marker stripped",
+			field: "plugins[0]",
+			url:   "https://raw.githubusercontent.com/org/repo/abc123/plugins/gopls-lsp/plugin.json",
+			want:  "gopls-lsp",
+		},
+		{
+			name:    "raw marker at ref root rejected",
+			field:   "skills[0]",
+			url:     "https://raw.githubusercontent.com/org/repo/abc123/SKILL.md",
+			wantErr: "must point to a marker file inside a directory",
+		},
+		{
+			name:  "raw non-marker URL keeps last segment",
+			field: "skills[0]",
+			url:   "https://raw.githubusercontent.com/org/repo/abc123/skills/pr-review",
+			want:  "pr-review",
+		},
+		{
+			name:  "unparseable URL falls back to last segment",
+			field: "skills[0]",
+			url:   "https://example.com/skills/my-skill",
+			want:  "my-skill",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := lockTreeDirName(tt.field, tt.url)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveFromLock_LocalPathsSurviveStrip(t *testing.T) {
 	// When a harness has URL resources (with lock deps) AND local-path
 	// profiles/providers (without lock deps), the lock strip must keep the

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -1895,6 +1895,53 @@ func TestResolveFromLock_PluginSharedURLWithSkill(t *testing.T) {
 	assert.Equal(t, "shared-dir", filepath.Base(h.Plugins[0]))
 }
 
+func TestResolveFromLock_PluginRawContentURL(t *testing.T) {
+	// Base-composed plugins use raw.githubusercontent.com URLs ending in
+	// /plugin.json. resolveFromLock must parse these via ParseRawContentURL
+	// (not ParseForgeURL, which rejects non-github.com hosts) to extract
+	// the plugin directory name.
+	manifestJSON := []byte(`{"name": "gopls-lsp"}`)
+	pluginFiles := map[string][]byte{
+		"plugin.json": manifestJSON,
+	}
+	treeHash := fetch.ComputeTreeHash(pluginFiles)
+
+	root := t.TempDir()
+	pluginFileURL := "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/plugins/gopls-lsp/plugin.json"
+	_, err := fetch.CachePutDir(root, pluginFileURL, pluginFiles)
+	require.NoError(t, err)
+
+	entry := &lock.HarnessLock{
+		Dependencies: []lock.DependencyEntry{
+			{
+				Field:  "plugins[0]",
+				URL:    pluginFileURL,
+				SHA256: treeHash,
+				Type:   "directory",
+				Files: []lock.FileEntry{
+					{Path: "plugin.json", SHA256: fetch.ComputeSHA256(manifestJSON)},
+				},
+			},
+		},
+	}
+
+	h := &harness.Harness{
+		Agent:                  "agents/code.md",
+		Plugins:                []string{"plugins/gopls-lsp"},
+		AllowedRemoteResources: []string{"https://raw.githubusercontent.com/fullsend-ai/"},
+	}
+
+	printer := ui.New(os.Stdout)
+	lockResult, err := resolveFromLock(h, entry, root, printer)
+	require.NoError(t, err)
+	require.Len(t, lockResult.Deps, 1)
+
+	assert.Equal(t, "gopls-lsp", filepath.Base(h.Plugins[0]),
+		"plugin basename must be derived from the URL directory, not the marker file")
+	assert.False(t, harness.IsURL(h.Plugins[0]))
+	assert.FileExists(t, filepath.Join(h.Plugins[0], "plugin.json"))
+}
+
 func TestResolveFromLock_LocalPathsSurviveStrip(t *testing.T) {
 	// When a harness has URL resources (with lock deps) AND local-path
 	// profiles/providers (without lock deps), the lock strip must keep the

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -1554,12 +1554,9 @@ func fetchBasePlugin(ctx context.Context, field, baseURLDir, pluginPath string, 
 	}
 
 	if opts.FetchPolicy.Offline {
-		if staleFallback != nil {
-			if cErr := ChmodPluginDir(staleFallbackPath); cErr != nil {
-				return Dependency{}, "", fmt.Errorf("base %s: setting plugin permissions: %w", field, cErr)
-			}
-			return *staleFallback, staleFallbackPath, nil
-		}
+		// staleFallback is only set when Offline=false (line above), so it
+		// is always nil here; skip the nil guard and go straight to the
+		// cache-miss error.
 		return Dependency{}, "", fmt.Errorf("base %s: URL %s not in cache and offline mode is enabled (run 'fullsend lock' first)", field, pluginFileURL)
 	}
 

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -191,7 +191,7 @@ func LoadWithBase(ctx context.Context, path string, opts ComposeOpts) (*Harness,
 	child.Base = ""
 
 	// When the harness was fetched from a URL, the child may still have
-	// relative resource paths (skills, agent, policy, host_files, scripts)
+	// relative resource paths (skills, plugins, agent, policy, host_files, scripts)
 	// that originated in the child harness — not the base. After merge,
 	// base resources are absolute cache paths but the child's own relative
 	// paths remain unresolved. Resolve them against the SourceURL now,
@@ -1630,12 +1630,14 @@ func fetchBasePluginDir(ctx context.Context, field, pluginDirURL, pluginFileURL,
 	if resolveErr != nil {
 		return Dependency{}, "", fmt.Errorf("base %s: resolving plugin symlink: %w", field, resolveErr)
 	}
-	_ = filepath.Walk(resolved, func(p string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil || info.IsDir() {
-			return walkErr
+	if walkErr := filepath.Walk(resolved, func(p string, info os.FileInfo, wErr error) error {
+		if wErr != nil || info.IsDir() {
+			return wErr
 		}
 		return os.Chmod(p, 0o755)
-	})
+	}); walkErr != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: setting plugin permissions: %w", field, walkErr)
+	}
 
 	return Dependency{
 		Field:     field,

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -1543,6 +1543,9 @@ func fetchBasePlugin(ctx context.Context, field, baseURLDir, pluginPath string, 
 					if aErr := auditBaseFetch(opts, pluginFileURL, treeHash, allowedBy, true, entry.FetchTime, "plugin"); aErr != nil {
 						return Dependency{}, "", aErr
 					}
+					if cErr := ChmodPluginDir(treePath); cErr != nil {
+						return Dependency{}, "", fmt.Errorf("base %s: setting plugin permissions: %w", field, cErr)
+					}
 					return cachedDep, treePath, nil
 				}
 			}
@@ -1552,6 +1555,9 @@ func fetchBasePlugin(ctx context.Context, field, baseURLDir, pluginPath string, 
 
 	if opts.FetchPolicy.Offline {
 		if staleFallback != nil {
+			if cErr := ChmodPluginDir(staleFallbackPath); cErr != nil {
+				return Dependency{}, "", fmt.Errorf("base %s: setting plugin permissions: %w", field, cErr)
+			}
 			return *staleFallback, staleFallbackPath, nil
 		}
 		return Dependency{}, "", fmt.Errorf("base %s: URL %s not in cache and offline mode is enabled (run 'fullsend lock' first)", field, pluginFileURL)
@@ -1563,6 +1569,9 @@ func fetchBasePlugin(ctx context.Context, field, baseURLDir, pluginPath string, 
 			return Dependency{}, "", err
 		}
 		staleFallback.Warning = fmt.Sprintf("using stale cached content (re-fetch failed: %s)", err)
+		if cErr := ChmodPluginDir(staleFallbackPath); cErr != nil {
+			return Dependency{}, "", fmt.Errorf("base %s: setting plugin permissions: %w", field, cErr)
+		}
 		return *staleFallback, staleFallbackPath, nil
 	}
 	return dep, dirPath, err
@@ -1624,19 +1633,8 @@ func fetchBasePluginDir(ctx context.Context, field, pluginDirURL, pluginFileURL,
 		return Dependency{}, "", aErr
 	}
 
-	// Make plugin files executable -- plugins may contain scripts or MCP
-	// server binaries that need the execute bit.
-	resolved, resolveErr := filepath.EvalSymlinks(treePath)
-	if resolveErr != nil {
-		return Dependency{}, "", fmt.Errorf("base %s: resolving plugin symlink: %w", field, resolveErr)
-	}
-	if walkErr := filepath.Walk(resolved, func(p string, info os.FileInfo, wErr error) error {
-		if wErr != nil || info.IsDir() {
-			return wErr
-		}
-		return os.Chmod(p, 0o755)
-	}); walkErr != nil {
-		return Dependency{}, "", fmt.Errorf("base %s: setting plugin permissions: %w", field, walkErr)
+	if err := ChmodPluginDir(treePath); err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: setting plugin permissions: %w", field, err)
 	}
 
 	return Dependency{

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -1067,7 +1067,7 @@ func resolveBasePlugins(ctx context.Context, base *Harness, baseURL string, allo
 		if err := validateBaseRelPath(fieldName, p); err != nil {
 			return nil, err
 		}
-		if base := filepath.Base(p); !ValidPluginBasename(base) {
+		if baseName := filepath.Base(p); !ValidPluginBasename(baseName) {
 			return nil, fmt.Errorf("base %s path %q does not end in a valid plugin basename (allowed: a-z, A-Z, 0-9, _, -)", fieldName, p)
 		}
 		dep, localDir, err := fetchBasePlugin(ctx, fieldName, baseURLDir, p, allowlist, opts)

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -191,7 +191,7 @@ func LoadWithBase(ctx context.Context, path string, opts ComposeOpts) (*Harness,
 	child.Base = ""
 
 	// When the harness was fetched from a URL, the child may still have
-	// relative resource paths (skills, plugins, agent, policy, host_files, scripts)
+	// relative resource paths (agent, policy, skills, plugins, host_files, scripts, profiles, providers)
 	// that originated in the child harness — not the base. After merge,
 	// base resources are absolute cache paths but the child's own relative
 	// paths remain unresolved. Resolve them against the SourceURL now,

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -140,6 +140,12 @@ func LoadWithBase(ctx context.Context, path string, opts ComposeOpts) (*Harness,
 				return nil, nil, fmt.Errorf("resolving URL-sourced providers: %w", err)
 			}
 			deps = append(deps, providerDeps...)
+
+			pluginDeps, err := resolveBasePlugins(ctx, child, opts.SourceURL, opts.OrgAllowlist, opts)
+			if err != nil {
+				return nil, nil, fmt.Errorf("resolving URL-sourced plugins: %w", err)
+			}
+			deps = append(deps, pluginDeps...)
 		}
 
 		if err := child.validateForge(); err != nil {
@@ -229,6 +235,12 @@ func LoadWithBase(ctx context.Context, path string, opts ComposeOpts) (*Harness,
 			return nil, nil, fmt.Errorf("resolving URL-sourced providers after base composition: %w", err)
 		}
 		deps = append(deps, providerDeps...)
+
+		pluginDeps, err := resolveBasePlugins(ctx, child, opts.SourceURL, allowlist, opts)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving URL-sourced plugins after base composition: %w", err)
+		}
+		deps = append(deps, pluginDeps...)
 	}
 
 	// ResolveForge once on the merged result
@@ -331,6 +343,12 @@ func loadBaseChain(
 			return nil, nil, fmt.Errorf("resolving base providers from %s: %w", cleanURL, err)
 		}
 		deps = append(deps, providerDeps...)
+
+		pluginDeps, err := resolveBasePlugins(ctx, base, baseRef, allowlist, opts)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving base plugins from %s: %w", cleanURL, err)
+		}
+		deps = append(deps, pluginDeps...)
 
 		baseDir = childDir
 	} else {
@@ -1024,6 +1042,41 @@ func resolveBaseProviders(ctx context.Context, base *Harness, baseURL string, al
 	return deps, nil
 }
 
+// resolveBasePlugins fetches plugin directories with relative paths from a
+// URL-referenced base harness, the same way resolveBaseResources handles
+// skills. Plugins are directories (fetched via fetchBasePlugin) that use
+// plugin.json as their marker file instead of SKILL.md.
+func resolveBasePlugins(ctx context.Context, base *Harness, baseURL string, allowlist []string, opts ComposeOpts) ([]Dependency, error) {
+	if len(base.Plugins) == 0 {
+		return nil, nil
+	}
+
+	baseURLDir := urlParentDirPrefix(baseURL)
+	if baseURLDir == "" {
+		return nil, fmt.Errorf("cannot determine directory from base URL")
+	}
+
+	var deps []Dependency
+
+	for i, p := range base.Plugins {
+		if p == "" || IsURL(p) || isFullsendCachePath(p, opts.WorkspaceRoot) {
+			continue
+		}
+		fieldName := fmt.Sprintf("plugins[%d]", i)
+		if err := validateBaseRelPath(fieldName, p); err != nil {
+			return nil, err
+		}
+		dep, localDir, err := fetchBasePlugin(ctx, fieldName, baseURLDir, p, allowlist, opts)
+		if err != nil {
+			return nil, err
+		}
+		base.Plugins[i] = localDir
+		deps = append(deps, dep)
+	}
+
+	return deps, nil
+}
+
 // validateBaseRelPath validates that a relative path inherited from a URL base
 // is safe to resolve. Rejects null bytes, query/fragment markers, URLs,
 // absolute paths, and path traversal segments.
@@ -1442,6 +1495,151 @@ func fetchBaseSkillDir(ctx context.Context, field, skillDirURL, skillFileURL, sk
 	return Dependency{
 		Field:     field,
 		URL:       skillFileURL,
+		LocalPath: treePath,
+		SHA256:    treeHash,
+		FetchedAt: fetchedAt,
+		CacheHit:  false,
+		Type:      "directory",
+	}, treePath, nil
+}
+
+// fetchBasePlugin fetches a plugin directory from a URL-referenced base harness.
+// It mirrors fetchBaseSkill but uses plugin.json as the marker file instead of
+// SKILL.md, and uses "plugin:" as the cache index prefix.
+func fetchBasePlugin(ctx context.Context, field, baseURLDir, pluginPath string, allowlist []string, opts ComposeOpts) (Dependency, string, error) {
+	pluginDirURL := baseURLDir + pluginPath
+	pluginFileURL := pluginDirURL + "/plugin.json"
+
+	allowedBy := matchingAllowedPrefix(pluginFileURL, allowlist)
+	if allowedBy == "" {
+		return Dependency{}, "", fmt.Errorf("base %s: URL %q is not in allowed_remote_resources", field, pluginFileURL)
+	}
+
+	hash, indexHit := urlIndexLookup(opts.WorkspaceRoot, pluginFileURL)
+	var staleFallback *Dependency
+	var staleFallbackPath string
+	if indexHit {
+		treeHash, ok := urlIndexLookup(opts.WorkspaceRoot, "plugin:"+pluginFileURL)
+		if ok {
+			treePath, entry, err := fetch.CacheGetDir(opts.WorkspaceRoot, treeHash)
+			if err == nil && treePath != "" {
+				treePath, err = fetch.CacheNamedSymlink(treePath, filepath.Base(pluginPath))
+				if err != nil {
+					return Dependency{}, "", fmt.Errorf("base %s: %w", field, err)
+				}
+				cachedDep := Dependency{
+					Field:     field,
+					URL:       pluginFileURL,
+					LocalPath: treePath,
+					SHA256:    treeHash,
+					FetchedAt: entry.FetchTime,
+					CacheHit:  true,
+					Type:      "directory",
+				}
+				if !entry.FullListing && !opts.FetchPolicy.Offline {
+					staleFallback = &cachedDep
+					staleFallbackPath = treePath
+				} else {
+					if aErr := auditBaseFetch(opts, pluginFileURL, treeHash, allowedBy, true, entry.FetchTime, "plugin"); aErr != nil {
+						return Dependency{}, "", aErr
+					}
+					return cachedDep, treePath, nil
+				}
+			}
+		}
+		_ = hash
+	}
+
+	if opts.FetchPolicy.Offline {
+		if staleFallback != nil {
+			return *staleFallback, staleFallbackPath, nil
+		}
+		return Dependency{}, "", fmt.Errorf("base %s: URL %s not in cache and offline mode is enabled (run 'fullsend lock' first)", field, pluginFileURL)
+	}
+
+	dep, dirPath, err := fetchBasePluginDir(ctx, field, pluginDirURL, pluginFileURL, pluginPath, allowedBy, allowlist, opts)
+	if err != nil && staleFallback != nil {
+		if !isTransientFetchError(err) {
+			return Dependency{}, "", err
+		}
+		staleFallback.Warning = fmt.Sprintf("using stale cached content (re-fetch failed: %s)", err)
+		return *staleFallback, staleFallbackPath, nil
+	}
+	return dep, dirPath, err
+}
+
+// fetchBasePluginDir fetches the full plugin directory via git sparse checkout.
+func fetchBasePluginDir(ctx context.Context, field, pluginDirURL, pluginFileURL, pluginPath, allowedBy string, allowlist []string, opts ComposeOpts) (Dependency, string, error) {
+	dirPrefix := pluginDirURL + "/"
+	if ab := matchingAllowedPrefix(dirPrefix, allowlist); ab == "" {
+		return Dependency{}, "", fmt.Errorf("base %s: plugin directory URL %q is not in allowed_remote_resources", field, dirPrefix)
+	}
+
+	forgeInfo, err := forge.ParseRawContentURL(pluginDirURL)
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: parsing raw URL for plugin directory fetch: %w", field, err)
+	}
+
+	fetcher := opts.TreeFetcher
+	if fetcher == nil {
+		fetcher = gitfetch.FetchTree
+	}
+
+	files, err := fetcher(ctx, forgeInfo.CloneURL(), forgeInfo.Path, forgeInfo.Ref, opts.GitToken)
+	if err != nil {
+		if opts.GitToken == "" {
+			return Dependency{}, "", fmt.Errorf("base %s: fetching plugin directory %s: %w (hint: set GH_TOKEN or GITHUB_TOKEN for private repos)", field, pluginPath, err)
+		}
+		return Dependency{}, "", fmt.Errorf("base %s: fetching plugin directory %s: %w", field, pluginPath, err)
+	}
+
+	if _, ok := files["plugin.json"]; !ok {
+		return Dependency{}, "", fmt.Errorf("base %s: plugin directory %s has no plugin.json", field, pluginPath)
+	}
+
+	treeHash, err := fetch.CachePutDir(opts.WorkspaceRoot, pluginFileURL, files, fetch.DirCachePutOpts{FullListing: true})
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: caching plugin directory: %w", field, err)
+	}
+
+	treePath, _, err := fetch.CacheGetDir(opts.WorkspaceRoot, treeHash)
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: reading cached plugin directory: %w", field, err)
+	}
+
+	treePath, err = fetch.CacheNamedSymlink(treePath, filepath.Base(forgeInfo.Path))
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: %w", field, err)
+	}
+
+	if iErr := urlIndexPut(opts.WorkspaceRoot, pluginFileURL, treeHash); iErr != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: updating URL index: %w", field, iErr)
+	}
+	if iErr := urlIndexPut(opts.WorkspaceRoot, "plugin:"+pluginFileURL, treeHash); iErr != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: updating URL index for plugin tree: %w", field, iErr)
+	}
+
+	fetchedAt := time.Now().UTC()
+	if aErr := auditBaseFetch(opts, pluginFileURL, treeHash, allowedBy, false, fetchedAt, "plugin"); aErr != nil {
+		return Dependency{}, "", aErr
+	}
+
+	// Make plugin files executable -- plugins may contain scripts or MCP
+	// server binaries that need the execute bit.
+	resolved, resolveErr := filepath.EvalSymlinks(treePath)
+	if resolveErr != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: resolving plugin symlink: %w", field, resolveErr)
+	}
+	_ = filepath.Walk(resolved, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info.IsDir() {
+			return walkErr
+		}
+		return os.Chmod(p, 0o755)
+	})
+
+	return Dependency{
+		Field:     field,
+		URL:       pluginFileURL,
 		LocalPath: treePath,
 		SHA256:    treeHash,
 		FetchedAt: fetchedAt,

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -191,7 +191,8 @@ func LoadWithBase(ctx context.Context, path string, opts ComposeOpts) (*Harness,
 	child.Base = ""
 
 	// When the harness was fetched from a URL, the child may still have
-	// relative resource paths (agent, policy, skills, plugins, host_files, scripts, profiles, providers)
+	// relative resource paths (including scripts, agent, policy, skills,
+	// host_files, profiles, providers, and plugins)
 	// that originated in the child harness — not the base. After merge,
 	// base resources are absolute cache paths but the child's own relative
 	// paths remain unresolved. Resolve them against the SourceURL now,
@@ -1043,9 +1044,9 @@ func resolveBaseProviders(ctx context.Context, base *Harness, baseURL string, al
 }
 
 // resolveBasePlugins fetches plugin directories with relative paths from a
-// URL-referenced base harness, the same way resolveBaseResources handles
-// skills. Plugins are directories (fetched via fetchBasePlugin) that use
-// plugin.json as their marker file instead of SKILL.md.
+// URL-referenced base harness, following the same pattern as
+// resolveBaseResources. Plugins are directories (fetched via fetchBasePlugin)
+// that use plugin.json as their marker file instead of SKILL.md.
 func resolveBasePlugins(ctx context.Context, base *Harness, baseURL string, allowlist []string, opts ComposeOpts) ([]Dependency, error) {
 	if len(base.Plugins) == 0 {
 		return nil, nil
@@ -1065,6 +1066,9 @@ func resolveBasePlugins(ctx context.Context, base *Harness, baseURL string, allo
 		fieldName := fmt.Sprintf("plugins[%d]", i)
 		if err := validateBaseRelPath(fieldName, p); err != nil {
 			return nil, err
+		}
+		if base := filepath.Base(p); !ValidPluginBasename(base) {
+			return nil, fmt.Errorf("base %s path %q does not end in a valid plugin basename (allowed: a-z, A-Z, 0-9, _, -)", fieldName, p)
 		}
 		dep, localDir, err := fetchBasePlugin(ctx, fieldName, baseURLDir, p, allowlist, opts)
 		if err != nil {

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -6728,3 +6728,89 @@ plugins:
 	require.NoError(t, h.ValidateFilesExist(),
 		"plugin path should have been resolved to a cache path, not left as a relative path")
 }
+
+func TestFetchBasePluginDir_FullDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fetcher := fakeTreeFetcher(map[string][]byte{
+		"plugin.json": []byte(`{"name":"gopls-lsp"}`),
+		"bin/gopls":   []byte("#!/bin/sh\nexec gopls"),
+	})
+
+	baseURLDir := "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/"
+	pluginDirURL := baseURLDir + "plugins/gopls-lsp"
+	pluginFileURL := pluginDirURL + "/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/fullsend-ai/agents/"}
+
+	dep, localDir, err := fetchBasePluginDir(context.Background(), "plugins[0]",
+		pluginDirURL, pluginFileURL, "plugins/gopls-lsp", "fullsend-ai/agents", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   fetcher,
+		})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, localDir)
+	assert.Equal(t, "directory", dep.Type)
+	assert.Empty(t, dep.Warning)
+	assert.False(t, dep.CacheHit)
+	assert.Equal(t, "gopls-lsp", filepath.Base(localDir))
+
+	pluginJSON, err := os.ReadFile(filepath.Join(localDir, "plugin.json"))
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"gopls-lsp"}`, string(pluginJSON))
+
+	binGopls, err := os.ReadFile(filepath.Join(localDir, "bin", "gopls"))
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/sh\nexec gopls", string(binGopls))
+
+	info, err := os.Stat(filepath.Join(localDir, "bin", "gopls"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+		"plugin files should be chmod 0755")
+}
+
+func TestFetchBasePluginDir_NoPluginJSON(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fetcher := fakeTreeFetcher(map[string][]byte{
+		"bin/gopls": []byte("#!/bin/sh"),
+	})
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref1/"
+	pluginDirURL := baseURLDir + "plugins/gopls-lsp"
+	pluginFileURL := pluginDirURL + "/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	_, _, err := fetchBasePluginDir(context.Background(), "plugins[0]",
+		pluginDirURL, pluginFileURL, "plugins/gopls-lsp", "org/repo", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   fetcher,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no plugin.json")
+}
+
+func TestFetchBasePluginDir_FetchError(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	failFetcher := func(_ context.Context, _, _, _, _ string) (map[string][]byte, error) {
+		return nil, fmt.Errorf("network timeout")
+	}
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref1/"
+	pluginDirURL := baseURLDir + "plugins/gopls-lsp"
+	pluginFileURL := pluginDirURL + "/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	_, _, err := fetchBasePluginDir(context.Background(), "plugins[0]",
+		pluginDirURL, pluginFileURL, "plugins/gopls-lsp", "org/repo", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   failFetcher,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetching plugin directory")
+	assert.Contains(t, err.Error(), "network timeout")
+}

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -7034,3 +7034,247 @@ func TestResolveBasePlugins_InvalidBaseURL(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot determine directory")
 }
+
+func TestResolveBasePlugins_PathTraversal(t *testing.T) {
+	base := &Harness{Plugins: []string{"../../../etc/shadow"}}
+	_, err := resolveBasePlugins(context.Background(), base,
+		"https://raw.githubusercontent.com/org/repo/ref/harness/triage.yaml",
+		[]string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestResolveBasePlugins_SkipsEmptyURLAndCache(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	base := &Harness{Plugins: []string{
+		"",
+		"https://example.com/plugin",
+		filepath.Join(cacheDir, ".fullsend-cache/sha256/abc/my-plugin"),
+	}}
+	deps, err := resolveBasePlugins(context.Background(), base,
+		"https://raw.githubusercontent.com/org/repo/ref/harness/triage.yaml",
+		nil, ComposeOpts{WorkspaceRoot: cacheDir})
+	require.NoError(t, err)
+	assert.Empty(t, deps, "empty, URL, and cache paths should be skipped")
+}
+
+func TestFetchBasePluginDir_NarrowAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fetcher := fakeTreeFetcher(map[string][]byte{
+		"plugin.json": []byte(`{"name":"gopls-lsp"}`),
+	})
+
+	narrowAllowlist := []string{
+		"https://raw.githubusercontent.com/org/repo/ref1/plugins/gopls-lsp/plugin.json",
+	}
+
+	_, _, err := fetchBasePluginDir(context.Background(), "plugins[0]",
+		"https://raw.githubusercontent.com/org/repo/ref1/plugins/gopls-lsp",
+		"https://raw.githubusercontent.com/org/repo/ref1/plugins/gopls-lsp/plugin.json",
+		"plugins/gopls-lsp", "org/repo", narrowAllowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   fetcher,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugin directory URL")
+	assert.Contains(t, err.Error(), "not in allowed_remote_resources")
+}
+
+func TestFetchBasePluginDir_FetchErrorWithToken(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	failFetcher := func(_ context.Context, _, _, _, _ string) (map[string][]byte, error) {
+		return nil, fmt.Errorf("git fetch failed")
+	}
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref1/"
+	pluginDirURL := baseURLDir + "plugins/gopls-lsp"
+	pluginFileURL := pluginDirURL + "/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	_, _, err := fetchBasePluginDir(context.Background(), "plugins[0]",
+		pluginDirURL, pluginFileURL, "plugins/gopls-lsp", "org/repo", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   failFetcher,
+			GitToken:      "ghp_test123",
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetching plugin directory")
+	assert.NotContains(t, err.Error(), "hint:")
+}
+
+func TestFetchBasePluginDir_FetchErrorNoToken(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	failFetcher := func(_ context.Context, _, _, _, _ string) (map[string][]byte, error) {
+		return nil, fmt.Errorf("git fetch failed")
+	}
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref1/"
+	pluginDirURL := baseURLDir + "plugins/gopls-lsp"
+	pluginFileURL := pluginDirURL + "/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	_, _, err := fetchBasePluginDir(context.Background(), "plugins[0]",
+		pluginDirURL, pluginFileURL, "plugins/gopls-lsp", "org/repo", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   failFetcher,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hint:")
+}
+
+func TestLoadWithBase_SourceURL_PluginPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	// Pre-populate agent in cache so resolveBaseResources succeeds
+	agentRes := []byte("# triage agent")
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/agents/triage.md", agentRes))
+	require.NoError(t, urlIndexPut(cacheDir, "https://example.com/agents/triage.md", fetch.ComputeSHA256(agentRes)))
+
+	path := writeTestHarness(t, dir, "triage.yaml", `
+role: test
+slug: test
+agent: agents/triage.md
+plugins:
+  - ../../../etc/shadow
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		SourceURL:     "https://example.com/harness/triage.yaml",
+		OrgAllowlist:  []string{"https://example.com/"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving URL-sourced plugins")
+}
+
+func TestLoadWithBase_URLBase_PluginPathTraversalAfterMerge(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseContent := []byte(`
+agent: agents/remote.md
+role: test
+`)
+	hash := computeHash(baseContent)
+
+	// Pre-populate agent + base in cache
+	agentRes := []byte("# test agent")
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/base.yaml", baseContent))
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/agents/remote.md", agentRes))
+	require.NoError(t, urlIndexPut(cacheDir, "https://example.com/agents/remote.md", fetch.ComputeSHA256(agentRes)))
+
+	baseURL := "https://example.com/base.yaml#sha256=" + hash
+
+	// The child harness is loaded from a SourceURL and has a path-traversal plugin.
+	// The base is clean, but after merge, the child's plugin remains.
+	// resolveBasePlugins is called on the merged harness with the SourceURL.
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: `+baseURL+`
+plugins:
+  - ../../../etc/shadow
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		OrgAllowlist:  []string{"https://example.com/"},
+		SourceURL:     "https://example.com/harness/child.yaml",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving URL-sourced plugins after base composition")
+}
+
+func TestChmodPluginDir_NonexistentSymlink(t *testing.T) {
+	err := ChmodPluginDir(filepath.Join(t.TempDir(), "nonexistent-link"))
+	require.Error(t, err)
+}
+
+func TestLoadWithBase_URLBase_PluginInChainedBase(t *testing.T) {
+	pluginContent := []byte(`{"name":"gopls-lsp"}`)
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	grandparentContent := []byte(`
+agent: agents/grandparent.md
+role: test
+model: opus
+plugins:
+  - plugins/gopls-lsp
+`)
+	grandparentHash := computeHash(grandparentContent)
+
+	parentContent := []byte(`
+agent: agents/parent.md
+role: test
+base: https://example.com/grandparent.yaml#sha256=` + grandparentHash + `
+`)
+	parentHash := computeHash(parentContent)
+
+	// Pre-populate cache: parent harness
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/parent.yaml", parentContent))
+	// Pre-populate cache: grandparent harness
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/grandparent.yaml", grandparentContent))
+	// Pre-populate cache: agent resources
+	agentRes := []byte("# test agent")
+	for _, agentURL := range []string{
+		"https://example.com/agents/grandparent.md",
+		"https://example.com/agents/parent.md",
+	} {
+		require.NoError(t, fetch.CachePut(cacheDir, agentURL, agentRes))
+		require.NoError(t, urlIndexPut(cacheDir, agentURL, fetch.ComputeSHA256(agentRes)))
+	}
+	// Pre-populate cache: plugin directory
+	pluginFileURL := "https://example.com/plugins/gopls-lsp/plugin.json"
+	require.NoError(t, fetch.CachePut(cacheDir, pluginFileURL, pluginContent))
+	pluginFileHash := fetch.ComputeSHA256(pluginContent)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, pluginFileHash))
+	files := map[string][]byte{"plugin.json": pluginContent}
+	treeHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, files, fetch.DirCachePutOpts{FullListing: true})
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, treeHash))
+
+	baseURL := "https://example.com/parent.yaml#sha256=" + parentHash
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+role: test
+base: `+baseURL+`
+`)
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		OrgAllowlist:  []string{"https://example.com/"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "agents/child.md", h.Agent)
+	assert.Equal(t, "opus", h.Model)
+
+	require.Len(t, h.Plugins, 1)
+	assert.True(t, filepath.IsAbs(h.Plugins[0]),
+		"plugin should be resolved to cache path, got %s", h.Plugins[0])
+
+	pluginJSON, err := os.ReadFile(filepath.Join(h.Plugins[0], "plugin.json"))
+	require.NoError(t, err)
+	assert.Equal(t, pluginContent, pluginJSON)
+
+	var foundPlugin bool
+	for _, d := range deps {
+		if d.Field == "plugins[0]" {
+			foundPlugin = true
+			assert.Equal(t, "directory", d.Type)
+		}
+	}
+	assert.True(t, foundPlugin, "should have plugin dependency")
+}

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -6529,3 +6529,202 @@ providers:
 	}
 	assert.True(t, fieldNames["providers[0]"], "should have provider dep")
 }
+
+func TestLoadWithBase_URLBase_PluginFetchedAsDir(t *testing.T) {
+	baseContent := []byte(`
+agent: agents/triage.md
+role: test
+plugins:
+  - plugins/gopls-lsp
+`)
+
+	server, policy := setupScriptTestServer(t, baseContent, map[string][]byte{
+		"/plugins/gopls-lsp/plugin.json": []byte(`{"name":"gopls-lsp"}`),
+	})
+
+	hash := computeHash(baseContent)
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	baseURL := server.URL + "/harness/triage.yaml#sha256=" + hash
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+role: test
+base: `+baseURL+`
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   policy,
+		OrgAllowlist:  []string{server.URL + "/"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a raw.githubusercontent.com URL")
+}
+
+func TestLoadWithBase_URLBase_PluginOfflineCacheHit(t *testing.T) {
+	pluginContent := []byte(`{"name":"gopls-lsp"}`)
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseContent := []byte(`
+agent: agents/triage.md
+role: test
+plugins:
+  - plugins/gopls-lsp
+`)
+	hash := computeHash(baseContent)
+
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/harness/triage.yaml", baseContent))
+
+	agentRes := []byte("# triage agent")
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/agents/triage.md", agentRes))
+	require.NoError(t, urlIndexPut(cacheDir, "https://example.com/agents/triage.md", fetch.ComputeSHA256(agentRes)))
+
+	pluginFileURL := "https://example.com/plugins/gopls-lsp/plugin.json"
+	require.NoError(t, fetch.CachePut(cacheDir, pluginFileURL, pluginContent))
+	pluginFileHash := fetch.ComputeSHA256(pluginContent)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, pluginFileHash))
+
+	files := map[string][]byte{"plugin.json": pluginContent}
+	treeHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, files)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, treeHash))
+
+	baseURL := "https://example.com/harness/triage.yaml#sha256=" + hash
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+role: test
+base: `+baseURL+`
+`)
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		OrgAllowlist:  []string{"https://example.com/"},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, h.Plugins, 1)
+	assert.True(t, filepath.IsAbs(h.Plugins[0]))
+
+	cachedPlugin := filepath.Join(h.Plugins[0], "plugin.json")
+	content, err := os.ReadFile(cachedPlugin)
+	require.NoError(t, err)
+	assert.Equal(t, pluginContent, content)
+
+	assert.True(t, deps[len(deps)-1].CacheHit, "plugin should be cache hit")
+	assert.Equal(t, "directory", deps[len(deps)-1].Type)
+}
+
+func TestLoadWithBase_SourceURL_Plugins(t *testing.T) {
+	pluginContent := []byte(`{"name":"gopls-lsp"}`)
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	harnessContent := []byte(`
+role: test
+slug: test
+agent: agents/triage.md
+plugins:
+  - plugins/gopls-lsp
+`)
+
+	pluginFileURL := "https://example.com/plugins/gopls-lsp/plugin.json"
+	require.NoError(t, fetch.CachePut(cacheDir, pluginFileURL, pluginContent))
+	pluginFileHash := fetch.ComputeSHA256(pluginContent)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, pluginFileHash))
+
+	files := map[string][]byte{"plugin.json": pluginContent}
+	treeHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, files)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, treeHash))
+
+	agentRes := []byte("# triage agent")
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/agents/triage.md", agentRes))
+	require.NoError(t, urlIndexPut(cacheDir, "https://example.com/agents/triage.md", fetch.ComputeSHA256(agentRes)))
+
+	path := writeTestHarness(t, dir, "triage.yaml", string(harnessContent))
+
+	sourceURL := "https://example.com/harness/triage.yaml"
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		OrgAllowlist:  []string{"https://example.com/"},
+		SourceURL:     sourceURL,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, h.Plugins, 1)
+	assert.True(t, filepath.IsAbs(h.Plugins[0]),
+		"plugin should be resolved to cache path, got %s", h.Plugins[0])
+
+	cachedPlugin := filepath.Join(h.Plugins[0], "plugin.json")
+	content, err := os.ReadFile(cachedPlugin)
+	require.NoError(t, err)
+	assert.Equal(t, pluginContent, content)
+
+	fieldNames := map[string]bool{}
+	for _, d := range deps {
+		fieldNames[d.Field] = true
+	}
+	assert.True(t, fieldNames["plugins[0]"], "should have plugin dep")
+}
+
+// Regression test for the bug where a harness fetched from a remote source
+// (e.g. fullsend-ai/agents) had relative plugin paths that were not resolved
+// against the source URL. ResolveRelativeTo would resolve them against the
+// target repo's .fullsend dir (where the plugin doesn't exist), and
+// ValidateFilesExist would fail with "no such file or directory".
+func TestLoadWithBase_SourceURL_PluginPassesValidateFilesExist(t *testing.T) {
+	pluginContent := []byte(`{"name":"gopls-lsp"}`)
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	fullsendDir := filepath.Join(dir, "fullsend")
+	require.NoError(t, os.MkdirAll(fullsendDir, 0o755))
+
+	harnessContent := []byte(`
+role: test
+slug: test
+agent: agents/triage.md
+plugins:
+  - plugins/gopls-lsp
+`)
+
+	pluginFileURL := "https://example.com/plugins/gopls-lsp/plugin.json"
+	require.NoError(t, fetch.CachePut(cacheDir, pluginFileURL, pluginContent))
+	pluginFileHash := fetch.ComputeSHA256(pluginContent)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, pluginFileHash))
+
+	files := map[string][]byte{"plugin.json": pluginContent}
+	treeHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, files)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, treeHash))
+
+	agentRes := []byte("# triage agent")
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/agents/triage.md", agentRes))
+	require.NoError(t, urlIndexPut(cacheDir, "https://example.com/agents/triage.md", fetch.ComputeSHA256(agentRes)))
+
+	path := writeTestHarness(t, dir, "triage.yaml", string(harnessContent))
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		OrgAllowlist:  []string{"https://example.com/"},
+		SourceURL:     "https://example.com/harness/triage.yaml",
+	})
+	require.NoError(t, err)
+
+	// Simulate what run.go does: ResolveRelativeTo then ValidateFilesExist.
+	// Without the fix, ResolveRelativeTo would resolve "plugins/gopls-lsp"
+	// against fullsendDir (where it does not exist) and ValidateFilesExist
+	// would fail.
+	require.NoError(t, h.ResolveRelativeTo(fullsendDir))
+	require.NoError(t, h.ValidateFilesExist(),
+		"plugin path should have been resolved to a cache path, not left as a relative path")
+}

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -7044,6 +7044,15 @@ func TestResolveBasePlugins_PathTraversal(t *testing.T) {
 	assert.Contains(t, err.Error(), "path traversal")
 }
 
+func TestResolveBasePlugins_InvalidBasename(t *testing.T) {
+	base := &Harness{Plugins: []string{"plugins/bad name"}}
+	_, err := resolveBasePlugins(context.Background(), base,
+		"https://raw.githubusercontent.com/org/repo/ref/harness/triage.yaml",
+		[]string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "valid plugin basename")
+}
+
 func TestResolveBasePlugins_SkipsEmptyURLAndCache(t *testing.T) {
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -6814,3 +6814,223 @@ func TestFetchBasePluginDir_FetchError(t *testing.T) {
 	assert.Contains(t, err.Error(), "fetching plugin directory")
 	assert.Contains(t, err.Error(), "network timeout")
 }
+
+func TestFetchBasePlugin_AllowlistRejection(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	_, _, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"plugins/gopls-lsp", []string{"https://raw.githubusercontent.com/other/"}, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowed_remote_resources")
+}
+
+func TestFetchBasePlugin_FreshFetch(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fetcher := fakeTreeFetcher(map[string][]byte{
+		"plugin.json": []byte(`{"name":"gopls-lsp"}`),
+	})
+
+	dep, localDir, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"plugins/gopls-lsp", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   fetcher,
+		})
+	require.NoError(t, err)
+	assert.False(t, dep.CacheHit)
+	assert.Equal(t, "directory", dep.Type)
+	assert.FileExists(t, filepath.Join(localDir, "plugin.json"))
+}
+
+func TestFetchBasePlugin_FullCacheHit(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref/"
+	pluginFileURL := baseURLDir + "plugins/gopls-lsp/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	files := map[string][]byte{"plugin.json": []byte(`{"name":"gopls-lsp"}`)}
+	treeHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, files, fetch.DirCachePutOpts{FullListing: true})
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, treeHash))
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, treeHash))
+
+	dep, localDir, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		baseURLDir, "plugins/gopls-lsp", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+		})
+	require.NoError(t, err)
+	assert.True(t, dep.CacheHit)
+	assert.Equal(t, "directory", dep.Type)
+	assert.FileExists(t, filepath.Join(localDir, "plugin.json"))
+}
+
+func TestFetchBasePlugin_StaleCacheInvalidation(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref/"
+	pluginFileURL := baseURLDir + "plugins/gopls-lsp/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	oldFiles := map[string][]byte{"plugin.json": []byte(`{"name":"old"}`)}
+	oldHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, oldFiles)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, oldHash))
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, oldHash))
+
+	fetcher := fakeTreeFetcher(map[string][]byte{
+		"plugin.json": []byte(`{"name":"gopls-lsp"}`),
+		"bin/gopls":   []byte("#!/bin/sh"),
+	})
+
+	dep, localDir, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		baseURLDir, "plugins/gopls-lsp", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   fetcher,
+		})
+	require.NoError(t, err)
+	assert.False(t, dep.CacheHit, "stale cache should be bypassed")
+	assert.FileExists(t, filepath.Join(localDir, "plugin.json"))
+	assert.FileExists(t, filepath.Join(localDir, "bin", "gopls"))
+
+	dep2, _, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		baseURLDir, "plugins/gopls-lsp", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   fetcher,
+		})
+	require.NoError(t, err)
+	assert.True(t, dep2.CacheHit, "re-fetched entry should be cached")
+}
+
+func TestFetchBasePlugin_StaleCacheOfflineServesStale(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref/"
+	pluginFileURL := baseURLDir + "plugins/gopls-lsp/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	oldFiles := map[string][]byte{"plugin.json": []byte(`{"name":"old"}`)}
+	oldHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, oldFiles)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, oldHash))
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, oldHash))
+
+	dep, localDir, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		baseURLDir, "plugins/gopls-lsp", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		})
+	require.NoError(t, err)
+	assert.True(t, dep.CacheHit)
+	assert.FileExists(t, filepath.Join(localDir, "plugin.json"))
+}
+
+func TestFetchBasePlugin_StaleCacheTransientFallback(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref/"
+	pluginFileURL := baseURLDir + "plugins/gopls-lsp/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	oldFiles := map[string][]byte{"plugin.json": []byte(`{"name":"old"}`)}
+	oldHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, oldFiles)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, oldHash))
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, oldHash))
+
+	failFetcher := func(_ context.Context, _, _, _, _ string) (map[string][]byte, error) {
+		return nil, &gitfetch.TransientError{Err: fmt.Errorf("connection refused")}
+	}
+
+	dep, localDir, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		baseURLDir, "plugins/gopls-lsp", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   failFetcher,
+		})
+	require.NoError(t, err)
+	assert.True(t, dep.CacheHit)
+	assert.Contains(t, dep.Warning, "using stale cached content")
+	assert.Contains(t, dep.Warning, "connection refused")
+	assert.FileExists(t, filepath.Join(localDir, "plugin.json"))
+}
+
+func TestFetchBasePlugin_StaleCacheNonTransientError(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref/"
+	pluginFileURL := baseURLDir + "plugins/gopls-lsp/plugin.json"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	oldFiles := map[string][]byte{"plugin.json": []byte(`{"name":"old"}`)}
+	oldHash, err := fetch.CachePutDir(cacheDir, pluginFileURL, oldFiles)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, oldHash))
+	require.NoError(t, urlIndexPut(cacheDir, "plugin:"+pluginFileURL, oldHash))
+
+	failFetcher := func(_ context.Context, _, _, _, _ string) (map[string][]byte, error) {
+		return nil, fmt.Errorf("authentication failed: 401 Unauthorized")
+	}
+
+	_, _, err = fetchBasePlugin(context.Background(), "plugins[0]",
+		baseURLDir, "plugins/gopls-lsp", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   failFetcher,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+func TestFetchBasePlugin_OfflineNoCacheError(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	_, _, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"plugins/gopls-lsp", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in cache and offline mode is enabled")
+}
+
+func TestFetchBasePlugin_PartialIndexHit_RefetchesViaTreeFetcher(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	pluginFileURL := "https://raw.githubusercontent.com/org/repo/ref/plugins/gopls-lsp/plugin.json"
+	content := []byte(`{"name":"gopls-lsp"}`)
+	require.NoError(t, fetch.CachePut(cacheDir, pluginFileURL, content))
+	fileHash := fetch.ComputeSHA256(content)
+	require.NoError(t, urlIndexPut(cacheDir, pluginFileURL, fileHash))
+	// Deliberately omit the "plugin:" tree hash entry to trigger partial index hit
+
+	fetcher := fakeTreeFetcher(map[string][]byte{"plugin.json": content})
+
+	dep, _, err := fetchBasePlugin(context.Background(), "plugins[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"plugins/gopls-lsp", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			TreeFetcher:   fetcher,
+		})
+	require.NoError(t, err)
+	assert.False(t, dep.CacheHit)
+}
+
+func TestResolveBasePlugins_InvalidBaseURL(t *testing.T) {
+	base := &Harness{Plugins: []string{"plugins/test"}}
+	_, err := resolveBasePlugins(context.Background(), base, "", nil, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot determine directory")
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -884,6 +884,9 @@ func (h *Harness) ValidateResourceTypes() error {
 			if info.PathType == "blob" {
 				return fmt.Errorf("skills[%d] URL must use /tree/ (directory), not /blob/ (single file) — skills are directories", i)
 			}
+			if info.Path == "" {
+				return fmt.Errorf("skills[%d] URL must point to a directory inside the repo, not the repo root", i)
+			}
 		}
 	}
 	for i, p := range h.Plugins {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -29,6 +29,22 @@ func ValidPluginBasename(name string) bool {
 	return validPluginName.MatchString(name)
 }
 
+// ChmodPluginDir makes all files under dir executable (0755). It resolves
+// symlinks first so it operates on the real directory tree. Plugins may
+// contain scripts or MCP server binaries that need the execute bit.
+func ChmodPluginDir(dir string) error {
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return err
+	}
+	return filepath.Walk(resolved, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		return os.Chmod(path, 0o755)
+	})
+}
+
 // HostFile describes a file on the host that must be copied into the sandbox
 // during bootstrap. Src may contain ${VAR} references that are expanded from
 // the host environment at bootstrap time. Use this for any file that must

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -2069,6 +2069,19 @@ func TestValidateResourceTypes_PluginBlobURLRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "plugins[0] URL must use /tree/ (directory), not /blob/ (single file)")
 }
 
+func TestValidateResourceTypes_SkillRepoRootURLRejected(t *testing.T) {
+	h := &Harness{
+		Agent: "agents/test.md",
+		Role:  "test",
+		Skills: []string{
+			"https://github.com/org/myskills/tree/main#sha256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+	}
+	err := h.ValidateResourceTypes()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "skills[0] URL must point to a directory inside the repo, not the repo root")
+}
+
 func TestValidateResourceTypes_PluginRepoRootURLRejected(t *testing.T) {
 	h := &Harness{
 		Agent: "agents/test.md",

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -826,14 +826,5 @@ func resolveSkillTransitiveDeps(ctx context.Context, parentURL, skillDirPath str
 // files (markdown, JSON) executable is harmless, and the SHA-256
 // integrity pin constrains content, not permissions.
 func chmodPluginDir(dir string) error {
-	resolved, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		return err
-	}
-	return filepath.Walk(resolved, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
-			return err
-		}
-		return os.Chmod(path, 0o755)
-	})
+	return harness.ChmodPluginDir(dir)
 }


### PR DESCRIPTION
## Summary

- `resolveBaseResources` in `compose.go` fetches `agent`, `policy`, and `skills` from the base URL when a harness is loaded from a remote source, but skips `plugins`
- Relative plugin paths (e.g. `plugins/gopls-lsp`) pass through to `ResolveRelativeTo`, which resolves them against the target repo's `.fullsend` directory where they do not exist, causing `ValidateFilesExist` to fail
- Add `resolveBasePlugins` (with `fetchBasePlugin`/`fetchBasePluginDir`) using `plugin.json` as the marker file, and call it from all three resolution sites in `LoadWithBase`

## Failing runs on v0.34.0

- https://github.com/rh-hemartin-fullsendai/my-app/actions/runs/31102858867/job/92620561677
- https://github.com/openkaiden/kaiden/actions/runs/31091696357/job/92584001666

## Test plan

- [x] `TestLoadWithBase_URLBase_PluginFetchedAsDir` -- forge URL parse path is hit
- [x] `TestLoadWithBase_URLBase_PluginOfflineCacheHit` -- plugins resolve from cache in offline mode
- [x] `TestLoadWithBase_SourceURL_Plugins` -- SourceURL no-base path resolves plugins
- [x] `TestLoadWithBase_SourceURL_PluginPassesValidateFilesExist` -- regression test: `ResolveRelativeTo` + `ValidateFilesExist` passes when plugin is resolved to cache path
- [x] Full harness test suite passes with `-race`
- [x] Verified fix in production: https://github.com/rh-hemartin-fullsendai/my-app/actions/runs/31104568468/job/92626328900

Closes #5977