### PR TITLE
refactor(#5974): log matched PR numbers in dispatch existing-PR guard skip notice

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -331,14 +331,14 @@ jobs:
           SOURCE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Query issues for PRs that actually close them (Fixes/Closes/Resolves
+          # Query for PRs that actually close this issue (Fixes/Closes/Resolves
           # keywords), not a substring search over title/body — the latter
           # false-positives on any PR that merely references the issue (#5575).
           # closedByPullRequestsReferences also returns MERGED PRs regardless of
-          # includeClosedPrs, so filter on .state explicitly. GraphQL's Bot.login
-          # omits the REST "[bot]" suffix, so match on __typename == "Bot" rather
-          # than a literal "fullsend-ai-coder[bot]" string — see
-          # docs/contributing/bot-identities.md for the login.
+          # includeClosedPrs, so filter on .state explicitly. Exclude the code-
+          # agent bot via __typename + login so it can re-dispatch even when it
+          # already has an open PR (#5974); other bots (e.g. Renovate) still
+          # block. See docs/contributing/bot-identities.md for the login format.
           OWNER="${SOURCE_REPO%%/*}"
           REPO_NAME="${SOURCE_REPO##*/}"
           GQL_ERR=$(mktemp)
@@ -355,14 +355,14 @@ jobs:
             --jq '[.data.repository.issue.closedByPullRequestsReferences.nodes[]
                    | select(.state == "OPEN")
                    | select(.author.__typename != "Bot" or .author.login != "fullsend-ai-coder")]
-                   | .[].number' \
+                   | map("#\(.number)") | join(", ")' \
             2>"${GQL_ERR}"); then
             echo "::warning::Linked-PR query failed for issue #${ISSUE_NUMBER}: $(tr '\n' ' ' < "${GQL_ERR}" | sed 's/::/__/g')"
             LINKED_PRS=""
           fi
           rm -f "${GQL_ERR}"
           if [[ -n "${LINKED_PRS}" ]]; then
-            echo "::notice::Open PR(s) linked to close issue #${ISSUE_NUMBER} found — skipping code dispatch"
+            echo "::notice::Skipping code dispatch — issue #${ISSUE_NUMBER} has open PR(s) ${LINKED_PRS}"
             echo "skipped=true" >> "${GITHUB_OUTPUT}"
           fi
 

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -266,14 +266,14 @@ jobs:
           SOURCE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Query issues for PRs that actually close them (Fixes/Closes/Resolves
+          # Query for PRs that actually close this issue (Fixes/Closes/Resolves
           # keywords), not a substring search over title/body — the latter
           # false-positives on any PR that merely references the issue (#5575).
           # closedByPullRequestsReferences also returns MERGED PRs regardless of
-          # includeClosedPrs, so filter on .state explicitly. GraphQL's Bot.login
-          # omits the REST "[bot]" suffix, so match on __typename == "Bot" rather
-          # than a literal "fullsend-ai-coder[bot]" string — see
-          # docs/contributing/bot-identities.md for the login.
+          # includeClosedPrs, so filter on .state explicitly. Exclude the code-
+          # agent bot via __typename + login so it can re-dispatch even when it
+          # already has an open PR (#5974); other bots (e.g. Renovate) still
+          # block. See docs/contributing/bot-identities.md for the login format.
           #
           # NOTE (org/workflow_call mode): this job's token lacks `issues: read`
           # (neither this job nor the shim-workflow-call.yaml caller grants it),
@@ -298,14 +298,14 @@ jobs:
             --jq '[.data.repository.issue.closedByPullRequestsReferences.nodes[]
                    | select(.state == "OPEN")
                    | select(.author.__typename != "Bot" or .author.login != "fullsend-ai-coder")]
-                   | .[].number' \
+                   | map("#\(.number)") | join(", ")' \
             2>"${GQL_ERR}"); then
             echo "::warning::Linked-PR query failed for issue #${ISSUE_NUMBER}: $(tr '\n' ' ' < "${GQL_ERR}" | sed 's/::/__/g')"
             LINKED_PRS=""
           fi
           rm -f "${GQL_ERR}"
           if [[ -n "${LINKED_PRS}" ]]; then
-            echo "::notice::Open PR(s) linked to close issue #${ISSUE_NUMBER} found — skipping code dispatch"
+            echo "::notice::Skipping code dispatch — issue #${ISSUE_NUMBER} has open PR(s) ${LINKED_PRS}"
             echo "skipped=true" >> "${GITHUB_OUTPUT}"
           fi
 

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -690,6 +690,45 @@ func TestDispatchPRHeadResolution(t *testing.T) {
 	}
 }
 
+// TestDispatchPRCheckBotFilter validates that the existing-PR guard in both
+// dispatch workflows uses __typename + login for bot detection (not bare login
+// string comparison), and includes matched PR numbers in the skip notice (#5974).
+func TestDispatchPRCheckBotFilter(t *testing.T) {
+	type workflowCase struct {
+		name    string
+		content func(t *testing.T) []byte
+	}
+
+	cases := []workflowCase{
+		{
+			"reusable-dispatch.yml",
+			loadRepoFile(".github/workflows/reusable-dispatch.yml"),
+		},
+		{
+			"scaffold/dispatch.yml",
+			loadScaffoldFile(".github/workflows/dispatch.yml"),
+		},
+	}
+
+	for _, wc := range cases {
+		t.Run(wc.name, func(t *testing.T) {
+			s := string(wc.content(t))
+
+			assert.Contains(t, s, `author { login __typename }`,
+				"GraphQL query must request both login and __typename for bot detection")
+
+			assert.Contains(t, s, `select(.author.__typename != "Bot" or .author.login != "fullsend-ai-coder")`,
+				"bot filter must exclude only the code-agent bot via __typename + login — see docs/contributing/bot-identities.md")
+
+			assert.Contains(t, s, `map("#\(.number)") | join(", ")`,
+				"jq must format PR numbers as #N, #M — bare .[].number silently truncates multi-PR notices")
+
+			assert.Regexp(t, `::notice::.*\$\{LINKED_PRS\}`, s,
+				"skip notice must include the matched PR number(s)")
+		})
+	}
+}
+
 // TestActionPRHeadSHAInput validates that action.yml declares the pr-head-sha
 // input and uses it in both the fullsend run step and the reconcile step.
 func TestActionPRHeadSHAInput(t *testing.T) {


### PR DESCRIPTION
## Summary

- Include matched PR numbers in the dispatch existing-PR guard skip notice (e.g., `Skipping code dispatch for issue #123: found open PR(s) #456, #789`) so silent dispatch skips are debuggable.
- Update guard comments to clarify `__typename + login` filter intent: only the code-agent bot is excluded so it can re-dispatch; other bots (e.g. Renovate) still block.
- Add `TestDispatchPRCheckBotFilter` alignment test to prevent regression on both `reusable-dispatch.yml` and the scaffold template.

Note: Issue #5974 lists three items. Items 1 (structured reference pattern via `closedByPullRequestsReferences`) and 3 (bot-author filter via `__typename + login`) were already resolved on main prior to this PR — item 1 by commit 9f9a9cae (#5575, 2026-07-24) and item 3 by the same commit's GraphQL migration. The ggallen comment on #5974 reporting a broken bot filter ("Open PR(s) mentioning issue #6246 found") used the old "mentioning" wording removed in that commit, indicating the evidence came from a stale, unsynced per-org `dispatch.yml` copy (the drift tracked by #6013), not the current GraphQL-based code on main. This PR addresses item 2 (log matched PR numbers) and adds a regression test covering item 3.

Closes #5974

## Test plan

- [x] `TestDispatchPRCheckBotFilter` passes for both `reusable-dispatch.yml` and `scaffold/dispatch.yml`
- [x] All `internal/scaffold/` tests pass
- [x] Codecov: all modified and coverable lines are covered
- [ ] Verify in a live dispatch run that the skip notice includes matched PR numbers — requires per-org resync (#6013) for orgs still on the standalone `dispatch.yml` copy; per-repo mode picks up the change immediately via `reusable-dispatch.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)