### PR TITLE
feat: gate agents tag on functional test validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,33 @@ jobs:
             git push origin v0
           fi
 
-      # Sync the version tag to fullsend-ai/agents. Runs for all tags
-      # including pre-releases — agents' own release.yml handles
-      # pre-release semantics. Intentionally coupled to the v0 step:
-      # if the v0 move fails, the release state is suspect and agents
-      # should not be tagged until the issue is investigated.
+  validate-agents:
+    needs: release
+    permissions:
+      contents: read
+      id-token: write
+    uses: fullsend-ai/agents/.github/workflows/functional-tests.yml@a8566cd5305fe094b96588690118022967ad0061 # main
+    with:
+      fullsend_ref: ${{ github.ref_name }}
+    secrets:
+      E2E_GCP_WIF_PROVIDER: ${{ secrets.E2E_GCP_WIF_PROVIDER }}
+      E2E_GCP_SERVICE_ACCOUNT: ${{ secrets.E2E_GCP_SERVICE_ACCOUNT }}
+      E2E_GCP_PROJECT_ID: ${{ secrets.E2E_GCP_PROJECT_ID }}
+      # Fine-grained PAT scoped to the eval org — used by functional
+      # tests to read eval repos and record eval run results.
+      EVAL_GH_TOKEN: ${{ secrets.EVAL_GH_TOKEN }}
+
+  tag-agents:
+    # Sync the version tag to fullsend-ai/agents. Runs for all tags
+    # including pre-releases — agents' own release.yml handles
+    # pre-release semantics. Only runs after agents functional tests
+    # pass against the release tag.
+    needs: [release, validate-agents]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
       - name: Generate agents repo token
         id: agents-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -87,3 +109,22 @@ jobs:
             -f ref="refs/tags/${TAG}" \
             -f sha="${AGENTS_SHA}"
           echo "Created tag ${TAG} on fullsend-ai/agents at ${AGENTS_SHA}"
+
+  notify-agents-sync-failure:
+    needs: [release, validate-agents, tag-agents]
+    if: >-
+      always()
+      && needs.release.result == 'success'
+      && (needs.validate-agents.result == 'failure' || needs.tag-agents.result == 'failure')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          PAYLOAD=$(jq -n --arg tag "${GITHUB_REF_NAME}" --arg url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{text: ":warning: Agents tag sync failed for `\($tag)`. The fullsend release shipped but the agents tag was not created. <\($url)|View run>"}')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$SLACK_WEBHOOK"

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -180,8 +180,13 @@ installs the binary as `fullsend-<tag>` so multiple versions can coexist.
   workflows. It is automatically moved by the release workflow after
   GoReleaser completes (skipped for pre-release tags).
 - **The `fullsend-ai/agents` repo** is tagged with the same version
-  automatically. After GoReleaser completes, the release workflow
-  pushes the tag to agents using an org-owned GitHub App token
-  (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`). That tag push
-  triggers agents' own `release.yml`, which creates a GitHub Release
-  and moves its `v0` floating tag.
+  after the release workflow validates agents against the new binary.
+  After GoReleaser completes, the `validate-agents` job runs agents'
+  functional tests (via a cross-repo reusable workflow call) against
+  the release tag. Only if those tests pass does the `tag-agents` job
+  push the tag to agents using an org-owned GitHub App token
+  (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`). If validation or
+  tagging fails, a Slack notification is sent and the fullsend release
+  still ships — only the agents tag is blocked. That tag push triggers
+  agents' own `release.yml`, which creates a GitHub Release and moves
+  its `v0` floating tag.

--- a/skills/cutting-releases/post-flight.md
+++ b/skills/cutting-releases/post-flight.md
@@ -30,19 +30,28 @@ gh release view <tag>
 Check that the title, changelog, and binary assets look correct.
 Verify the release is not marked as a draft.
 
-## B2. Verify agents repo release
+## B2. Verify agents validation and tag
 
-The release workflow pushes the same tag to `fullsend-ai/agents`,
-which triggers agents' own `release.yml` to create a GitHub Release
-and move the `v0` floating tag.
+The release workflow gates the agents tag on functional test
+validation. After GoReleaser completes, `validate-agents` runs
+agents' functional tests against the release tag. Only if those
+tests pass does `tag-agents` push the tag to agents. If either
+job fails, a Slack notification is sent automatically.
 
-Verify the agents release workflow succeeded:
+First, verify the `validate-agents` and `tag-agents` jobs succeeded
+in the release workflow run:
 
 ```
-gh run list --repo fullsend-ai/agents --workflow=release.yml --limit=1
+gh run view <run-id> --repo fullsend-ai/fullsend --json jobs \
+  --jq '.jobs[] | select(.name | test("validate-agents|tag-agents")) | {name, conclusion}'
 ```
 
-Verify the tag and release exist:
+If `validate-agents` failed, the agents functional tests did not
+pass against the new binary — investigate before proceeding. The
+fullsend release shipped, but agents was not tagged. A Slack
+notification should have been sent.
+
+If both jobs succeeded, verify the tag and release exist on agents:
 
 ```
 gh release view <tag> --repo fullsend-ai/agents


### PR DESCRIPTION
## Summary

- Run agents functional tests against the release tag **before** pushing the version tag to `fullsend-ai/agents`
- Extracts the agents tag push into a separate `tag-agents` job, gated on a new `validate-agents` job
- The fullsend release (binary, checksums, `v0` tag) ships regardless — only the agents tag is gated on test success

## How it works

The `release` job is unchanged. Two new jobs:

1. **`validate-agents`** — calls `fullsend-ai/agents/.github/workflows/functional-tests.yml@main` with `fullsend_ref` set to the release tag. This builds fullsend from the tag and runs agents' functional test suite against it.
2. **`tag-agents`** — `needs: [release, validate-agents]`. Only runs if validation passes. Contains the existing app-token generation and tag-push logic, moved from the `release` job.

## Prerequisites

- [x] `fullsend-ai/agents#775` — agents workflow accepts `workflow_call` with `fullsend_ref` input (PR #776 merged)

## Test plan

- [ ] Verify workflow YAML is valid (pre-commit `actionlint` passed)
- [ ] Trigger a pre-release tag to validate the end-to-end flow
- [ ] Confirm fullsend release completes even if agents validation fails

Closes #6173

🤖 Generated with [Claude Code](https://claude.com/claude-code)