### PR TITLE
fix(#5536): use is_bot for bot-author detection in fix eligibility

### DIFF
--- a/.github/scripts/check-fix-eligibility-test.sh
+++ b/.github/scripts/check-fix-eligibility-test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# check-fix-eligibility-test.sh — Tests for check-fix-eligibility.sh
+#
+# Run from the repo root:
+#   bash .github/scripts/check-fix-eligibility-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/check-fix-eligibility.sh"
+FAILURES=0
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+# build_mock creates a mock gh binary that returns preconfigured PR JSON.
+#   $1 — is_bot value (true/false/null)
+#   $2 — login value
+#   $3 — comma-separated labels (optional)
+build_mock() {
+  local is_bot="$1" login="$2" labels="${3:-}"
+  local mock_bin="${TMPDIR}/bin"
+
+  rm -rf "${mock_bin}"
+  mkdir -p "${mock_bin}"
+
+  local labels_json="[]"
+  if [[ -n "${labels}" ]]; then
+    labels_json=$(printf '%s' "${labels}" | jq -R 'split(",")')
+  fi
+
+  local json
+  json=$(jq -n \
+    --argjson is_bot "${is_bot}" \
+    --arg login "${login}" \
+    --argjson labels "${labels_json}" \
+    '{labels: $labels, is_bot: $is_bot, login: $login}')
+
+  printf '%s' "${json}" > "${TMPDIR}/pr-json.txt"
+  printf '%s' "${TMPDIR}/pr-json.txt" > "${TMPDIR}/pr-json-path"
+
+  cat > "${mock_bin}/gh" <<'MOCKEOF'
+#!/usr/bin/env bash
+MOCK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PR_JSON_FILE="$(cat "${MOCK_DIR}/pr-json-path")"
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  shift 2
+  json_arg="" jq_arg=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repo) shift ;;
+      --json) shift; json_arg="$1" ;;
+      --jq)   shift; jq_arg="$1" ;;
+      *)      ;;
+    esac
+    shift
+  done
+  if [[ "${json_arg}" != "labels,author" ]]; then
+    echo "mock gh: unexpected --json arg: ${json_arg}" >&2
+    exit 1
+  fi
+  if [[ "${jq_arg}" != '{labels: [.labels[].name], is_bot: .author.is_bot, login: .author.login}' ]]; then
+    echo "mock gh: unexpected --jq arg: ${jq_arg}" >&2
+    exit 1
+  fi
+  cat "${PR_JSON_FILE}"
+  exit 0
+fi
+echo "unexpected gh call: $*" >&2
+exit 1
+MOCKEOF
+
+  chmod +x "${mock_bin}/gh"
+
+  echo "${mock_bin}"
+}
+
+# run_test runs the eligibility script with mocked PR data and asserts exit code
+# and (optionally) annotation text.
+#   $1 — test name
+#   $2 — expected exit code
+#   $3 — is_bot value
+#   $4 — login value
+#   $5 — trigger source
+#   $6 — labels (optional, comma-separated)
+#   $7 — expected annotation substring (optional)
+run_test() {
+  local name="$1" expected_exit="$2" is_bot="$3" login="$4" trigger="$5" labels="${6:-}" expected_annotation="${7:-}"
+  local mock_bin
+  mock_bin=$(build_mock "${is_bot}" "${login}" "${labels}")
+
+  local actual_exit=0 output
+  output=$(PATH="${mock_bin}:${PATH}" \
+    TRIGGER_SOURCE="${trigger}" \
+    PR_NUM="123" \
+    SOURCE_REPO="org/repo" \
+    GH_TOKEN="fake" \
+    bash "${SCRIPT}" 2>&1) || actual_exit=$?
+
+  if [[ "${actual_exit}" -ne "${expected_exit}" ]]; then
+    echo "FAIL: ${name} — expected exit ${expected_exit}, got ${actual_exit}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if [[ -n "${expected_annotation}" ]] && [[ "${output}" != *"${expected_annotation}"* ]]; then
+    echo "FAIL: ${name} — expected annotation '${expected_annotation}' not found in output"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${name}"
+}
+
+echo "=== check-fix-eligibility tests ==="
+
+# Human trigger always proceeds (exit 0)
+run_test "human trigger skips gate" 0 "false" "some-user" "human-user"
+
+# Human trigger ignores fullsend-no-fix label (exit 0)
+run_test "human trigger ignores no-fix label" 0 "false" "some-user" "human-user" "fullsend-no-fix"
+
+# Human trigger ignores both labels (exit 0)
+run_test "human trigger ignores both labels" 0 "false" "some-user" "human-user" "fullsend-no-fix,fullsend-fix"
+
+# Coder bot PR auto-fixes (exit 0)
+run_test "coder bot auto-fixes" 0 "true" "app/fullsend-ai-coder" "review-bot[bot]"
+
+# Human-authored PR without label is skipped (exit 1)
+run_test "human PR without label skipped" 1 "false" "some-user" "review-bot[bot]" "" "lacks 'fullsend-fix' label"
+
+# Human-authored PR with fullsend-fix label proceeds (exit 0)
+run_test "human PR with label proceeds" 0 "false" "some-user" "review-bot[bot]" "fullsend-fix"
+
+# Other bot (renovate) without label is skipped (exit 1)
+run_test "renovate bot without label skipped" 1 "true" "app/renovate-fullsend" "review-bot[bot]" "" "lacks 'fullsend-fix' label"
+
+# Other bot (renovate) with label proceeds (exit 0)
+run_test "renovate bot with label proceeds" 0 "true" "app/renovate-fullsend" "review-bot[bot]" "fullsend-fix"
+
+# fullsend-no-fix label blocks even coder bot (exit 1)
+run_test "no-fix label blocks coder bot" 1 "true" "app/fullsend-ai-coder" "review-bot[bot]" "fullsend-no-fix" "has 'fullsend-no-fix' label"
+
+# fullsend-no-fix takes priority over fullsend-fix (exit 1)
+run_test "no-fix priority over fix label" 1 "true" "app/fullsend-ai-coder" "review-bot[bot]" "fullsend-no-fix,fullsend-fix" "has 'fullsend-no-fix' label"
+
+# null is_bot (old gh CLI) without label is skipped (exit 1)
+run_test "null is_bot without label skipped" 1 "null" "app/fullsend-ai-coder" "review-bot[bot]" "" "lacks 'fullsend-fix' label"
+
+# null is_bot (old gh CLI) with fullsend-fix label proceeds (exit 0)
+run_test "null is_bot with label proceeds" 0 "null" "app/fullsend-ai-coder" "review-bot[bot]" "fullsend-fix" "did not return is_bot field"
+
+# is_bot=false with coder login (login alone doesn't bypass label gate)
+run_test "false is_bot coder login without label skipped" 1 "false" "app/fullsend-ai-coder" "review-bot[bot]" "" "lacks 'fullsend-fix' label"
+
+# is_bot=false with coder login and label proceeds (exit 0)
+run_test "false is_bot coder login with label proceeds" 0 "false" "app/fullsend-ai-coder" "review-bot[bot]" "fullsend-fix"
+
+# gh pr view failure (network error / invalid token) emits ::error:: and exits 1
+run_test_gh_failure() {
+  local mock_bin="${TMPDIR}/bin-fail"
+  rm -rf "${mock_bin}"
+  mkdir -p "${mock_bin}"
+
+  cat > "${mock_bin}/gh" <<'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  echo "gh: Could not resolve to a PullRequest" >&2
+  exit 1
+fi
+echo "unexpected gh call: $*" >&2
+exit 1
+MOCKEOF
+  chmod +x "${mock_bin}/gh"
+
+  local actual_exit=0 output
+  output=$(PATH="${mock_bin}:${PATH}" \
+    TRIGGER_SOURCE="review-bot[bot]" \
+    PR_NUM="999" \
+    SOURCE_REPO="org/repo" \
+    GH_TOKEN="fake" \
+    bash "${SCRIPT}" 2>&1) || actual_exit=$?
+
+  if [[ "${actual_exit}" -ne 1 ]]; then
+    echo "FAIL: gh pr view failure — expected exit 1, got ${actual_exit}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if [[ "${output}" != *"::error::Failed to fetch PR info"* ]]; then
+    echo "FAIL: gh pr view failure — expected ::error:: annotation not found in output"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: gh pr view failure"
+}
+run_test_gh_failure
+
+echo ""
+if [[ "${FAILURES}" -gt 0 ]]; then
+  echo "${FAILURES} test(s) FAILED"
+  exit 1
+else
+  echo "All tests passed"
+fi

--- a/.github/scripts/check-fix-eligibility.sh
+++ b/.github/scripts/check-fix-eligibility.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# check-fix-eligibility.sh — Determine if a bot-triggered fix should auto-run.
+#
+# Inputs (env vars):
+#   GH_TOKEN       — GitHub token for API calls
+#   PR_NUM         — Pull request number
+#   SOURCE_REPO    — Repository in owner/repo format
+#   TRIGGER_SOURCE — Username that triggered the fix
+#
+# Exits 0 if fix should proceed, 1 if it should be skipped.
+# Emits GitHub Actions annotations (::warning::) for skip reasons.
+
+set -euo pipefail
+
+# Only gate bot-triggered runs; human /fs-fix always proceeds.
+if [[ ! "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
+  exit 0
+fi
+
+PR_INFO=$(gh pr view "${PR_NUM}" --repo "${SOURCE_REPO}" \
+  --json labels,author --jq '{labels: [.labels[].name], is_bot: .author.is_bot, login: .author.login}') \
+  || { echo "::error::Failed to fetch PR info for #${PR_NUM}"; exit 1; }
+
+HAS_NO_FIX=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-no-fix")')
+if [[ "${HAS_NO_FIX}" == "true" ]]; then
+  echo "::warning::PR #${PR_NUM} has 'fullsend-no-fix' label — skipping bot-triggered fix"
+  exit 1
+fi
+
+PR_IS_BOT=$(echo "${PR_INFO}" | jq -r '.is_bot')
+PR_LOGIN=$(echo "${PR_INFO}" | jq -r '.login')
+
+_sanitize_for_annotation() {
+  local val="$1"
+  val="${val//::/__}"
+  val="${val//$'\n'/}"
+  val="${val//$'\r'/}"
+  val="${val//%25/}"
+  val="${val//%0A/}"
+  val="${val//%0a/}"
+  val="${val//%0D/}"
+  val="${val//%0d/}"
+  printf '%s' "${val}"
+}
+
+PR_IS_BOT_SAFE=$(_sanitize_for_annotation "${PR_IS_BOT}")
+PR_LOGIN_SAFE=$(_sanitize_for_annotation "${PR_LOGIN}")
+
+if [[ "${PR_IS_BOT}" != "true" && "${PR_IS_BOT}" != "false" ]]; then
+  echo "::warning::gh pr view did not return is_bot field (got '${PR_IS_BOT_SAFE}') — gh CLI may be too old; treating as non-bot"
+fi
+
+# Not the fullsend coder bot — require the fullsend-fix label.
+# The app/ prefix is the gh pr view --json format; see docs/contributing/bot-identities.md.
+if [[ "${PR_IS_BOT}" != "true" || "${PR_LOGIN}" != "app/fullsend-ai-coder" ]]; then
+  HAS_FIX_LABEL=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-fix")')
+  if [[ "${HAS_FIX_LABEL}" != "true" ]]; then
+    echo "::warning::PR #${PR_NUM} (author: ${PR_LOGIN_SAFE}, is_bot: ${PR_IS_BOT_SAFE}) is not the coder bot and lacks 'fullsend-fix' label — skipping bot-triggered fix"
+    exit 1
+  fi
+fi

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -339,6 +339,11 @@ jobs:
           # agent bot via __typename + login so it can re-dispatch even when it
           # already has an open PR (#5974); other bots (e.g. Renovate) still
           # block. See docs/contributing/bot-identities.md for the login format.
+          # NOTE: bot identity is checked in three places — (1) this existing-PR
+          # guard (GraphQL __typename), (2) the fix eligibility script
+          # (.defaults/.github/scripts/check-fix-eligibility.sh — gh pr view
+          # is_bot/login), (3) org-scaffold dispatch.yml:226 (webhook [bot]$
+          # regex). See docs/contributing/bot-identities.md.
           OWNER="${SOURCE_REPO%%/*}"
           REPO_NAME="${SOURCE_REPO##*/}"
           GQL_ERR=$(mktemp)
@@ -1073,27 +1078,7 @@ jobs:
           TRIGGER_SOURCE: ${{ needs.route.outputs.trigger_source }}
           PR_NUM: ${{ steps.context.outputs.pr_number }}
           SOURCE_REPO: ${{ github.repository }}
-        run: |
-          if [[ "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
-            PR_INFO=$(gh pr view "${PR_NUM}" --repo "${SOURCE_REPO}" \
-              --json labels,author --jq '{labels: [.labels[].name], author: .author.login}') \
-              || { echo "::error::Failed to fetch PR info for #${PR_NUM}"; exit 1; }
-
-            HAS_NO_FIX=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-no-fix")')
-            if [[ "${HAS_NO_FIX}" == "true" ]]; then
-              echo "::warning::PR #${PR_NUM} has 'fullsend-no-fix' label — skipping bot-triggered fix"
-              exit 1
-            fi
-
-            PR_AUTHOR=$(echo "${PR_INFO}" | jq -r '.author')
-            if [[ ! "${PR_AUTHOR}" =~ \[bot\]$ ]]; then
-              HAS_FIX_LABEL=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-fix")')
-              if [[ "${HAS_FIX_LABEL}" != "true" ]]; then
-                echo "::warning::Human-authored PR #${PR_NUM} without 'fullsend-fix' label — skipping bot-triggered fix"
-                exit 1
-              fi
-            fi
-          fi
+        run: bash .defaults/.github/scripts/check-fix-eligibility.sh
 
       - name: Checkout target repository at PR HEAD
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -289,27 +289,7 @@ jobs:
           TRIGGER_SOURCE: ${{ inputs.trigger_source }}
           PR_NUM: ${{ steps.context.outputs.pr_number }}
           SOURCE_REPO: ${{ inputs.source_repo }}
-        run: |
-          if [[ "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
-            PR_INFO=$(gh pr view "${PR_NUM}" --repo "${SOURCE_REPO}" \
-              --json labels,author --jq '{labels: [.labels[].name], author: .author.login}') \
-              || { echo "::error::Failed to fetch PR info for #${PR_NUM}"; exit 1; }
-
-            HAS_NO_FIX=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-no-fix")')
-            if [[ "${HAS_NO_FIX}" == "true" ]]; then
-              echo "::warning::PR #${PR_NUM} has 'fullsend-no-fix' label — skipping bot-triggered fix"
-              exit 1
-            fi
-
-            PR_AUTHOR=$(echo "${PR_INFO}" | jq -r '.author')
-            if [[ ! "${PR_AUTHOR}" =~ \[bot\]$ ]]; then
-              HAS_FIX_LABEL=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-fix")')
-              if [[ "${HAS_FIX_LABEL}" != "true" ]]; then
-                echo "::warning::Human-authored PR #${PR_NUM} without 'fullsend-fix' label — skipping bot-triggered fix"
-                exit 1
-              fi
-            fi
-          fi
+        run: bash .defaults/.github/scripts/check-fix-eligibility.sh
 
       - name: Checkout target repository at PR HEAD
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ endef
 script-test:
 	$(call run-timed,bash scripts/check-e2e-authorization-test.sh)
 	$(call run-timed,bash .github/scripts/redact-behaviour-artifacts-test.sh)
+	$(call run-timed,bash .github/scripts/check-fix-eligibility-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh)
 	$(call run-timed,bash hack/gitlab-runner-vm/executor/prepare_validation_test.sh)

--- a/docs/agents/fix.md
+++ b/docs/agents/fix.md
@@ -119,9 +119,13 @@ direct control over what to fix:
 The fix agent also triggers automatically when the [review agent](review.md) submits a
 "changes requested" review on a same-repo PR (fork PRs are blocked).
 
-For **bot-authored PRs** (e.g., PRs opened by the code agent), automatic fixing
-happens with no extra setup — the fix agent responds to review feedback out of
-the box.
+For **PRs authored by the fullsend code agent** (`fullsend-ai-coder[bot]`),
+automatic fixing happens with no extra setup — the fix agent responds to review
+feedback out of the box. PRs from other bots (e.g., Renovate) require the
+`fullsend-fix` label; without it, the bot-triggered fix run is dispatched but
+the eligibility check exits early with a warning. See
+[Bot identities](../contributing/bot-identities.md) for how the eligibility
+script identifies the coder bot across different API surfaces.
 
 For **human-authored PRs**, the fix agent will not auto-fix review feedback
 unless you opt in by adding the `fullsend-fix` label. This prevents the agent
@@ -137,7 +141,7 @@ Remove the label or use `/fs-fix` to re-engage.
 
 | Label | Meaning |
 |-------|---------|
-| `fullsend-fix` | Enables automatic bot-triggered fix runs on human-authored PRs. Without this label, the fix agent only runs on human PRs when explicitly invoked via `/fs-fix`. Bot-authored PRs do not need this label. |
+| `fullsend-fix` | Enables automatic bot-triggered fix runs on human-authored PRs and PRs from bots other than the fullsend code agent. Without this label, the fix agent only runs when explicitly invoked via `/fs-fix`. PRs authored by `fullsend-ai-coder[bot]` are always eligible without this label. |
 | `fullsend-no-fix` | Prevents bot-triggered fix runs on this PR. Applied by `/fs-fix-stop`. Human `/fs-fix` commands are unaffected. Takes priority over `fullsend-fix`. |
 | `needs-human` | The fix agent is approaching its iteration cap and needs human direction. Applied automatically when a bot-triggered fix iteration reaches the warning threshold. |
 

--- a/docs/contributing/bot-identities.md
+++ b/docs/contributing/bot-identities.md
@@ -15,3 +15,5 @@ Fullsend agents authenticate as GitHub Apps; the table below also includes non-a
 When referencing bot identities in code (e.g., trusted actor lists, dispatch filters), always verify the login name against this table. Do not assume each agent role has a unique app identity — the fix agent reuses `fullsend-ai-coder[bot]`, not a separate `fullsend-ai-fix[bot]`.
 
 **REST vs. GraphQL login format:** the `[bot]` suffix above is the REST/App-slug form. GitHub's GraphQL API omits it — a bot author's `login` field comes back as `fullsend-ai-coder`, not `fullsend-ai-coder[bot]`, with `__typename: "Bot"`. Comparing a GraphQL-sourced login against a literal `"...[bot]"` string never matches (see #5575) — match on `__typename == "Bot"` plus the un-suffixed login instead.
+
+**`gh pr view --json` format:** the `gh pr view --json author` CLI command uses a different schema than raw GraphQL — it exposes `.author.is_bot` (boolean) and `.author.login` (with an `app/` prefix, e.g. `app/fullsend-ai-coder`), but does **not** expose `__typename`. When using `gh pr view --json`, check `.author.is_bot == true` plus `.author.login` against the `app/`-prefixed name (see #5536).

--- a/internal/scaffold/vendormanifest.go
+++ b/internal/scaffold/vendormanifest.go
@@ -152,6 +152,8 @@ var vendoredDefaultsInfraPaths = []string{
 	".github/actions/prepare-workspace/action.yml",
 	".github/actions/setup-gcp/action.yml",
 	".github/actions/validate-enrollment/action.yml",
+	".github/scripts/check-fix-eligibility-test.sh",
+	".github/scripts/check-fix-eligibility.sh",
 	".github/scripts/install-openshell.sh",
 	".github/scripts/install-podman.sh",
 	".github/scripts/openshell-version.sh",


### PR DESCRIPTION
## Summary

- Fix agent's eligibility check used `gh pr view --json author` (GraphQL), which returns `app/fullsend-ai-coder` — not the REST `fullsend-ai-coder[bot]` format. The `[bot]$` regex never matched, so bot-authored PRs were misidentified as human-authored and skipped.
- Switch to checking `.author.is_bot` (bool) and `.author.login` to precisely identify coder-bot PRs. This uses the fields actually exposed by `gh pr view --json`, following the same identity-check logic as the existing-PR guard (see #5974 and `docs/contributing/bot-identities.md`) adapted for the `gh pr view` API surface.
- Extract eligibility logic into shared script (`.github/scripts/check-fix-eligibility.sh`) with 15 fixture tests, called by both `reusable-fix.yml` and `reusable-dispatch.yml`.
- The third location named in #5536 (org-level scaffold `dispatch.yml` at `internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml:226-247`) has a fix eligibility gate that uses `PR_USER_LOGIN` from the webhook payload, which carries the REST `[bot]` suffix — so the `[bot]$` regex matches there correctly. No change needed.
- Scope: this fix covers the default hosted app-set (`fullsend-ai-coder`). Self-hosted `--app-set` deployments with custom app names remain in the same state as before (requiring the `fullsend-fix` label) — not a regression since the old `[bot]$` regex never matched any bot.

Closes #5536

## Test plan

- [x] Verify `gh pr view <bot-pr> --json author --jq '{is_bot: .author.is_bot, login: .author.login}'` returns `{"is_bot":true,"login":"app/fullsend-ai-coder"}` for a coder-bot-authored PR (verified via PR #6252)
- [x] Verify the same query returns `{"is_bot":false,...}` for a human-authored PR
- [ ] Confirm fix agent auto-executes on a bot-authored PR after review posts CHANGES_REQUESTED (no manual `/fs-fix` needed)
- [ ] Confirm fix agent still requires `fullsend-fix` label for human-authored PRs when bot-triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)