### PR TITLE
ci(#6026): route actor PAT secrets into behaviour job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -271,6 +271,11 @@ jobs:
           # repo secrets (not the prod site-deploy CLOUDFLARE_* secrets).
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          # Human-like actor PATs (write / triage / outsider) for behaviour SCM ops.
+          # Env names match repo secret names; consumption is driver/step work (#6027).
+          TEST_ACTOR_WRITE_PAT: ${{ secrets.TEST_ACTOR_WRITE_PAT }}
+          TEST_ACTOR_TRIAGE_PAT: ${{ secrets.TEST_ACTOR_TRIAGE_PAT }}
+          TEST_ACTOR_OUTSIDER_PAT: ${{ secrets.TEST_ACTOR_OUTSIDER_PAT }}
 
       - name: Upload behaviour debug artifacts
         if: failure() && steps.changes.outputs.relevant != 'false'

--- a/docs/guides/dev/behaviour-testing.md
+++ b/docs/guides/dev/behaviour-testing.md
@@ -228,6 +228,9 @@ BEHAVIOUR_CI=githubactions
 BEHAVIOUR_INSTALL_MODE=per-repo
 E2E_GCP_PROJECT_ID=...        # inference project; install runs inference provision per pool repo
 E2E_GCP_WIF_PROVIDER=...      # CI job GCP auth (not written to pool test-repo secrets)
+TEST_ACTOR_WRITE_PAT=...      # write-level human-like actor PAT (CI: same-named repo secret)
+TEST_ACTOR_TRIAGE_PAT=...     # triage-level human-like actor PAT
+TEST_ACTOR_OUTSIDER_PAT=...   # outsider human-like actor PAT (no org write on base)
 ```
 
 Triage scenarios apply the `ready-for-triage` label (not `/fs-triage` comments) because the per-repo shim ignores `issue_comment` events from bot users and CI uses minted e2e installation tokens.

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -62,6 +62,9 @@ Required repository secrets:
 | `E2E_GCP_PROJECT_ID` | GCP project ID for inference secrets (`github setup --inference-project`) |
 | `TEST_CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID for CF mint behaviour-test deploys (mapped to env `CLOUDFLARE_ACCOUNT_ID` in the behaviour job) |
 | `TEST_CLOUDFLARE_API_TOKEN` | Test-only Cloudflare API token for Wrangler against Worker `mint-test` (mapped to env `CLOUDFLARE_API_TOKEN`; distinct from site-deploy `CLOUDFLARE_*`) |
+| `TEST_ACTOR_WRITE_PAT` | Classic PAT for the write-level human-like test actor (`fstest-write`); exposed to the behaviour job under the same env name |
+| `TEST_ACTOR_TRIAGE_PAT` | Classic PAT for the triage-level human-like test actor (`fstest-triage`); exposed to the behaviour job under the same env name |
+| `TEST_ACTOR_OUTSIDER_PAT` | Classic PAT for the outsider (no org write) human-like test actor (`fstest-outsider`); exposed to the behaviour job under the same env name |
 
 Mint URL uses the hosted public endpoint by default (same as `fullsend admin --mint-url`). Override with org/repo variable `FULLSEND_MINT_URL` if needed; no separate e2e secret.
 


### PR DESCRIPTION
## Summary
- Wire `TEST_ACTOR_WRITE_PAT`, `TEST_ACTOR_TRIAGE_PAT`, and `TEST_ACTOR_OUTSIDER_PAT` into the behaviour job env in `.github/workflows/e2e.yml` (same names as repo secrets).
- Document the secrets in the e2e inventory and behaviour runner-env snippet.
- `e2e-ok-to-test.yml` already uses `secrets: inherit` — no change needed.

Closes #6026.

Note: the `blocked` label on #6026 can be cleared — #6024 landed and the secrets exist. Driver/step consumption remains #6027.

## Test plan
- [ ] Confirm behaviour job env in `e2e.yml` maps all three `${{ secrets.TEST_ACTOR_*_PAT }}` entries
- [ ] Confirm admin `e2e` job is unchanged
- [ ] After merge, a behaviour-relevant CI run has non-empty env for the three vars (without printing values)
- [ ] Clear `blocked` on #6026


Made with [Cursor](https://cursor.com)