### PR TITLE
refactor(runtime): register opencode as a stub runtime

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -9,6 +9,7 @@ When adding a runtime, fill in the security matrix below and register it in `run
 | Runtime | Purpose | Inference |
 |---------|---------|-----------|
 | `claude` | Production agent runs via Claude Code | Required |
+| `opencode` | OpenCode agent runs (stub — not yet functional) | Required |
 | `dummy` | Behaviour tests — scripted ops in real sandbox | None |
 
 ## Security feature matrix

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -14,20 +14,20 @@ When adding a runtime, fill in the security matrix below and register it in `run
 
 ## Security feature matrix
 
-| Feature | Where it runs | Claude Code | Notes for future runtimes |
-|---------|---------------|-------------|---------------------------|
-| **Host-side context injection scan** (DeBERTa / LLM Guard, unicode, SSRF patterns on repo context files) | Host + sandbox `scan context` | ✓ | Requires sandbox image with ML models; harness `security.host_scanners` |
-| **Host-side runtime content scan** (agent def, SKILL.md, plugin JSON before upload) | Host (`scanRuntimeContent`) | ✓ | Uses `security.InputPipeline()`; not part of `Runtime` interface — runner responsibility |
-| **Tirith** (Bash command scanning) | Sandbox PreToolUse hook | ✓ | `tirith_check.py`; harness `security.sandbox_hooks.tirith` |
-| **SSRF pre-tool** | Sandbox PreToolUse hook | ✓ | `ssrf_pretool.py`; default on |
-| **Canary token detection** | Sandbox Pre/PostToolUse hooks | ✓ | `canary_pretool.py` / `canary_posttool.py` |
-| **Secret redaction** | Sandbox PostToolUse hook | ✓ | `secret_redact_posttool.py` |
-| **Unicode normalization** | Sandbox PostToolUse hook | ✓ | `unicode_posttool.py` |
-| **Context suppression** | Sandbox PostToolUse hook | ✓ | `context_suppress_posttool.py` |
-| **Tool allowlist** | Sandbox PreToolUse hook | opt-in | `tool_allowlist_pretool.py`; requires `FULLSEND_TOOL_ALLOWLIST` |
-| **Prompt injection (DeBERTa)** | Host Path A + sandbox Path B | ✓ | Same scanner stack as context files when enabled in harness |
-| **Optional Claude sandbox hooks** | `ClaudeHooksBootstrap` type assert | ✓ only | Other runtimes must define their own hook/bootstrap extension; absence means **no** sandbox tool hooks installed |
-| **Transcript / debug artifacts** | `TranscriptHandler` | ✓ (stream-json, `claude-debug.log`) | Format-specific; not shared across runtimes |
+| Feature | Where it runs | Claude Code | OpenCode (stub) | Notes for future runtimes |
+|---------|---------------|-------------|-----------------|---------------------------|
+| **Host-side context injection scan** (DeBERTa / LLM Guard, unicode, SSRF patterns on repo context files) | Host + sandbox `scan context` | ✓ | N/A — stub | Requires sandbox image with ML models; harness `security.host_scanners` |
+| **Host-side runtime content scan** (agent def, SKILL.md, plugin JSON before upload) | Host (`scanRuntimeContent`) | ✓ | N/A — stub | Uses `security.InputPipeline()`; not part of `Runtime` interface — runner responsibility |
+| **Tirith** (Bash command scanning) | Sandbox PreToolUse hook | ✓ | N/A — stub | `tirith_check.py`; harness `security.sandbox_hooks.tirith` |
+| **SSRF pre-tool** | Sandbox PreToolUse hook | ✓ | N/A — stub | `ssrf_pretool.py`; default on |
+| **Canary token detection** | Sandbox Pre/PostToolUse hooks | ✓ | N/A — stub | `canary_pretool.py` / `canary_posttool.py` |
+| **Secret redaction** | Sandbox PostToolUse hook | ✓ | N/A — stub | `secret_redact_posttool.py` |
+| **Unicode normalization** | Sandbox PostToolUse hook | ✓ | N/A — stub | `unicode_posttool.py` |
+| **Context suppression** | Sandbox PostToolUse hook | ✓ | N/A — stub | `context_suppress_posttool.py` |
+| **Tool allowlist** | Sandbox PreToolUse hook | opt-in | N/A — stub | `tool_allowlist_pretool.py`; requires `FULLSEND_TOOL_ALLOWLIST` |
+| **Prompt injection (DeBERTa)** | Host Path A + sandbox Path B | ✓ | N/A — stub | Same scanner stack as context files when enabled in harness |
+| **Optional Claude sandbox hooks** | `ClaudeHooksBootstrap` type assert | ✓ only | ✗ — does not implement `ClaudeHooksBootstrap` | Other runtimes must define their own hook/bootstrap extension; absence means **no** sandbox tool hooks installed |
+| **Transcript / debug artifacts** | `TranscriptHandler` | ✓ (stream-json, `claude-debug.log`) | No-op — see #1935 | Format-specific; not shared across runtimes |
 
 ### Fail modes
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -9,7 +9,7 @@ When adding a runtime, fill in the security matrix below and register it in `run
 | Runtime | Purpose | Inference |
 |---------|---------|-----------|
 | `claude` | Production agent runs via Claude Code | Required |
-| `opencode` | OpenCode agent runs (stub — not yet functional) | Required |
+| `opencode` | OpenCode agent runs (stub — not yet functional; resolved by `runtime.Resolve()` but not in `ValidRuntimes()` until implemented) | Required |
 | `dummy` | Behaviour tests — scripted ops in real sandbox | None |
 
 ## Security feature matrix

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,7 +174,7 @@ func ValidProviders() []string {
 
 // ValidRuntimes returns the set of recognized agent runtimes.
 func ValidRuntimes() []string {
-	return []string{"claude", "dummy"}
+	return []string{"claude", "dummy", "opencode"}
 }
 
 // DefaultAgentRoles returns the standard set of agent roles installed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,7 +174,7 @@ func ValidProviders() []string {
 
 // ValidRuntimes returns the set of recognized agent runtimes.
 func ValidRuntimes() []string {
-	return []string{"claude", "dummy", "opencode"}
+	return []string{"claude", "dummy"}
 }
 
 // DefaultAgentRoles returns the standard set of agent roles installed

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -398,6 +398,11 @@ func TestOrgConfigValidateRuntime(t *testing.T) {
 	}
 	require.NoError(t, cfg.Validate())
 
+	// opencode is resolvable via runtime.Resolve() but not in ValidRuntimes(),
+	// so config validation must reject it until the runtime is implemented.
+	cfg.Defaults.Runtime = "opencode"
+	require.Error(t, cfg.Validate())
+
 	cfg.Defaults.Runtime = "invalid"
 	require.Error(t, cfg.Validate())
 }
@@ -647,8 +652,15 @@ func TestPerRepoConfigValidate_Runtime(t *testing.T) {
 	}
 	assert.NoError(t, cfg.Validate())
 
-	cfg.Runtime = "invalid"
+	// opencode is resolvable via runtime.Resolve() but not in ValidRuntimes(),
+	// so config validation must reject it until the runtime is implemented.
+	cfg.Runtime = "opencode"
 	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid runtime")
+
+	cfg.Runtime = "invalid"
+	err = cfg.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid runtime")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -384,6 +384,7 @@ func TestValidRuntimes(t *testing.T) {
 	runtimes := ValidRuntimes()
 	assert.Contains(t, runtimes, "claude")
 	assert.Contains(t, runtimes, "dummy")
+	assert.Contains(t, runtimes, "opencode")
 }
 
 func TestOrgConfigValidateRuntime(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -384,7 +384,7 @@ func TestValidRuntimes(t *testing.T) {
 	runtimes := ValidRuntimes()
 	assert.Contains(t, runtimes, "claude")
 	assert.Contains(t, runtimes, "dummy")
-	assert.Contains(t, runtimes, "opencode")
+	assert.NotContains(t, runtimes, "opencode", "opencode is resolved via runtime.Resolve() but not user-selectable until implemented")
 }
 
 func TestOrgConfigValidateRuntime(t *testing.T) {

--- a/internal/runtime/opencode.go
+++ b/internal/runtime/opencode.go
@@ -20,8 +20,9 @@ func (OpenCodeRuntime) Name() string { return "opencode" }
 
 // System returns the OTEL GenAI gen_ai.system value. OpenCode is multi-provider
 // (Anthropic, OpenAI, Google, etc.), so the system is the runtime itself rather
-// than a single model vendor. The actual model vendor can be captured from
-// InitEvent at stream parse time in a future PR.
+// than a single model vendor. The actual model vendor may be capturable from
+// opencode's stream/export events in a future PR once the event schema is
+// confirmed (see #1935).
 func (OpenCodeRuntime) System() string { return "opencode" }
 
 func (OpenCodeRuntime) ConfigDir() string { return sandbox.SandboxWorkspace + "/.opencode" }
@@ -30,7 +31,9 @@ func (OpenCodeRuntime) WorkspaceDir() string { return sandbox.SandboxWorkspace }
 
 func (OpenCodeRuntime) EnvExports() []string { return nil }
 
-func (OpenCodeRuntime) Bootstrap(_ BootstrapInput) error { return nil }
+func (OpenCodeRuntime) Bootstrap(_ BootstrapInput) error {
+	return fmt.Errorf("opencode runtime is not yet implemented")
+}
 
 func (OpenCodeRuntime) Run(_ context.Context, _ RunParams, _ *ui.Printer, _ time.Time, _ *RunMetrics) (int, error) {
 	return -1, fmt.Errorf("opencode runtime is not yet implemented")

--- a/internal/runtime/opencode.go
+++ b/internal/runtime/opencode.go
@@ -1,0 +1,62 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/sandbox"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+// OpenCodeRuntime is a stub implementation of the Runtime and TranscriptHandler
+// interfaces for the OpenCode agent runtime. All methods are no-ops or return
+// not-implemented errors. Subsequent PRs will fill in stream parsing, bootstrap,
+// run execution, and transcript extraction.
+type OpenCodeRuntime struct{}
+
+func (OpenCodeRuntime) Name() string { return "opencode" }
+
+// System returns the OTEL GenAI gen_ai.system value. OpenCode is multi-provider
+// (Anthropic, OpenAI, Google, etc.), so the system is the runtime itself rather
+// than a single model vendor. The actual model vendor can be captured from
+// InitEvent at stream parse time in a future PR.
+func (OpenCodeRuntime) System() string { return "opencode" }
+
+func (OpenCodeRuntime) ConfigDir() string { return sandbox.SandboxWorkspace + "/.opencode" }
+
+func (OpenCodeRuntime) WorkspaceDir() string { return sandbox.SandboxWorkspace }
+
+func (OpenCodeRuntime) EnvExports() []string { return nil }
+
+func (OpenCodeRuntime) Bootstrap(_ BootstrapInput) error { return nil }
+
+func (OpenCodeRuntime) Run(_ context.Context, _ RunParams, _ *ui.Printer, _ time.Time, _ *RunMetrics) (int, error) {
+	return -1, fmt.Errorf("opencode runtime is not yet implemented")
+}
+
+func (OpenCodeRuntime) ClearIterationArtifacts(_ string) error { return nil }
+
+// TranscriptHandler stub methods — all no-ops until opencode export integration
+// is implemented.
+
+func (OpenCodeRuntime) ExtractTranscripts(_, _, _ string) error { return nil }
+
+func (OpenCodeRuntime) ExtractDebugLog(_, _, _ string) error { return nil }
+
+func (OpenCodeRuntime) ParseTranscriptErrors(_ string) []TranscriptError { return nil }
+
+func (OpenCodeRuntime) ParseTranscriptFile(_ string) (TranscriptError, bool) {
+	return TranscriptError{}, false
+}
+
+func (OpenCodeRuntime) EmitTranscriptErrors(w io.Writer, summaries []TranscriptError) {
+	emitTranscriptErrors(w, summaries)
+}
+
+// Compile-time interface assertions.
+var (
+	_ Runtime           = OpenCodeRuntime{}
+	_ TranscriptHandler = OpenCodeRuntime{}
+)

--- a/internal/runtime/opencode.go
+++ b/internal/runtime/opencode.go
@@ -25,6 +25,11 @@ func (OpenCodeRuntime) Name() string { return "opencode" }
 // confirmed (see #1935).
 func (OpenCodeRuntime) System() string { return "opencode" }
 
+// ConfigDir returns the opencode config directory inside the sandbox.
+// Provisional — verify opencode's config discovery before implementing
+// Bootstrap (#1260). Consider placing config outside the agent-writable
+// workspace (like Claude's /sandbox/claude-config) to prevent the agent
+// from rewriting its own runtime config.
 func (OpenCodeRuntime) ConfigDir() string { return sandbox.SandboxWorkspace + "/.opencode" }
 
 func (OpenCodeRuntime) WorkspaceDir() string { return sandbox.SandboxWorkspace }
@@ -41,12 +46,17 @@ func (OpenCodeRuntime) Run(_ context.Context, _ RunParams, _ *ui.Printer, _ time
 
 func (OpenCodeRuntime) ClearIterationArtifacts(_ string) error { return nil }
 
-// TranscriptHandler stub methods — all no-ops until opencode export integration
-// is implemented.
+// TranscriptHandler stub methods — return not-implemented errors for extract
+// methods (to avoid silent success claims in CI logs) and no-ops for parse
+// methods (which correctly indicate "nothing found"). See #1935.
 
-func (OpenCodeRuntime) ExtractTranscripts(_, _, _ string) error { return nil }
+func (OpenCodeRuntime) ExtractTranscripts(_, _, _ string) error {
+	return fmt.Errorf("opencode transcript extraction not implemented (see #1935)")
+}
 
-func (OpenCodeRuntime) ExtractDebugLog(_, _, _ string) error { return nil }
+func (OpenCodeRuntime) ExtractDebugLog(_, _, _ string) error {
+	return fmt.Errorf("opencode debug log extraction not implemented (see #1935)")
+}
 
 func (OpenCodeRuntime) ParseTranscriptErrors(_ string) []TranscriptError { return nil }
 

--- a/internal/runtime/opencode_test.go
+++ b/internal/runtime/opencode_test.go
@@ -17,7 +17,7 @@ func TestOpenCodeRuntimeMetadata(t *testing.T) {
 	rt := OpenCodeRuntime{}
 	assert.Equal(t, "opencode", rt.Name())
 	assert.Equal(t, "opencode", rt.System())
-	assert.Equal(t, sandbox.SandboxWorkspace+"/.opencode", rt.ConfigDir())
+	assert.Equal(t, sandbox.SandboxWorkspace+"/.opencode", rt.ConfigDir()) // provisional — see ConfigDir() comment
 	assert.Equal(t, sandbox.SandboxWorkspace, rt.WorkspaceDir())
 	assert.Nil(t, rt.EnvExports())
 }
@@ -41,12 +41,23 @@ func TestOpenCodeRuntimeBootstrap_NotImplemented(t *testing.T) {
 	assert.Contains(t, err.Error(), "not yet implemented")
 }
 
+func TestOpenCodeRuntimeExtractStubs_NotImplemented(t *testing.T) {
+	t.Parallel()
+
+	rt := OpenCodeRuntime{}
+	err := rt.ExtractTranscripts("", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "#1935")
+
+	err = rt.ExtractDebugLog("", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "#1935")
+}
+
 func TestOpenCodeRuntimeNoopMethods(t *testing.T) {
 	t.Parallel()
 
 	rt := OpenCodeRuntime{}
-	assert.NoError(t, rt.ExtractTranscripts("", "", ""))
-	assert.NoError(t, rt.ExtractDebugLog("", "", ""))
 	assert.Nil(t, rt.ParseTranscriptErrors(""))
 	assert.NoError(t, rt.ClearIterationArtifacts(""))
 

--- a/internal/runtime/opencode_test.go
+++ b/internal/runtime/opencode_test.go
@@ -32,11 +32,19 @@ func TestOpenCodeRuntimeRun_NotImplemented(t *testing.T) {
 	assert.Contains(t, err.Error(), "not yet implemented")
 }
 
+func TestOpenCodeRuntimeBootstrap_NotImplemented(t *testing.T) {
+	t.Parallel()
+
+	rt := OpenCodeRuntime{}
+	err := rt.Bootstrap(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet implemented")
+}
+
 func TestOpenCodeRuntimeNoopMethods(t *testing.T) {
 	t.Parallel()
 
 	rt := OpenCodeRuntime{}
-	assert.NoError(t, rt.Bootstrap(nil))
 	assert.NoError(t, rt.ExtractTranscripts("", "", ""))
 	assert.NoError(t, rt.ExtractDebugLog("", "", ""))
 	assert.Nil(t, rt.ParseTranscriptErrors(""))

--- a/internal/runtime/opencode_test.go
+++ b/internal/runtime/opencode_test.go
@@ -1,0 +1,51 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/sandbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenCodeRuntimeMetadata(t *testing.T) {
+	t.Parallel()
+
+	rt := OpenCodeRuntime{}
+	assert.Equal(t, "opencode", rt.Name())
+	assert.Equal(t, "opencode", rt.System())
+	assert.Equal(t, sandbox.SandboxWorkspace+"/.opencode", rt.ConfigDir())
+	assert.Equal(t, sandbox.SandboxWorkspace, rt.WorkspaceDir())
+	assert.Nil(t, rt.EnvExports())
+}
+
+func TestOpenCodeRuntimeRun_NotImplemented(t *testing.T) {
+	t.Parallel()
+
+	rt := OpenCodeRuntime{}
+	exit, err := rt.Run(context.Background(), RunParams{}, nil, time.Now(), nil)
+	assert.Equal(t, -1, exit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet implemented")
+}
+
+func TestOpenCodeRuntimeNoopMethods(t *testing.T) {
+	t.Parallel()
+
+	rt := OpenCodeRuntime{}
+	assert.NoError(t, rt.Bootstrap(nil))
+	assert.NoError(t, rt.ExtractTranscripts("", "", ""))
+	assert.NoError(t, rt.ExtractDebugLog("", "", ""))
+	assert.Nil(t, rt.ParseTranscriptErrors(""))
+	assert.NoError(t, rt.ClearIterationArtifacts(""))
+
+	te, ok := rt.ParseTranscriptFile("")
+	assert.False(t, ok)
+	assert.Equal(t, TranscriptError{}, te)
+
+	var buf bytes.Buffer
+	rt.EmitTranscriptErrors(&buf, nil)
+}

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -17,6 +17,9 @@ func Resolve(name string) (Backend, error) {
 		// Selected only via explicit per-repo/org config (behaviour test orgs).
 		r := DummyRuntime{}
 		return Backend{Runtime: r, Transcripts: r}, nil
+	case "opencode":
+		r := OpenCodeRuntime{}
+		return Backend{Runtime: r, Transcripts: r}, nil
 	default:
 		return Backend{}, fmt.Errorf("unknown runtime %q: must be one of %s", name, strings.Join(config.ValidRuntimes(), ", "))
 	}

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -23,6 +23,8 @@ func TestResolve(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "opencode", oc.Runtime.Name())
 	assert.NotNil(t, oc.Transcripts)
+	_, isOC := oc.Transcripts.(OpenCodeRuntime)
+	assert.True(t, isOC, "Transcripts should be OpenCodeRuntime")
 
 	_, err = Resolve("unknown")
 	require.Error(t, err)
@@ -61,6 +63,14 @@ func TestResolveFromPerRepoConfig(t *testing.T) {
 	dummyBackend, err := ResolveFromPerRepoConfig(cfg)
 	require.NoError(t, err)
 	assert.Equal(t, "dummy", dummyBackend.Runtime.Name())
+
+	// opencode is not in ValidRuntimes() but is resolvable via Resolve().
+	// A hand-written config bypassing validation can reach the stub.
+	ocCfg := config.NewPerRepoConfig(nil, "")
+	ocCfg.SetRuntime("opencode")
+	ocBackend, err := ResolveFromPerRepoConfig(ocCfg)
+	require.NoError(t, err)
+	assert.Equal(t, "opencode", ocBackend.Runtime.Name())
 
 	invalidCfg := config.NewPerRepoConfig(nil, "")
 	invalidCfg.SetRuntime("invalid")

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -19,6 +19,11 @@ func TestResolve(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "dummy", dummy.Runtime.Name())
 
+	oc, err := Resolve("opencode")
+	require.NoError(t, err)
+	assert.Equal(t, "opencode", oc.Runtime.Name())
+	assert.NotNil(t, oc.Transcripts)
+
 	_, err = Resolve("unknown")
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Register "opencode" as an agent runtime backend via `runtime.Resolve()` with a stub `OpenCodeRuntime` that satisfies both `Runtime` and `TranscriptHandler` interfaces. The stub is **not** added to `config.ValidRuntimes()` — it is resolvable internally for dev/testing but not user-selectable via `fullsend github --runtime` or `fullsend admin install --runtime` until the runtime is functional.

**Note:** This stub does not resolve #1935. The format-neutral TranscriptHandler contract (#1935) remains a hard prerequisite before `Run()` and TranscriptHandler methods can be implemented for real. Extract methods return explicit not-implemented errors referencing #1935 to prevent silent success claims.

## Related Issue

Refs #1260
Refs #1935

## Changes

- Add `case "opencode"` to `runtime.Resolve()` returning a Backend with `OpenCodeRuntime`
- Create `internal/runtime/opencode.go` — stub struct with:
  - `Bootstrap()` and `Run()` returning `fmt.Errorf("opencode runtime is not yet implemented")` (fails during sandbox bootstrap, before agent execution)
  - `ExtractTranscripts()`/`ExtractDebugLog()` returning not-implemented errors referencing #1935 (prevents silent success in CI logs)
  - Parse/emit methods returning no-ops (correctly indicate "nothing found")
  - `ConfigDir()` marked provisional with security note about agent-writable workspace (#1260)
- Add compile-time interface assertions for both `Runtime` and `TranscriptHandler`
- Add `opencode` column to `docs/runtimes.md` security feature matrix (all N/A — stub; does not implement `ClaudeHooksBootstrap`)
- Add `opencode` row to `docs/runtimes.md` registered runtimes table (noted as not in `ValidRuntimes()` until implemented)
- **Not** added to `config.ValidRuntimes()` — avoids exposing a non-functional runtime on user setup paths and avoids updating ~5 doc/CLI surfaces that enumerate valid runtimes

## Testing

- [x] `make lint` passes (stage changes first, then run)
- [x] Tests added/updated for new or modified logic

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it