### PR TITLE
fix(#6178): bump actions/cache to v6.1.0, add actions:write to harness-dispatch

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1371,6 +1371,7 @@ jobs:
     name: Harness dispatch
     runs-on: ${{ inputs.runner_image }}
     permissions:
+      actions: write
       contents: read
       pull-requests: read
     outputs:
@@ -1433,7 +1434,7 @@ jobs:
       - name: Restore fullsend CLI cache
         if: steps.triggers.outputs.has_triggers == 'true'
         id: cli-cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/fullsend-cache
           key: fullsend-cli-${{ steps.mode.outputs.mode }}-${{ job.workflow_sha }}
@@ -1488,7 +1489,7 @@ jobs:
 
       - name: Save fullsend CLI cache
         if: steps.triggers.outputs.has_triggers == 'true' && steps.cli-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/fullsend-cache
           key: fullsend-cli-${{ steps.mode.outputs.mode }}-${{ job.workflow_sha }}


### PR DESCRIPTION
## Summary
- Bump `actions/cache/restore` and `actions/cache/save` from v4.3.0 to v6.1.0 in the `harness-dispatch` job, removing the Node.js 20 deprecation warning.
- Add `actions: write` permission to `harness-dispatch` so the GitHub Actions cache API can save entries (fixes "cache write denied: token has no writable scopes").

Fixes #6178

🤖 Generated with [Claude Code](https://claude.com/claude-code)