### PR TITLE
ci(e2e): delete leaked repo-level FULLSEND_MINT_URL from test-repo

### DIFF
--- a/pkg/e2etest/cleanup.go
+++ b/pkg/e2etest/cleanup.go
@@ -104,6 +104,16 @@ func CleanupStaleResources(ctx context.Context, client forge.Client, token, org 
 		t.Logf("[cleanup] Warning: could not delete per-repo guard variable: %v", delErr)
 	}
 
+	// 8. Delete stale repo-level FULLSEND_MINT_URL variable from test-repo.
+	// Per-repo install drivers (e.g. cfmint) write this as a repo variable,
+	// which takes precedence over the org-level FULLSEND_MINT_URL set by
+	// admin install. Ephemeral preview mints (cfmint) are torn down at the
+	// end of their run, so a leaked repo variable points to a dead URL and
+	// breaks dispatch for any later run that reuses this org.
+	if delErr := client.DeleteRepoVariable(ctx, org, TestRepo, "FULLSEND_MINT_URL"); delErr != nil {
+		t.Logf("[cleanup] Warning: could not delete stale repo-level mint URL variable: %v", delErr)
+	}
+
 	t.Log("[cleanup] Stale resource scan complete")
 }
 
@@ -117,6 +127,14 @@ func TeardownPerRepoInstall(ctx context.Context, client forge.Client, token, org
 	deleteBranch(ctx, token, org, repo, "fullsend/onboard", log)
 	deleteBranch(ctx, token, org, repo, "fullsend/offboard", log)
 	deleteShimWorkflow(ctx, token, org, repo, log)
+	// Delete the repo-level FULLSEND_MINT_URL variable written by
+	// per-repo install drivers. It takes precedence over org-level
+	// FULLSEND_MINT_URL, so leaving it behind breaks dispatch for any
+	// later run (e.g. an org-level admin install) that reuses this repo
+	// from a shared org pool.
+	if delErr := client.DeleteRepoVariable(ctx, org, repo, "FULLSEND_MINT_URL"); delErr != nil {
+		log.Logf("[cleanup] Warning: could not delete repo-level mint URL variable: %v", delErr)
+	}
 	prs, err := client.ListRepoPullRequests(ctx, org, repo)
 	if err != nil {
 		log.Logf("[cleanup] Warning: could not list PRs: %v", err)


### PR DESCRIPTION
## Summary
- `cfmint` (the behaviour-test CF Worker preview mint driver from #6037) writes `FULLSEND_MINT_URL` as a repo-level variable on `test-repo` via `fullsend github setup`
- Repo-level variables take precedence over org-level ones, and nothing ever deleted this variable — since e2e admin tests and behaviour tests share the same org pool and both use a repo named `test-repo`, a leaked value from a prior behaviour-test run shadows the org-level `FULLSEND_MINT_URL` that admin install sets
- Because the CF Worker preview mint is ephemeral (torn down at the end of its run), the leaked URL is dead, so dispatch fails with a DNS resolution error for any run that later reuses the org — this is currently breaking `TestAdminInstallUninstall`'s triage-dispatch phase intermittently across PRs
- Delete the repo variable in `TeardownPerRepoInstall` (immediate cleanup) and `CleanupStaleResources` (defensive cleanup so already-poisoned orgs in the pool self-heal)

## Test plan
- [x] `go build ./pkg/e2etest/... ./pkg/behaviourtest/...`
- [x] `go test ./pkg/e2etest/... ./pkg/behaviourtest/... ./internal/forge/...`
- [x] `pre-commit run --files pkg/e2etest/cleanup.go`

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>