### PR TITLE
docs(#6280): remove stale mint enrollment block from getting started

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,7 +6,6 @@ Practical how-to documentation for fullsend, organized by audience. For design d
 
 Guides for onboarding organizations and configuring GitHub — the first thing most users need.
 
-- [Mint enrollment](getting-started/README.md) — Enroll your org or repo in a token mint before configuring anything else
 - [Getting Inference](getting-started/getting-inference.md) — Provision GCP inference access for your org or repo
 - [Configuring GitHub](getting-started/configuring-github.md) — Install GitHub Apps and run the setup CLI
 - [Organization Mode](getting-started/org-mode.md) — _(deprecated — see [per-repo Getting Started](getting-started/configuring-github.md))_ Org-wide setup with a shared `.fullsend` config repo

--- a/docs/guides/getting-started/README.md
+++ b/docs/guides/getting-started/README.md
@@ -7,20 +7,6 @@ sidebar_position: 1
 This section contains easy and to the point guides to help you
 set up Fullsend. These are intended to be read in a certain order:
 
-1. **Mint enrollment** — before configuring anything, your org or repo
-   must be enrolled in a fullsend token mint service so the mint
-   accepts token requests from your GitHub Actions workflows.
-   The CLI defaults to the hosted mint. To enroll, contact the
-   fullsend team in the internal Slack channel with your GitHub org
-   name (for org mode) or `owner/repo` (for per-repo mode). To deploy
-   and manage your own mint instead, see the
-   [Mint administration](../infrastructure/mint-administration.md) guide.
-
-   > **Note:** Self-service enrollment is not yet available.
-   > [Public mint mode](https://github.com/fullsend-ai/fullsend/pull/1580)
-   > will remove the need for per-org/repo enrollment, but is still
-   > in progress.
-
-2. [Getting Inference](getting-inference.md)
-3. [Configuring GitHub](configuring-github.md)
-4. [Organization Mode](org-mode.md)
+1. [Getting Inference](getting-inference.md)
+2. [Configuring GitHub](configuring-github.md)
+3. [Organization Mode](org-mode.md)

--- a/docs/guides/getting-started/configuring-github.md
+++ b/docs/guides/getting-started/configuring-github.md
@@ -8,7 +8,6 @@ The goal of this document is that you configure Fullsend for your GitHub reposit
 
 ## Prerequisites
 
-* Your org or repo is enrolled in a fullsend token mint service (see [Getting Started](README.md) step 1).
 * You have your WIF provider URL from [Getting Inference](getting-inference.md).
 * Download the latest [fullsend](https://github.com/fullsend-ai/fullsend/releases) CLI.
 * Download the latest [gh](https://cli.github.com/) CLI and authenticate with it.

--- a/docs/guides/getting-started/operations.md
+++ b/docs/guides/getting-started/operations.md
@@ -69,7 +69,7 @@ To remove fullsend from a single repository:
 
 1. Delete `.github/workflows/fullsend.yaml` and repo-level secrets/variables
 2. Run `fullsend inference deprovision "$OWNER/$REPO"` to remove WIF access
-3. Contact the fullsend team to unenroll the repo from the hosted mint
+3. If you use a self-hosted mint, run `fullsend mint unenroll "$OWNER/$REPO"` to remove the repo from the mint. See the [standalone commands](#standalone-commands) table for details. The public hosted mint requires no unenrollment.
 
 **GitLab repos:**
 
@@ -77,8 +77,6 @@ To remove fullsend from a single repository:
 2. Delete all CI/CD variables prefixed with `FULLSEND_`
 3. Revoke the `fullsend-bot` project access token (Settings → Access Tokens)
 4. Delete fullsend pipeline schedules (`fullsend slash poll` and `fullsend event poll`)
-
-If you manage your own self-hosted mint, run `fullsend mint unenroll "$OWNER/$REPO"` instead of GitHub step 3. See the [standalone commands](#standalone-commands) table for details.
 
 ## Standalone commands
 

--- a/docs/guides/getting-started/repo-management.md
+++ b/docs/guides/getting-started/repo-management.md
@@ -19,7 +19,7 @@ fullsend across an organization. Individual repo owners should use
 - **fullsend CLI** installed (see [releases](https://github.com/fullsend-ai/fullsend/releases))
 - **GitHub access** — admin or write access to the target repositories
 - **`gh` CLI** authenticated with the required OAuth scopes (see [OAuth scope reference](../infrastructure/advanced-setup.md#oauth-scope-reference))
-- **GCP prerequisites** — GCP WIF provisioning (`fullsend inference provision`) and mint enrollment (`fullsend mint enroll`, GitHub only) must be completed separately before running `repos install`. When multiple repos share the same GCP project, existing inference secrets are reused automatically. See [Mint administration](../infrastructure/mint-administration.md) and [Advanced setup](../infrastructure/advanced-setup.md).
+- **GCP prerequisites** — GCP WIF provisioning (`fullsend inference provision`) must be completed separately before running `repos install`. When multiple repos share the same GCP project, existing inference secrets are reused automatically. If you use a private or self-hosted mint, mint enrollment (`fullsend mint enroll`) is also required before install. See [Mint administration](../infrastructure/mint-administration.md) and [Advanced setup](../infrastructure/advanced-setup.md).
 
 ## Getting started
 
@@ -139,9 +139,10 @@ Install runs in three phases:
    drift (synced automatically) and scaffold ref drift (upgraded
    automatically).
 
-> **Prerequisite:** GCP infrastructure (WIF pools/providers, mint
-> enrollment) must be provisioned separately before running install.
-> See `fullsend inference provision` and `fullsend mint enroll`.
+> **Prerequisite:** GCP infrastructure (WIF pools/providers) must be
+> provisioned separately before running install.
+> See `fullsend inference provision`. If you use a private or
+> self-hosted mint, also run `fullsend mint enroll` first.
 
 > **Note:** When your token does not have direct push access to a target
 > repository, the install command creates a fork and submits the scaffold


### PR DESCRIPTION
## Summary

- Remove the "Mint enrollment" step from the getting started guide — the hosted mint is now public (`mint.fullsend.sh`) and requires no per-org/repo enrollment
- Remove the corresponding entry from the guides index (`docs/guides/README.md`)
- Remove the mint enrollment prerequisite from `configuring-github.md`

Closes #6280
Related: #3013

🤖 Generated with [Claude Code](https://claude.com/claude-code)