### PR TITLE
fix(jira-poll): degrade gracefully when project role lookup returns 401

### DIFF
--- a/internal/forge/jira/client.go
+++ b/internal/forge/jira/client.go
@@ -159,7 +159,9 @@ func (e *APIError) Unwrap() error {
 	if e.StatusCode == http.StatusNotFound {
 		return forge.ErrNotFound
 	}
-	if e.StatusCode == http.StatusForbidden {
+	// Jira Cloud returns 401 for project-level permission denials
+	// (e.g. project role listing) in addition to the standard 403.
+	if e.StatusCode == http.StatusForbidden || e.StatusCode == http.StatusUnauthorized {
 		return forge.ErrForbidden
 	}
 	return nil

--- a/internal/forge/jira/client_test.go
+++ b/internal/forge/jira/client_test.go
@@ -461,6 +461,7 @@ func TestErrorResponse_401(t *testing.T) {
 	var apiErr *APIError
 	require.True(t, errors.As(err, &apiErr))
 	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.True(t, errors.Is(err, forge.ErrForbidden), "401 should unwrap to forge.ErrForbidden")
 }
 
 func TestErrorResponse_403(t *testing.T) {

--- a/internal/jirapoll/poller.go
+++ b/internal/jirapoll/poller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand/v2"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/fullsend-ai/fullsend/internal/dispatch"
+	"github.com/fullsend-ai/fullsend/internal/forge"
 	"github.com/fullsend-ai/fullsend/internal/forge/jira"
 	"github.com/fullsend-ai/fullsend/internal/poll"
 
@@ -113,10 +115,14 @@ func (p *Poller) Run(ctx context.Context) error {
 	if len(selected) > 0 {
 		if p.opts.JiraProject != "" {
 			membership, err := p.client.GetProjectRoleMembership(ctx, p.opts.JiraProject)
-			if err != nil {
+			switch {
+			case err == nil:
+				p.roleMembership = membership
+			case errors.Is(err, forge.ErrForbidden):
+				log.Printf("WARNING: insufficient permissions to read project roles for %s (defaulting to external): %v", p.opts.JiraProject, err)
+			default:
 				return fmt.Errorf("load project roles for %s: %w", p.opts.JiraProject, err)
 			}
-			p.roleMembership = membership
 		} else {
 			log.Printf("WARNING: no Jira project key set, cannot resolve actor roles (defaulting to external)")
 		}

--- a/internal/jirapoll/poller_test.go
+++ b/internal/jirapoll/poller_test.go
@@ -543,6 +543,58 @@ func TestRunRoleLoadFailure_FailsCycle(t *testing.T) {
 	}
 }
 
+// TestRunRoleLoadForbidden_DegradesToExternal verifies that a permission
+// error (401/403) on the project role endpoint degrades gracefully to
+// external roles instead of aborting the cycle. The poll should still
+// complete and advance checkpoints; only transient errors (5xx) should
+// fail the cycle.
+func TestRunRoleLoadForbidden_DegradesToExternal(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	mc := newMockClient()
+	mc.roleErr = fmt.Errorf("list project roles for PROJ: %w",
+		&jira.APIError{StatusCode: 401, Message: "You cannot edit the configuration of this project."})
+	mc.searchResult = []jira.Issue{
+		{
+			ID:  "10042",
+			Key: "PROJ-123",
+			Fields: jira.IssueFields{
+				Reporter: jira.User{AccountID: "reporter-id"},
+				Created:  now.Add(-1 * time.Hour).Format("2006-01-02T15:04:05.000-0700"),
+			},
+		},
+	}
+	mc.comments["PROJ-123"] = []jira.Comment{
+		{
+			ID:      "1",
+			Body:    "/fs-code fix it",
+			Created: now.Add(-30 * time.Minute).Format("2006-01-02T15:04:05.000-0700"),
+			Author:  jira.User{AccountID: "u1", AccountType: "atlassian"},
+		},
+	}
+
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "dispatches.json")
+	p := newTestPoller(mc, &stubRouter{stages: []string{"code"}}, Options{
+		TargetRepo:  "acme/platform",
+		JiraBaseURL: "https://acme.atlassian.net",
+		JiraProject: "PROJ",
+		OutputPath:  outputPath,
+	})
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run() should succeed on permission-denied role load, got: %v", err)
+	}
+
+	// Checkpoint should have advanced (cycle completed, not aborted).
+	lastCheck, err := p.readLastCheck(context.Background(), "PROJ-123")
+	if err != nil {
+		t.Fatalf("readLastCheck() error: %v", err)
+	}
+	if lastCheck.IsZero() {
+		t.Error("expected lastCheck to advance after a gracefully degraded cycle")
+	}
+}
+
 // TestDetectChanges_EditedCommentAttributedToEditor: a comment edited by
 // someone other than its author must be attributed to the EDITOR, not the
 // original author — otherwise attacker-injected slash-command text runs


### PR DESCRIPTION
Jira Cloud returns 401 ("You cannot edit the configuration of this project.") when the service account lacks Administer Projects permission, even on a read-only GET /project/{key}/role call. Previously this aborted the entire poll cycle, making --jira-project unusable without project admin access. Now the poller logs a warning and continues with external roles, matching the existing behavior when --jira-project is omitted. Transient errors (5xx) still fail the cycle so checkpoints are not advanced past lost events.

Also maps HTTP 401 to forge.ErrForbidden in the Jira APIError.Unwrap, since Jira Cloud uses 401 for project-level permission denials in addition to the standard 403.

## Summary
<!-- 1-3 sentences: what this PR does and why -->

## Related Issue
<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->

## Changes
<!-- Bullet list of key changes -->

## Testing
- [ ] `make lint` passes (stage changes first, then run)
- [ ] Tests added/updated for new or modified logic

## Checklist
- [ ] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [ ] Commits are signed off (DCO) — human and human-directed agent sessions only
- [ ] I wrote this contribution myself and can explain all changes in it
