### PR TITLE
fix(#6125): delete leaked repo-level FULLSEND_MINT_URL in e2e cleanup

### DIFF
--- a/pkg/e2etest/cleanup.go
+++ b/pkg/e2etest/cleanup.go
@@ -77,6 +77,11 @@ func CleanupStaleResources(ctx context.Context, client forge.Client, token, org 
 	// Clear per-repo install guard so enroll-all includes test-repo.
 	deleteRepoVariable(ctx, token, org, TestRepo, forge.PerRepoGuardVar, t)
 
+	// Clear leaked repo-level FULLSEND_MINT_URL left by cfmint behaviour
+	// tests (#6037). Repo variables shadow org-level ones, so a stale
+	// value pointing at a torn-down CF Worker preview breaks dispatch.
+	deleteRepoVariable(ctx, token, org, TestRepo, "FULLSEND_MINT_URL", t)
+
 	// 4. Delete stale enrollment and unenrollment branches from test-repo.
 	deleteBranch(ctx, token, org, TestRepo, "fullsend/onboard", t)
 	deleteBranch(ctx, token, org, TestRepo, "fullsend/offboard", t)


### PR DESCRIPTION
## Summary
- Add FULLSEND_MINT_URL deletion to CleanupStaleResources so already-poisoned halfsend orgs self-heal at the start of the next admin E2E run
- Root cause: cfmint behaviour tests (#6037) write a repo-level FULLSEND_MINT_URL on test-repo that shadows the org-level variable and points to a torn-down CF Worker preview, breaking the OIDC mint step in dispatch.yml
- PR #6112 prevents future poisoning but does not heal existing state; this completes the fix

Closes #6125

## Test plan
- [ ] Merge queue E2E TestAdminInstallUninstall passes (the cleanup runs at test start, deleting the leaked variable before install)
- [ ] Verify no regression on behaviour tests (this only touches admin E2E cleanup path)

Generated with Claude Code