### PR TITLE
feat(dispatch): route /fs-plan-tests to the qualityflow stage

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -1,5 +1,5 @@
 ---
-# lint-workflow-size: max-lines=610
+# lint-workflow-size: max-lines=625
 # Dispatcher workflow that routes events to agent workflows based on stage.
 # Routing logic determines the stage from event context — the shim only
 # forwards the raw event.  Adding a new stage requires only a case branch
@@ -161,6 +161,15 @@ jobs:
                 /fs-prioritize)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     STAGE="prioritize"
+                  fi
+                  ;;
+                /fs-plan-tests)
+                  # QualityFlow custom agent. Mirrors its harness CEL trigger
+                  # (change_proposal, non-fork); fork gate is in "Resolve PR
+                  # head" below. Interim until CEL dispatch is primary (#2902).
+                  if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized \
+                    && [[ "${ISSUE_HAS_PR}" == "true" ]]; then
+                    STAGE="qualityflow"
                   fi
                   ;;
                 *)
@@ -423,7 +432,9 @@ jobs:
           set -euo pipefail
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
-            code|fix) STAGE_ROLE="coder" ;;
+            # qualityflow declares "role: coder" in its harness — it commits
+            # generated tests to the PR branch, same trust level as code/fix.
+            code|fix|qualityflow) STAGE_ROLE="coder" ;;
           esac
 
           ROLES=$(yq '.defaults.roles[]' config.yaml 2>/dev/null || echo "")
@@ -477,18 +488,19 @@ jobs:
             --jq '{number, html_url,
               head: {ref: .head.ref, sha: .head.sha, repo: {full_name: .head.repo.full_name}},
               base: {ref: .base.ref, repo: {full_name: .base.repo.full_name}}}') || {
-            if [[ "${STAGE}" =~ ^(fix|review)$ ]]; then
+            if [[ "${STAGE}" =~ ^(fix|review|qualityflow)$ ]]; then
               echo "::error::Failed to fetch PR #${PR_NUMBER} head info"
               exit 1
             fi
             echo "::warning::Failed to fetch PR #${PR_NUMBER} head info — continuing without PR context"
             exit 0
           }
-          if [[ "${STAGE}" == "fix" ]]; then
+          # Mutating agents that push to the PR branch must not run on forks.
+          if [[ "${STAGE}" =~ ^(fix|qualityflow)$ ]]; then
             HEAD_REPO=$(printf '%s' "${PR_JSON}" | jq -r '.head.repo.full_name')
             BASE_REPO=$(printf '%s' "${PR_JSON}" | jq -r '.base.repo.full_name')
             if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
-              echo "::error::Fork PR detected (head=${HEAD_REPO}, base=${BASE_REPO}) — fix agent blocked"
+              echo "::error::Fork PR detected (head=${HEAD_REPO}, base=${BASE_REPO}) — ${STAGE} agent blocked"
               exit 1
             fi
           fi


### PR DESCRIPTION
## Problem

A custom agent registered via `config.yaml` `agents[]` cannot be triggered by comment in **per-org** mode.

Concretely, `/fs-plan-tests` on #6010 fired [run 32015419992](https://github.com/fullsend-ai/fullsend/actions/runs/32015419992) and the dispatch job logged:

```
EVENT_NAME: issue_comment
COMMENT_BODY: /fs-plan-tests
COMMENT_AUTHOR_ASSOC: MEMBER
...
No stage matched — skipping dispatch
```

Two reasons it routes nowhere:

1. The bash router here only knows the built-in commands; it never reads `config.yaml` `agents[]` (and cannot — routing runs before the config repo is checked out).
2. The harness CEL path (`reusable-dispatch.yml` → `harness-dispatch`) runs `fullsend dispatch --config-dir .fullsend` against the **caller** repo. Per-org enrolled repos have no `.fullsend/` directory, so CEL triggers never evaluate. QualityFlow's trigger is registered in fullsend-ai/.fullsend#93 and is correct — nothing consumes it yet.

## Change

This adds the case branch that this file documents as the way to add a stage:

- `/fs-plan-tests` → `STAGE=qualityflow`, gated PR-only + write+ + non-Bot, mirroring the harness CEL trigger (`has(change_proposal) && !is_fork`)
- `qualityflow` → `coder` role, which its harness declares (`role: coder`)
- fork gate extended to `qualityflow`, since the agent commits generated tests to the PR branch (same exposure as `fix`), and a failed PR-context fetch is fatal rather than a warning
- `max-lines` 610 → 625, the documented path for a justified increase

The companion stage workflow lives in `.fullsend` (org-local, like `scribe.yml`) and is discovered via its `# fullsend-stage: qualityflow` marker.

Interim by design: #2902 removes the bash routing this branch lives in, and this case goes with it.

## Verification

Extracted the real "Determine stage" script from the workflow and ran it against a stubbed `gh` (permission API), asserting the routed stage:

| case | expected | result |
|---|---|---|
| `/fs-plan-tests` on PR, write+ member | `qualityflow` | ✅ |
| `/fs-plan-tests PROJ-123` (trailing arg) | `qualityflow` | ✅ |
| `/fs-plan-tests` on an issue (no PR) | *(none)* | ✅ |
| `/fs-plan-tests` from a Bot | *(none)* | ✅ |
| `/fs-plan-tests` from read-only user | *(none)* | ✅ |
| `/fs-plan-tests` from triage-only user | *(none)* | ✅ |
| `/fs-review`, `/fs-code`, `/fs-triage` | unchanged | ✅ |
| unknown `/fs-bogus` | *(none)* | ✅ |

10/10, and the same 10 pass against the currently-deployed copy in `.fullsend` with the same patch applied. Happy to port these into the behaviour-test harness (#2891–#2895) if you'd prefer them in-repo.