### PR TITLE
fix(deps): resolve OpenShell digest lookup

### DIFF
--- a/.github/scripts/openshell-version.sh
+++ b/.github/scripts/openshell-version.sh
@@ -5,10 +5,15 @@
 # current shell. In GitHub Actions it also exports them to GITHUB_ENV
 # for downstream steps.
 #
+# OPENSHELL_VERSION is tracked by Renovate via a customManager in
+# renovate.json (not this file's magic comments — a bare "# renovate:"
+# comment here would be inert since no built-in manager scans .sh files).
+# OPENSHELL_SHA is refreshed automatically after each version bump by
+# scripts/renovate/update-openshell-sha.sh (see renovate.json postUpgradeTasks).
+#
 # Usage:
 #   source .github/scripts/openshell-version.sh
 
-# renovate: datasource=github-releases depName=NVIDIA/OpenShell
 OPENSHELL_VERSION=0.0.83
 OPENSHELL_SHA=e3d26dd3ae0dee247bbc5db368545832757ac493
 

--- a/images/README.md
+++ b/images/README.md
@@ -153,6 +153,12 @@ source URL for checksums.  When bumping a version:
 3. The base image digest can be updated by running
    `podman manifest inspect <image>:<tag>` and extracting the index digest.
 
+OpenShell CLI (runner) is the exception: `OPENSHELL_VERSION` is tracked by a
+Renovate customManager, and `OPENSHELL_SHA` is refreshed automatically by
+`scripts/renovate/update-openshell-sha.sh` via `postUpgradeTasks` after each
+version bump — no manual checksum download needed. See
+`.github/scripts/openshell-version.sh` for details.
+
 ## Local builds
 
 Build for your native architecture:

--- a/images/README.md
+++ b/images/README.md
@@ -153,11 +153,16 @@ source URL for checksums.  When bumping a version:
 3. The base image digest can be updated by running
    `podman manifest inspect <image>:<tag>` and extracting the index digest.
 
-OpenShell CLI (runner) is the exception: `OPENSHELL_VERSION` is tracked by a
-Renovate customManager, and `OPENSHELL_SHA` is refreshed automatically by
+OpenShell is partially automated: `OPENSHELL_VERSION` is tracked by a
+Renovate customManager, and `OPENSHELL_SHA` (the commit SHA used by
+`.github/scripts/install-openshell.sh` to pin the upstream installer on CI
+host runners) is refreshed automatically by
 `scripts/renovate/update-openshell-sha.sh` via `postUpgradeTasks` after each
-version bump — no manual checksum download needed. See
-`.github/scripts/openshell-version.sh` for details.
+version bump. The runner Containerfile's OpenShell install is independent —
+it downloads the release tarball by version and verifies it with
+`sha256sum -c` against the release checksums file (see the table above).
+See `.github/scripts/openshell-version.sh` for the version/SHA source of
+truth.
 
 ## Local builds
 

--- a/renovate.json
+++ b/renovate.json
@@ -22,12 +22,24 @@
       "enabled": false
     },
     {
-      "description": "Group OpenShell base image and version pin into one PR",
+      "description": "Group OpenShell base image and version pin into one PR. After a version bump, fetch and update OPENSHELL_SHA from the matching release tag (the github-releases datasource can't resolve a digest here because extractVersionTemplate strips the 'v' prefix that GitHub's tag lookup needs).",
       "matchPackageNames": [
         "ghcr.io/nvidia/openshell-community/sandboxes/base",
         "NVIDIA/OpenShell"
       ],
-      "groupName": "openshell"
+      "groupName": "openshell",
+      "automerge": false,
+      "postUpgradeTasks": {
+        "commands": ["bash scripts/renovate/update-openshell-sha.sh"],
+        "fileFilters": [".github/scripts/openshell-version.sh"],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "description": "Automerge digest bumps for Red Hat UBI base images once required checks pass",
+      "matchPackageNames": ["/^registry\\.access\\.redhat\\.com\\/ubi10\\//"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
     },
     {
       "description": "Group Cloudflare Worker packages to prevent broken lockfile-only PRs from peer dependency conflicts",
@@ -67,10 +79,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track OpenShell version pin in openshell-version.sh",
+      "description": "Track the OpenShell version pin in openshell-version.sh. OPENSHELL_SHA is updated automatically by postUpgradeTasks (scripts/renovate/update-openshell-sha.sh) since the github-releases datasource can't resolve a digest for the version-only (no 'v' prefix) value produced by extractVersionTemplate.",
       "managerFilePatterns": ["/^\\.github/scripts/openshell-version\\.sh$/"],
       "matchStrings": [
-        "OPENSHELL_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)\\nOPENSHELL_SHA=(?<currentDigest>[0-9a-f]{40})"
+        "OPENSHELL_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "NVIDIA/OpenShell",
       "datasourceTemplate": "github-releases",

--- a/renovate.json
+++ b/renovate.json
@@ -36,12 +36,6 @@
       }
     },
     {
-      "description": "Automerge digest bumps for Red Hat UBI base images once required checks pass",
-      "matchPackageNames": ["/^registry\\.access\\.redhat\\.com\\/ubi10\\//"],
-      "matchUpdateTypes": ["digest"],
-      "automerge": true
-    },
-    {
       "description": "Group Cloudflare Worker packages to prevent broken lockfile-only PRs from peer dependency conflicts",
       "matchPackageNames": ["/^@cloudflare\\//", "wrangler", "miniflare"],
       "groupName": "cloudflare-workers"

--- a/scripts/renovate/update-openshell-sha.sh
+++ b/scripts/renovate/update-openshell-sha.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Called by Renovate postUpgradeTasks after an OpenShell version bump.
+#
+# The github-releases datasource can't resolve a digest for OPENSHELL_SHA
+# directly: Renovate's digest lookup compares the new value against raw
+# GitHub tag names (e.g. "v0.0.103"), but extractVersionTemplate strips the
+# "v" prefix from the value tracked in this file (e.g. "0.0.103"), so the
+# comparison never matches. Instead, this script looks up the commit SHA
+# for the release tag directly and patches it in.
+set -euo pipefail
+
+FILE=".github/scripts/openshell-version.sh"
+
+OLD_VERSION=$(git show HEAD:"${FILE}" | grep -oP '^OPENSHELL_VERSION=\K\S+' || true)
+NEW_VERSION=$(grep -oP '^OPENSHELL_VERSION=\K\S+' "${FILE}" || true)
+
+if [[ -z "${NEW_VERSION}" ]]; then
+  echo "error: could not extract OPENSHELL_VERSION from working-tree ${FILE}" >&2
+  exit 1
+fi
+if [[ ! "${NEW_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: NEW_VERSION is not a valid semver: ${NEW_VERSION}" >&2
+  exit 1
+fi
+
+if [[ "${OLD_VERSION}" == "${NEW_VERSION}" ]]; then
+  echo "OpenShell version unchanged (${NEW_VERSION}), nothing to do"
+  exit 0
+fi
+
+echo "OpenShell: ${OLD_VERSION:-<none>} -> ${NEW_VERSION}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+curl -fsSL "https://api.github.com/repos/NVIDIA/OpenShell/commits/v${NEW_VERSION}" \
+  -o "${WORKDIR}/commit.json"
+SHA=$(grep -m1 -oP '"sha":\s*"\K[0-9a-f]{40}' "${WORKDIR}/commit.json" || true)
+
+if [[ ! "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "error: resolved SHA is not a valid 40-char hex commit sha: ${SHA}" >&2
+  exit 1
+fi
+
+sed -i "s/^OPENSHELL_SHA=.*/OPENSHELL_SHA=${SHA}/" "${FILE}"
+
+echo "updated OPENSHELL_SHA to ${SHA} for v${NEW_VERSION}"

--- a/scripts/renovate/update-openshell-sha.sh
+++ b/scripts/renovate/update-openshell-sha.sh
@@ -35,13 +35,23 @@ trap 'rm -rf "${WORKDIR}"' EXIT
 
 curl -fsSL "https://api.github.com/repos/NVIDIA/OpenShell/commits/v${NEW_VERSION}" \
   -o "${WORKDIR}/commit.json"
-SHA=$(grep -m1 -oP '"sha":\s*"\K[0-9a-f]{40}' "${WORKDIR}/commit.json" || true)
+SHA=$(jq -r '.sha // empty' "${WORKDIR}/commit.json")
 
 if [[ ! "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
   echo "error: resolved SHA is not a valid 40-char hex commit sha: ${SHA}" >&2
   exit 1
 fi
 
+if ! grep -q "^OPENSHELL_SHA=" "${FILE}"; then
+  echo "error: no OPENSHELL_SHA line found in ${FILE}" >&2
+  exit 1
+fi
+
 sed -i "s/^OPENSHELL_SHA=.*/OPENSHELL_SHA=${SHA}/" "${FILE}"
+
+if ! grep -q "^OPENSHELL_SHA=${SHA}$" "${FILE}"; then
+  echo "error: failed to update OPENSHELL_SHA in ${FILE}" >&2
+  exit 1
+fi
 
 echo "updated OPENSHELL_SHA to ${SHA} for v${NEW_VERSION}"


### PR DESCRIPTION
## Summary

- Fixes the Dependency Dashboard warning (#2682): `Could not determine new digest for update (github-releases package NVIDIA/OpenShell)`. Root cause: the customManager's `extractVersionTemplate` strips the leading `v` from `OPENSHELL_VERSION` so it matches the bare-number value stored in the file, but Renovate's digest lookup for `github-releases` compares that stripped value against raw GitHub tag names (e.g. `v0.0.103`) and never finds a match — so `currentDigest`/`OPENSHELL_SHA` tracking can never succeed. This is a structural incompatibility between `extractVersionTemplate` and digest tracking, not a config typo (confirmed by reading Renovate's `findCommitOfTag` source). PR #5749 fixed a related-but-different problem (unreleased tags) by switching datasources; it didn't touch this.
- Fix: stop asking Renovate to resolve `OPENSHELL_SHA` as a digest. Track only `OPENSHELL_VERSION`, and add a `postUpgradeTasks` script (`scripts/renovate/update-openshell-sha.sh`) that looks up the release tag's commit SHA directly via the GitHub API and patches it in — the same pattern already used here for `tirith`/`cosign`.
- Removes the inert `# renovate:` magic comment from `openshell-version.sh` — no built-in Renovate manager scans `.sh` files for magic comments, so it did nothing (the customManager's explicit `depNameTemplate`/`datasourceTemplate` is what actually drives extraction).

## Testing

- [x] `npx --yes --package renovate -- renovate-config-validator` — config validated successfully
- [x] `LOG_LEVEL=debug npx --yes --package renovate -- renovate --dry-run=full fullsend-ai/fullsend` against the **unpatched** `main` branch reproduced the exact reported warning (`Could not determine new digest for update (github-releases package NVIDIA/OpenShell)`), confirming the root-cause diagnosis
- [x] Manually exercised `update-openshell-sha.sh` against a scratch git repo: version bump `0.0.83 -> 0.0.103` correctly resolves and writes `OPENSHELL_SHA=c825b1f8efac457f3ca3c6f9e06fb068e8ce3ecc` (verified independently against `gh api repos/NVIDIA/OpenShell/commits/v0.0.103`); unchanged-version and bad-tag cases exit cleanly/non-zero as expected
- [x] Confirmed production Renovate's `RENOVATE_ALLOWED_COMMANDS` regex (`.github/workflows/renovate.yml`) already covers `bash scripts/renovate/*.sh`, so the new postUpgradeTask needs no additional allowlisting
- [x] `pre-commit run` (shellcheck, check-json, etc.) passes on all changed files

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>