### PR TITLE
fix(post-review): post file-level comments in a separate review

### DIFF
--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -347,13 +347,24 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 	// Findings whose file is in the PR diff but whose line falls
 	// outside any diff hunk are posted as file-level comments so
 	// they remain visible on the PR code.
-	inlineComments, fileFiltered, fileLevelFallback := findingsToReviewComments(findings, diffHunks)
+	inlineComments, fileLevelComments, fileFiltered := findingsToReviewComments(findings, diffHunks)
 
 	if fileFiltered > 0 {
 		printer.StepWarn(fmt.Sprintf("%d inline comment(s) omitted (file not in PR diff) — findings still count toward verdict", fileFiltered))
 	}
-	if fileLevelFallback > 0 {
-		printer.StepInfo(fmt.Sprintf("%d finding(s) posted as file-level comment(s) (line outside diff hunk)", fileLevelFallback))
+	if len(fileLevelComments) > 0 {
+		printer.StepInfo(fmt.Sprintf("%d finding(s) posted as file-level comment(s) (line outside diff hunk)", len(fileLevelComments)))
+	}
+
+	// Post file-level comments in a separate COMMENT review so they
+	// don't poison the main review batch. A single invalid file-level
+	// comment would otherwise 422 the entire submission.
+	if len(fileLevelComments) > 0 {
+		if err := client.CreatePullRequestReview(ctx, owner, repo, pr, "COMMENT", "", commitSHA, fileLevelComments); err != nil {
+			printer.StepWarn(fmt.Sprintf("File-level comments failed (%v), findings remain in sticky comment", err))
+		} else {
+			printer.StepDone(fmt.Sprintf("Posted %d file-level comment(s)", len(fileLevelComments)))
+		}
 	}
 
 	// COMMENT verdicts skip the formal review unless there are inline-
@@ -413,12 +424,11 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 // patches) skip line-level filtering — the file is known to be in the
 // diff but hunk coverage is unavailable.
 //
-// Returns the comments, count of findings dropped because their file
-// was not in the diff, and count of findings that fell back to
-// file-level comments.
-func findingsToReviewComments(findings []ReviewFinding, diffHunks map[string][][2]int) ([]forge.ReviewComment, int, int) {
-	var comments []forge.ReviewComment
-	var fileFiltered, fileLevelFallback int
+// Returns inline comments (with line numbers), file-level comments
+// (Line=0, posted separately to avoid poisoning the review batch),
+// and the count of findings dropped because their file was not in
+// the diff.
+func findingsToReviewComments(findings []ReviewFinding, diffHunks map[string][][2]int) (inline []forge.ReviewComment, fileLevel []forge.ReviewComment, fileFiltered int) {
 	for _, f := range findings {
 		if f.File == "" || f.Line <= 0 {
 			continue
@@ -430,27 +440,21 @@ func findingsToReviewComments(findings []ReviewFinding, diffHunks map[string][][
 				continue
 			}
 			if len(hunks) > 0 && !lineInHunks(f.Line, hunks) {
-				// Fall back to file-level comments so findings
-				// remain visible on the PR even when the exact
-				// line is outside the changed region. Include the
-				// original line number in the body since file-level
-				// comments have no line annotation in the UI.
 				body := fmt.Sprintf("_Line %d_ · %s", f.Line, formatFindingComment(f))
-				comments = append(comments, forge.ReviewComment{
+				fileLevel = append(fileLevel, forge.ReviewComment{
 					Path: f.File,
 					Body: body,
 				})
-				fileLevelFallback++
 				continue
 			}
 		}
-		comments = append(comments, forge.ReviewComment{
+		inline = append(inline, forge.ReviewComment{
 			Path: f.File,
 			Line: f.Line,
 			Body: formatFindingComment(f),
 		})
 	}
-	return comments, fileFiltered, fileLevelFallback
+	return inline, fileLevel, fileFiltered
 }
 
 // formatFindingComment renders a single review finding as a Markdown

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -356,15 +356,15 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		printer.StepInfo(fmt.Sprintf("%d finding(s) posted as file-level comment(s) (line outside diff hunk)", len(fileLevelComments)))
 	}
 
-	// Post file-level comments in a separate COMMENT review so they
-	// don't poison the main review batch. A single invalid file-level
-	// comment would otherwise 422 the entire submission.
+	// Post file-level comments in a separate COMMENT review so a rejected
+	// file-level comment cannot take the main review's inline comments
+	// down with it. GitHub validates every comment in a review batch
+	// together, so one invalid entry fails the whole submission — the
+	// linked issues show that happening for out-of-hunk inline comments.
+	// Isolating file-level comments is defense in depth against the same
+	// class of failure, not a fix for an observed file-level rejection.
 	if len(fileLevelComments) > 0 {
-		if err := client.CreatePullRequestReview(ctx, owner, repo, pr, "COMMENT", "", commitSHA, fileLevelComments); err != nil {
-			printer.StepWarn(fmt.Sprintf("File-level comments failed (%v), findings remain in sticky comment", err))
-		} else {
-			printer.StepDone(fmt.Sprintf("Posted %d file-level comment(s)", len(fileLevelComments)))
-		}
+		postFileLevelComments(ctx, client, owner, repo, pr, commitSHA, fileLevelComments, printer)
 	}
 
 	// COMMENT verdicts skip the formal review unless there are inline-
@@ -409,6 +409,37 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 	}
 	printer.StepDone("Review submitted")
 	return nil
+}
+
+// postFileLevelComments submits file-level review comments in their own
+// COMMENT review, isolated from the main review batch. It is best-effort:
+// every failure path logs and returns so the caller's main review still
+// proceeds. On a 422 the comment bodies are retried inside a plain review
+// body — mirroring the main review's fallback — so the findings stay
+// visible on the review itself rather than only in the sticky comment.
+func postFileLevelComments(ctx context.Context, client forge.Client, owner, repo string, pr int, commitSHA string, comments []forge.ReviewComment, printer *ui.Printer) {
+	err := client.CreatePullRequestReview(ctx, owner, repo, pr, "COMMENT", "", commitSHA, comments)
+	if err == nil {
+		printer.StepDone(fmt.Sprintf("Posted %d file-level comment(s)", len(comments)))
+		return
+	}
+
+	if is422Error(err) {
+		printer.StepWarn(fmt.Sprintf("File-level comments failed with 422 (%d comment(s)), retrying without comments", len(comments)))
+		logRejectedComments(comments, err, printer)
+
+		fallbackBody := buildFallbackReviewBody("", comments)
+		if retryErr := client.CreatePullRequestReview(ctx, owner, repo, pr, "COMMENT", fallbackBody, commitSHA, nil); retryErr != nil {
+			logAPIErrorDetails(retryErr, printer)
+			printer.StepWarn(fmt.Sprintf("File-level comments failed (%v), findings remain in sticky comment", retryErr))
+			return
+		}
+		printer.StepDone("File-level comments posted in review body (comments omitted due to 422)")
+		return
+	}
+
+	logAPIErrorDetails(err, printer)
+	printer.StepWarn(fmt.Sprintf("File-level comments failed (%v), findings remain in sticky comment", err))
 }
 
 // findingsToReviewComments converts review findings with file and line
@@ -515,10 +546,11 @@ func logRejectedComments(comments []forge.ReviewComment, err error, printer *ui.
 	}
 }
 
-// buildFallbackReviewBody constructs a review body that embeds inline
-// comment content as markdown, used when GitHub rejects inline comments
-// with a 422 error. The original review body (if any) is preserved as
-// a prefix.
+// buildFallbackReviewBody constructs a review body that embeds review
+// comment content as markdown, used when GitHub rejects the comments of
+// a review with a 422 error. It serves both the main review's inline
+// comments and the isolated file-level review. The original review body
+// (if any) is preserved as a prefix.
 func buildFallbackReviewBody(originalBody string, comments []forge.ReviewComment) string {
 	var b strings.Builder
 	if originalBody != "" {
@@ -528,7 +560,7 @@ func buildFallbackReviewBody(originalBody string, comments []forge.ReviewComment
 		if b.Len() > 0 {
 			b.WriteString("\n\n---\n\n")
 		}
-		b.WriteString("**Note:** The following inline comments could not be posted on the diff (GitHub returned 422) and are included here instead:\n\n")
+		b.WriteString("**Note:** The following review comments could not be posted on the diff (GitHub returned 422) and are included here instead:\n\n")
 		for _, c := range comments {
 			if c.Line > 0 {
 				fmt.Fprintf(&b, "- **`%s:%d`**: %s\n", c.Path, c.Line, c.Body)

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -830,20 +830,20 @@ func TestFindingsToReviewComments(t *testing.T) {
 		{File: "c.go", Line: 20, Severity: "critical", Category: "security", Description: "Desc C", Remediation: "Fix it"},
 	}
 
-	comments, fileFiltered, fileLevelFallback := findingsToReviewComments(findings, nil)
+	inline, fileLevel, fileFiltered := findingsToReviewComments(findings, nil)
 	assert.Equal(t, 0, fileFiltered)
-	assert.Equal(t, 0, fileLevelFallback)
-	require.Len(t, comments, 2)
+	assert.Empty(t, fileLevel)
+	require.Len(t, inline, 2)
 
-	assert.Equal(t, "a.go", comments[0].Path)
-	assert.Equal(t, 10, comments[0].Line)
-	assert.Contains(t, comments[0].Body, "high")
-	assert.Contains(t, comments[0].Body, "Desc A")
+	assert.Equal(t, "a.go", inline[0].Path)
+	assert.Equal(t, 10, inline[0].Line)
+	assert.Contains(t, inline[0].Body, "high")
+	assert.Contains(t, inline[0].Body, "Desc A")
 
-	assert.Equal(t, "c.go", comments[1].Path)
-	assert.Equal(t, 20, comments[1].Line)
-	assert.Contains(t, comments[1].Body, "critical")
-	assert.Contains(t, comments[1].Body, "Fix it")
+	assert.Equal(t, "c.go", inline[1].Path)
+	assert.Equal(t, 20, inline[1].Line)
+	assert.Contains(t, inline[1].Body, "critical")
+	assert.Contains(t, inline[1].Body, "Fix it")
 }
 
 func TestFindingsToReviewComments_FiltersByDiffHunks(t *testing.T) {
@@ -858,18 +858,18 @@ func TestFindingsToReviewComments_FiltersByDiffHunks(t *testing.T) {
 		"also-changed.go": {{1, 10}},
 	}
 
-	comments, fileFiltered, fileLevelFallback := findingsToReviewComments(findings, diffHunks)
+	inline, fileLevel, fileFiltered := findingsToReviewComments(findings, diffHunks)
 	assert.Equal(t, 1, fileFiltered)
-	assert.Equal(t, 1, fileLevelFallback, "low-severity out-of-hunk finding should fall back to file-level")
-	require.Len(t, comments, 3)
-	assert.Equal(t, "changed.go", comments[0].Path)
-	assert.Equal(t, 10, comments[0].Line)
-	// The out-of-hunk low finding now falls back to file-level.
-	assert.Equal(t, "changed.go", comments[1].Path)
-	assert.Equal(t, 0, comments[1].Line)
-	assert.Contains(t, comments[1].Body, "Line 50", "file-level fallback should include original line number")
-	assert.Equal(t, "also-changed.go", comments[2].Path)
-	assert.Equal(t, 3, comments[2].Line)
+	require.Len(t, fileLevel, 1, "low-severity out-of-hunk finding should fall back to file-level")
+	require.Len(t, inline, 2)
+	assert.Equal(t, "changed.go", inline[0].Path)
+	assert.Equal(t, 10, inline[0].Line)
+	assert.Equal(t, "also-changed.go", inline[1].Path)
+	assert.Equal(t, 3, inline[1].Line)
+	// The out-of-hunk low finding is in the file-level slice.
+	assert.Equal(t, "changed.go", fileLevel[0].Path)
+	assert.Equal(t, 0, fileLevel[0].Line)
+	assert.Contains(t, fileLevel[0].Body, "Line 50", "file-level fallback should include original line number")
 }
 
 func TestFindingsToReviewComments_EmptyPatchSkipsLineFiltering(t *testing.T) {
@@ -885,18 +885,18 @@ func TestFindingsToReviewComments_EmptyPatchSkipsLineFiltering(t *testing.T) {
 		"changed.go": {{5, 15}},
 	}
 
-	comments, fileFiltered, fileLevelFallback := findingsToReviewComments(findings, diffHunks)
+	inline, fileLevel, fileFiltered := findingsToReviewComments(findings, diffHunks)
 	assert.Equal(t, 0, fileFiltered)
-	assert.Equal(t, 1, fileLevelFallback, "out-of-hunk info finding on changed.go should fall back to file-level")
-	require.Len(t, comments, 4)
-	assert.Equal(t, "binary.png", comments[0].Path)
-	assert.Equal(t, "large.go", comments[1].Path)
-	assert.Equal(t, "changed.go", comments[2].Path)
-	assert.Equal(t, 10, comments[2].Line)
-	// The info finding outside the hunk now falls back to file-level.
-	assert.Equal(t, "changed.go", comments[3].Path)
-	assert.Equal(t, 0, comments[3].Line)
-	assert.Contains(t, comments[3].Body, "Line 50", "file-level fallback should include original line number")
+	require.Len(t, fileLevel, 1, "out-of-hunk info finding on changed.go should fall back to file-level")
+	require.Len(t, inline, 3)
+	assert.Equal(t, "binary.png", inline[0].Path)
+	assert.Equal(t, "large.go", inline[1].Path)
+	assert.Equal(t, "changed.go", inline[2].Path)
+	assert.Equal(t, 10, inline[2].Line)
+	// The info finding outside the hunk is in the file-level slice.
+	assert.Equal(t, "changed.go", fileLevel[0].Path)
+	assert.Equal(t, 0, fileLevel[0].Line)
+	assert.Contains(t, fileLevel[0].Body, "Line 50", "file-level fallback should include original line number")
 }
 
 func TestFindingsToReviewComments_AllSeveritiesPassThrough(t *testing.T) {
@@ -907,14 +907,14 @@ func TestFindingsToReviewComments_AllSeveritiesPassThrough(t *testing.T) {
 		{File: "a.go", Line: 25, Severity: "medium", Category: "bug", Description: "Medium finding"},
 	}
 
-	comments, fileFiltered, fileLevelFallback := findingsToReviewComments(findings, nil)
+	inline, fileLevel, fileFiltered := findingsToReviewComments(findings, nil)
 	assert.Equal(t, 0, fileFiltered)
-	assert.Equal(t, 0, fileLevelFallback)
-	require.Len(t, comments, 4, "all findings should pass through regardless of severity")
-	assert.Contains(t, comments[0].Body, "Info finding with location")
-	assert.Contains(t, comments[1].Body, "Info finding case insensitive")
-	assert.Contains(t, comments[2].Body, "Low finding")
-	assert.Contains(t, comments[3].Body, "Medium finding")
+	assert.Empty(t, fileLevel)
+	require.Len(t, inline, 4, "all findings should pass through regardless of severity")
+	assert.Contains(t, inline[0].Body, "Info finding with location")
+	assert.Contains(t, inline[1].Body, "Info finding case insensitive")
+	assert.Contains(t, inline[2].Body, "Low finding")
+	assert.Contains(t, inline[3].Body, "Medium finding")
 }
 
 func TestFindingsToReviewComments_AllSeveritiesFallbackToFileLevel(t *testing.T) {
@@ -930,23 +930,22 @@ func TestFindingsToReviewComments_AllSeveritiesFallbackToFileLevel(t *testing.T)
 		"changed.go": {{5, 15}},
 	}
 
-	comments, fileFiltered, fileLevelFallback := findingsToReviewComments(findings, diffHunks)
+	inline, fileLevel, fileFiltered := findingsToReviewComments(findings, diffHunks)
 	assert.Equal(t, 0, fileFiltered)
-	assert.Equal(t, 5, fileLevelFallback, "all out-of-hunk findings should fall back to file-level")
-	require.Len(t, comments, 6)
+	require.Len(t, fileLevel, 5, "all out-of-hunk findings should fall back to file-level")
+	require.Len(t, inline, 1)
 
-	// First comment: in-hunk high finding with line number.
-	assert.Equal(t, "changed.go", comments[0].Path)
-	assert.Equal(t, 10, comments[0].Line)
+	// In-hunk high finding with line number.
+	assert.Equal(t, "changed.go", inline[0].Path)
+	assert.Equal(t, 10, inline[0].Line)
 
-	// Remaining: file-level fallback comments for all out-of-hunk findings.
+	// File-level fallback comments for all out-of-hunk findings.
 	expectedLines := []int{50, 60, 70, 75, 80}
 	for i, desc := range []string{"Medium outside hunk", "Critical outside hunk", "Low outside hunk", "Info outside hunk", "High outside hunk case insensitive"} {
-		idx := i + 1
-		assert.Equal(t, "changed.go", comments[idx].Path)
-		assert.Equal(t, 0, comments[idx].Line, "file-level comment should have Line=0")
-		assert.Contains(t, comments[idx].Body, desc)
-		assert.Contains(t, comments[idx].Body, fmt.Sprintf("Line %d", expectedLines[i]), "file-level fallback should include original line number")
+		assert.Equal(t, "changed.go", fileLevel[i].Path)
+		assert.Equal(t, 0, fileLevel[i].Line, "file-level comment should have Line=0")
+		assert.Contains(t, fileLevel[i].Body, desc)
+		assert.Contains(t, fileLevel[i].Body, fmt.Sprintf("Line %d", expectedLines[i]), "file-level fallback should include original line number")
 	}
 }
 
@@ -971,15 +970,20 @@ func TestSubmitFormalReview_FiltersByPRFileDiffs(t *testing.T) {
 
 	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "", "", findings, false, printer)
 	require.NoError(t, err)
-	require.Len(t, fc.CreatedReviews, 1)
-	require.Len(t, fc.CreatedReviews[0].Comments, 3, "file-not-in-diff finding omitted; out-of-hunk finding falls back to file-level")
+	// Two reviews: COMMENT for file-level, REQUEST_CHANGES for main.
+	require.Len(t, fc.CreatedReviews, 2)
+	// First review: file-level comment posted separately.
+	assert.Equal(t, "COMMENT", fc.CreatedReviews[0].Event)
+	require.Len(t, fc.CreatedReviews[0].Comments, 1)
 	assert.Equal(t, "changed.go", fc.CreatedReviews[0].Comments[0].Path)
-	assert.Equal(t, 10, fc.CreatedReviews[0].Comments[0].Line)
-	// Out-of-hunk low finding falls back to file-level comment.
-	assert.Equal(t, "changed.go", fc.CreatedReviews[0].Comments[1].Path)
-	assert.Equal(t, 0, fc.CreatedReviews[0].Comments[1].Line)
-	assert.Contains(t, fc.CreatedReviews[0].Comments[1].Body, "Line 50", "file-level fallback should include original line number")
-	assert.Equal(t, "also-changed.go", fc.CreatedReviews[0].Comments[2].Path)
+	assert.Equal(t, 0, fc.CreatedReviews[0].Comments[0].Line)
+	assert.Contains(t, fc.CreatedReviews[0].Comments[0].Body, "Line 50", "file-level fallback should include original line number")
+	// Second review: inline comments only.
+	assert.Equal(t, "REQUEST_CHANGES", fc.CreatedReviews[1].Event)
+	require.Len(t, fc.CreatedReviews[1].Comments, 2, "file-not-in-diff finding omitted; file-level posted separately")
+	assert.Equal(t, "changed.go", fc.CreatedReviews[1].Comments[0].Path)
+	assert.Equal(t, 10, fc.CreatedReviews[1].Comments[0].Line)
+	assert.Equal(t, "also-changed.go", fc.CreatedReviews[1].Comments[1].Path)
 	assert.Contains(t, out.String(), "1 inline comment(s) omitted (file not in PR diff) — findings still count toward verdict")
 	assert.Contains(t, out.String(), "1 finding(s) posted as file-level comment(s) (line outside diff hunk)")
 }
@@ -1576,15 +1580,47 @@ func TestIs422Error(t *testing.T) {
 	}
 }
 
-func TestSubmitFormalReview_422FallbackWithFileLevelComment(t *testing.T) {
+func TestSubmitFormalReview_FileLevelCommentPostedSeparately(t *testing.T) {
 	fc := forge.NewFakeClient()
 	fc.AuthenticatedUser = "fullsend-bot"
 	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
 		"acme/repo/1": {
-			// Hunk covers lines 30-54 only.
 			{Path: "internal/service.go", Patch: "@@ -30,20 +30,25 @@ func main() {"},
 		},
 	}
+
+	var out bytes.Buffer
+	printer := ui.New(&out)
+
+	findings := []ReviewFinding{
+		// Line 999 is outside hunk -> becomes file-level comment.
+		{Severity: "high", Category: "bug", File: "internal/service.go", Line: 999, Description: "Out of hunk."},
+	}
+
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "abc123", "", findings, false, printer)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "file-level comment")
+
+	// Two reviews: one COMMENT for file-level, one REQUEST_CHANGES for main.
+	require.Len(t, fc.CreatedReviews, 2)
+	assert.Equal(t, "COMMENT", fc.CreatedReviews[0].Event)
+	require.Len(t, fc.CreatedReviews[0].Comments, 1)
+	assert.Equal(t, 0, fc.CreatedReviews[0].Comments[0].Line)
+	assert.Equal(t, "REQUEST_CHANGES", fc.CreatedReviews[1].Event)
+	assert.Empty(t, fc.CreatedReviews[1].Comments)
+}
+
+func TestSubmitFormalReview_FileLevelFailureDoesNotBlockMainReview(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
+		"acme/repo/1": {
+			{Path: "internal/service.go", Patch: "@@ -30,20 +30,25 @@ func main() {"},
+		},
+	}
+	// First call (file-level) fails, second call (main review) succeeds.
 	fc.CreateReviewErrSeq = []error{
 		&gh.APIError{StatusCode: http.StatusUnprocessableEntity, Message: "Validation Failed"},
 		nil,
@@ -1594,7 +1630,6 @@ func TestSubmitFormalReview_422FallbackWithFileLevelComment(t *testing.T) {
 	printer := ui.New(&out)
 
 	findings := []ReviewFinding{
-		// Line 999 is outside hunk → becomes file-level comment (Line=0).
 		{Severity: "high", Category: "bug", File: "internal/service.go", Line: 999, Description: "Out of hunk."},
 	}
 
@@ -1602,11 +1637,12 @@ func TestSubmitFormalReview_422FallbackWithFileLevelComment(t *testing.T) {
 	require.NoError(t, err)
 
 	output := out.String()
-	assert.Contains(t, output, "file-level", "logRejectedComments should log file-level comment")
-	assert.Contains(t, output, "inline comments omitted due to 422")
+	assert.Contains(t, output, "File-level comments failed")
+	assert.Contains(t, output, "Review submitted")
 
+	// Only the main review succeeded; the file-level review errored.
 	require.Len(t, fc.CreatedReviews, 1)
-	assert.Contains(t, fc.CreatedReviews[0].Body, "internal/service.go")
+	assert.Equal(t, "REQUEST_CHANGES", fc.CreatedReviews[0].Event)
 }
 
 func TestBuildFallbackReviewBody(t *testing.T) {

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -1361,7 +1361,7 @@ func TestSubmitFormalReview_422FallbackRetriesWithoutInlineComments(t *testing.T
 	review := fc.CreatedReviews[0]
 	assert.Equal(t, "REQUEST_CHANGES", review.Event)
 	assert.Empty(t, review.Comments, "fallback retry should have no inline comments")
-	assert.Contains(t, review.Body, "inline comments could not be posted")
+	assert.Contains(t, review.Body, "review comments could not be posted")
 	assert.Contains(t, review.Body, "internal/service.go:42")
 	assert.Contains(t, review.Body, "Nil pointer dereference")
 
@@ -1620,9 +1620,98 @@ func TestSubmitFormalReview_FileLevelFailureDoesNotBlockMainReview(t *testing.T)
 			{Path: "internal/service.go", Patch: "@@ -30,20 +30,25 @@ func main() {"},
 		},
 	}
-	// First call (file-level) fails, second call (main review) succeeds.
+	// File-level review fails with a non-422 error: no fallback retry, and
+	// the main review still goes out.
+	fc.CreateReviewErrSeq = []error{
+		fmt.Errorf("server error"),
+		nil,
+	}
+
+	var out bytes.Buffer
+	printer := ui.New(&out)
+
+	findings := []ReviewFinding{
+		{Severity: "high", Category: "bug", File: "internal/service.go", Line: 999, Description: "Out of hunk."},
+	}
+
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "abc123", "", findings, false, printer)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "File-level comments failed")
+	assert.NotContains(t, output, "retrying without comments", "non-422 errors should not trigger the fallback")
+	assert.Contains(t, output, "Review submitted")
+
+	// Only the main review succeeded; the file-level review errored.
+	require.Len(t, fc.CreatedReviews, 1)
+	assert.Equal(t, "REQUEST_CHANGES", fc.CreatedReviews[0].Event)
+}
+
+func TestSubmitFormalReview_FileLevel422FallsBackToReviewBody(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
+		"acme/repo/1": {
+			{Path: "internal/service.go", Patch: "@@ -30,20 +30,25 @@ func main() {"},
+		},
+	}
+	// File-level review 422s; its fallback (body only) and the main review
+	// both succeed.
+	fc.CreateReviewErrSeq = []error{
+		&gh.APIError{
+			StatusCode: http.StatusUnprocessableEntity,
+			Message:    "Validation Failed",
+			Errors: []gh.APIErrorDetail{
+				{Resource: "PullRequestReviewComment", Field: "path", Code: "invalid", Message: "path must be part of the diff"},
+			},
+		},
+		nil,
+		nil,
+	}
+
+	var out bytes.Buffer
+	printer := ui.New(&out)
+
+	findings := []ReviewFinding{
+		{Severity: "high", Category: "bug", File: "internal/service.go", Line: 999, Description: "Out of hunk."},
+	}
+
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "abc123", "", findings, false, printer)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "File-level comments failed with 422")
+	// The qodo finding: structured API error details and the rejected
+	// comments must be logged, not just the formatted error string.
+	assert.Contains(t, output, "API error detail:")
+	assert.Contains(t, output, "path must be part of the diff")
+	assert.Contains(t, output, "internal/service.go (file-level)")
+
+	// Fallback COMMENT review carries the finding in its body, then the
+	// main review follows.
+	require.Len(t, fc.CreatedReviews, 2)
+	fallback := fc.CreatedReviews[0]
+	assert.Equal(t, "COMMENT", fallback.Event)
+	assert.Empty(t, fallback.Comments, "fallback retry should carry no comments")
+	assert.Contains(t, fallback.Body, "review comments could not be posted")
+	assert.Contains(t, fallback.Body, "internal/service.go")
+	assert.Contains(t, fallback.Body, "Out of hunk.")
+	assert.Equal(t, "REQUEST_CHANGES", fc.CreatedReviews[1].Event)
+}
+
+func TestSubmitFormalReview_FileLevelFallbackFailureDoesNotBlockMainReview(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
+		"acme/repo/1": {
+			{Path: "internal/service.go", Patch: "@@ -30,20 +30,25 @@ func main() {"},
+		},
+	}
+	// Both the file-level review and its fallback fail; the main review
+	// must still be submitted.
 	fc.CreateReviewErrSeq = []error{
 		&gh.APIError{StatusCode: http.StatusUnprocessableEntity, Message: "Validation Failed"},
+		fmt.Errorf("server error"),
 		nil,
 	}
 
@@ -1640,9 +1729,46 @@ func TestSubmitFormalReview_FileLevelFailureDoesNotBlockMainReview(t *testing.T)
 	assert.Contains(t, output, "File-level comments failed")
 	assert.Contains(t, output, "Review submitted")
 
-	// Only the main review succeeded; the file-level review errored.
 	require.Len(t, fc.CreatedReviews, 1)
 	assert.Equal(t, "REQUEST_CHANGES", fc.CreatedReviews[0].Event)
+}
+
+func TestSubmitFormalReview_CommentVerdictOnlyFileLevelFindings(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
+		"acme/repo/1": {
+			{Path: "internal/service.go", Patch: "@@ -30,20 +30,25 @@ func main() {"},
+		},
+	}
+
+	var out bytes.Buffer
+	printer := ui.New(&out)
+
+	// Every finding falls outside the diff hunk, so there are no inline
+	// comments left to attach to a COMMENT verdict.
+	findings := []ReviewFinding{
+		{Severity: "low", Category: "style", File: "internal/service.go", Line: 999, Description: "Out of hunk."},
+		{Severity: "low", Category: "style", File: "internal/service.go", Line: 1200, Description: "Also out of hunk."},
+	}
+
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "abc123", "", findings, false, printer)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Skipping formal COMMENT review")
+
+	// Exactly one review: the file-level COMMENT review. The main review
+	// is skipped because no inline comments remain.
+	require.Len(t, fc.CreatedReviews, 1)
+	review := fc.CreatedReviews[0]
+	assert.Equal(t, "COMMENT", review.Event)
+	assert.Empty(t, review.Body, "file-level review carries comments, not a body")
+	require.Len(t, review.Comments, 2)
+	for _, c := range review.Comments {
+		assert.Equal(t, 0, c.Line, "file-level comments carry no line")
+		assert.Equal(t, "internal/service.go", c.Path)
+	}
 }
 
 func TestBuildFallbackReviewBody(t *testing.T) {
@@ -1654,7 +1780,7 @@ func TestBuildFallbackReviewBody(t *testing.T) {
 		body := buildFallbackReviewBody("See review.", comments)
 		assert.Contains(t, body, "See review.")
 		assert.Contains(t, body, "---")
-		assert.Contains(t, body, "inline comments could not be posted")
+		assert.Contains(t, body, "review comments could not be posted")
 		assert.Contains(t, body, "`a.go:10`")
 		assert.Contains(t, body, "Bug here")
 		assert.Contains(t, body, "`b.go`")
@@ -1667,7 +1793,7 @@ func TestBuildFallbackReviewBody(t *testing.T) {
 		}
 		body := buildFallbackReviewBody("", comments)
 		assert.NotContains(t, body, "---", "no separator when original body is empty")
-		assert.Contains(t, body, "inline comments could not be posted")
+		assert.Contains(t, body, "review comments could not be posted")
 		assert.Contains(t, body, "`a.go:5`")
 	})
 


### PR DESCRIPTION
## Summary

File-level comments (findings whose line falls outside any diff hunk) were mixed into the main
review batch. GitHub validates every comment in a review submission together, so one invalid entry
fails the whole call and drops the valid inline comments with it.

The linked issues show that failure mode for out-of-hunk **inline** comments; no file-level
rejection has been observed. Isolating file-level comments into their own review is therefore
defense in depth against the same class of failure, not a fix for a confirmed file-level bug. The
code comment and this description are worded accordingly.

- `findingsToReviewComments` now returns two separate slices (`inline` and `fileLevel`) instead of
  one mixed slice.
- File-level comments are posted in a preceding COMMENT review by `postFileLevelComments`. The main
  review always proceeds, whatever that call does.
- On a 422 the file-level review retries with the comment bodies embedded in a plain review body
  (`buildFallbackReviewBody`), mirroring the main review's existing 422 fallback, so the findings
  stay visible on the review instead of only in the sticky comment.
- Failures log structured GitHub API error details (`logAPIErrorDetails`) and the rejected comments
  (`logRejectedComments`), matching the diagnostics the main review path already emits.

Relates-to: fullsend-ai/agents#430
Relates-to: fullsend-ai/agents#193

## Test plan

- [x] `TestFindingsToReviewComments` -- verifies inline/fileLevel separation with nil diffHunks
- [x] `TestFindingsToReviewComments_FiltersByDiffHunks` -- out-of-hunk finding lands in fileLevel slice
- [x] `TestFindingsToReviewComments_EmptyPatchSkipsLineFiltering` -- binary/empty patches skip line filtering
- [x] `TestFindingsToReviewComments_AllSeveritiesPassThrough` -- all severities remain inline with nil diffHunks
- [x] `TestFindingsToReviewComments_AllSeveritiesFallbackToFileLevel` -- all severities fall back to file-level when out of hunk
- [x] `TestSubmitFormalReview_FiltersByPRFileDiffs` -- integration: two reviews created (COMMENT + REQUEST_CHANGES)
- [x] `TestSubmitFormalReview_FileLevelCommentPostedSeparately` -- file-level COMMENT review posted before main review
- [x] `TestSubmitFormalReview_FileLevelFailureDoesNotBlockMainReview` -- non-422 failure drops the comments, no retry, main review unaffected
- [x] `TestSubmitFormalReview_FileLevel422FallsBackToReviewBody` -- 422 retries into a review body and logs API error details plus rejected comments
- [x] `TestSubmitFormalReview_FileLevelFallbackFailureDoesNotBlockMainReview` -- both file-level attempts failing still leaves the main review submitted
- [x] `TestSubmitFormalReview_CommentVerdictOnlyFileLevelFindings` -- COMMENT verdict with only out-of-hunk findings creates exactly one review and skips the main one
