### PR TITLE
fix(#5448): merge validation_loop at field level during composition

### DIFF
--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -630,14 +630,11 @@ func mergeBaseIntoChild(base, child *Harness) {
 		child.Env.mergeEnvFrom(base.Env, false)
 	}
 
-	// Pointer structs: child replaces if non-nil, but carry forward
-	// PreflightCheck when the child overrides validation_loop without
-	// setting its own preflight_check (avoids silently dropping inherited
-	// preflight checks — see #5074).
+	// Pointer structs: validation_loop merges at field level (child fields win, base fills gaps).
 	if child.ValidationLoop == nil {
 		child.ValidationLoop = base.ValidationLoop
-	} else if child.ValidationLoop.PreflightCheck == "" && base.ValidationLoop != nil {
-		child.ValidationLoop.PreflightCheck = base.ValidationLoop.PreflightCheck
+	} else if base.ValidationLoop != nil {
+		mergeValidationLoopInto(base.ValidationLoop, child.ValidationLoop)
 	}
 	// Security: child inherits base's config if nil. Note that a base harness
 	// (even integrity-pinned) could set fail_mode: open. Child authors must
@@ -1935,6 +1932,29 @@ func mergeForgeBlocks(base, child map[string]*ForgeConfig) map[string]*ForgeConf
 	return child
 }
 
+// mergeValidationLoopInto merges base ValidationLoop fields into child.
+// Child fields take precedence; base fields fill any unset/zero values.
+func mergeValidationLoopInto(base, child *ValidationLoop) {
+	if base == nil || child == nil {
+		return
+	}
+	if child.Script == "" {
+		child.Script = base.Script
+	}
+	if child.Schema == "" {
+		child.Schema = base.Schema
+	}
+	if child.MaxIterations == 0 {
+		child.MaxIterations = base.MaxIterations
+	}
+	if child.FeedbackMode == "" {
+		child.FeedbackMode = base.FeedbackMode
+	}
+	if child.PreflightCheck == "" {
+		child.PreflightCheck = base.PreflightCheck
+	}
+}
+
 // mergeForgeConfigInto merges base ForgeConfig fields into child.
 // Similar to mergeForgeConfig in forge.go but prepends base skills and host files
 // (base + child order) rather than appending forge values to harness values.
@@ -2003,13 +2023,11 @@ func mergeForgeConfigInto(base, child *ForgeConfig) {
 		child.Env.mergeEnvFrom(base.Env, false)
 	}
 
-	// ValidationLoop: child replaces if non-nil, but carry forward
-	// PreflightCheck when the child overrides validation_loop without
-	// setting its own preflight_check (see #5074).
+	// ValidationLoop: validation_loop merges at field level (child fields win, base fills gaps).
 	if child.ValidationLoop == nil {
 		child.ValidationLoop = base.ValidationLoop
-	} else if child.ValidationLoop.PreflightCheck == "" && base.ValidationLoop != nil {
-		child.ValidationLoop.PreflightCheck = base.ValidationLoop.PreflightCheck
+	} else if base.ValidationLoop != nil {
+		mergeValidationLoopInto(base.ValidationLoop, child.ValidationLoop)
 	}
 }
 

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -1260,6 +1260,32 @@ func TestMergeForgeConfigInto_PreflightCheckCarryForward(t *testing.T) {
 		"PreflightCheck should be carried forward from base in forge merge")
 }
 
+func TestMergeForgeConfigInto_ValidationLoopFieldLevelMerge(t *testing.T) {
+	base := &ForgeConfig{
+		ValidationLoop: &ValidationLoop{
+			Script:         "scripts/base-validate.sh",
+			Schema:         "schemas/base.json",
+			MaxIterations:  4,
+			FeedbackMode:   "replace",
+			PreflightCheck: "python3 -c 'import jsonschema'",
+		},
+	}
+	child := &ForgeConfig{
+		ValidationLoop: &ValidationLoop{
+			Schema: "schemas/custom.json",
+		},
+	}
+
+	mergeForgeConfigInto(base, child)
+
+	require.NotNil(t, child.ValidationLoop)
+	assert.Equal(t, "scripts/base-validate.sh", child.ValidationLoop.Script)
+	assert.Equal(t, "schemas/custom.json", child.ValidationLoop.Schema)
+	assert.Equal(t, 4, child.ValidationLoop.MaxIterations)
+	assert.Equal(t, "replace", child.ValidationLoop.FeedbackMode)
+	assert.Equal(t, "python3 -c 'import jsonschema'", child.ValidationLoop.PreflightCheck)
+}
+
 func TestMergeForgeConfigInto_PolicyInherited(t *testing.T) {
 	base := &ForgeConfig{
 		Policy:    "policies/base-gitlab.yaml",
@@ -4725,6 +4751,62 @@ func TestMergeBaseIntoChild_EffortEmptyBaseNoEffect(t *testing.T) {
 	mergeBaseIntoChild(base, child)
 
 	assert.Equal(t, "max", child.Effort)
+}
+
+func TestMergeBaseIntoChild_ValidationLoopFieldLevelMerge(t *testing.T) {
+	base := &Harness{
+		ValidationLoop: &ValidationLoop{
+			Script:         "scripts/validate.sh",
+			Schema:         "schemas/base.json",
+			MaxIterations:  3,
+			FeedbackMode:   "append",
+			PreflightCheck: "python3 -c 'import jsonschema'",
+		},
+	}
+	child := &Harness{
+		ValidationLoop: &ValidationLoop{
+			Schema: "schemas/custom.json",
+		},
+	}
+
+	mergeBaseIntoChild(base, child)
+
+	require.NotNil(t, child.ValidationLoop)
+	assert.Equal(t, "scripts/validate.sh", child.ValidationLoop.Script)
+	assert.Equal(t, "schemas/custom.json", child.ValidationLoop.Schema)
+	assert.Equal(t, 3, child.ValidationLoop.MaxIterations)
+	assert.Equal(t, "append", child.ValidationLoop.FeedbackMode)
+	assert.Equal(t, "python3 -c 'import jsonschema'", child.ValidationLoop.PreflightCheck)
+}
+
+func TestMergeBaseIntoChild_ValidationLoopChildWinsOnConflict(t *testing.T) {
+	base := &Harness{
+		ValidationLoop: &ValidationLoop{
+			Script:         "scripts/base-validate.sh",
+			Schema:         "schemas/base.json",
+			MaxIterations:  3,
+			FeedbackMode:   "append",
+			PreflightCheck: "base-check",
+		},
+	}
+	child := &Harness{
+		ValidationLoop: &ValidationLoop{
+			Script:         "scripts/child-validate.sh",
+			Schema:         "schemas/child.json",
+			MaxIterations:  1,
+			FeedbackMode:   "replace",
+			PreflightCheck: "child-check",
+		},
+	}
+
+	mergeBaseIntoChild(base, child)
+
+	require.NotNil(t, child.ValidationLoop)
+	assert.Equal(t, "scripts/child-validate.sh", child.ValidationLoop.Script)
+	assert.Equal(t, "schemas/child.json", child.ValidationLoop.Schema)
+	assert.Equal(t, 1, child.ValidationLoop.MaxIterations)
+	assert.Equal(t, "replace", child.ValidationLoop.FeedbackMode)
+	assert.Equal(t, "child-check", child.ValidationLoop.PreflightCheck)
 }
 
 func TestFetchBaseSkill_FullDirectory(t *testing.T) {

--- a/internal/harness/forge.go
+++ b/internal/harness/forge.go
@@ -154,7 +154,7 @@ func (h *Harness) ResolveForge(platform string) error {
 //   - OpenShell.Profiles: top-level + forge (concatenated)
 //   - HostFiles: top-level + forge (concatenated with last-writer-wins dedup by Dest)
 //   - RunnerEnv: top-level merged with forge; forge keys win
-//   - ValidationLoop: forge replaces entirely if non-nil
+//   - ValidationLoop: top-level merged with forge; forge fields win
 func mergeForgeConfig(h *Harness, fc *ForgeConfig) {
 	if fc.PreScript != "" {
 		h.PreScript = fc.PreScript
@@ -201,7 +201,13 @@ func mergeForgeConfig(h *Harness, fc *ForgeConfig) {
 	}
 
 	if fc.ValidationLoop != nil {
-		h.ValidationLoop = fc.ValidationLoop
+		if h.ValidationLoop == nil {
+			h.ValidationLoop = fc.ValidationLoop
+		} else {
+			merged := *fc.ValidationLoop
+			mergeValidationLoopInto(h.ValidationLoop, &merged)
+			h.ValidationLoop = &merged
+		}
 	}
 
 	// Env: merge sub-maps independently; forge keys win (ADR 0055)

--- a/internal/harness/forge_test.go
+++ b/internal/harness/forge_test.go
@@ -206,6 +206,60 @@ func TestResolveForge_ValidationLoopReplace(t *testing.T) {
 	assert.Equal(t, 1, h.ValidationLoop.MaxIterations)
 }
 
+func TestResolveForge_ValidationLoopFieldLevelMerge(t *testing.T) {
+	h := &Harness{
+		Agent: "agents/test.md",
+		ValidationLoop: &ValidationLoop{
+			Script:         "scripts/validate-common.sh",
+			Schema:         "schemas/base.json",
+			MaxIterations:  3,
+			FeedbackMode:   "append",
+			PreflightCheck: "python3 -c 'import jsonschema'",
+		},
+		Forge: map[string]*ForgeConfig{
+			"github": {
+				ValidationLoop: &ValidationLoop{
+					Schema: "schemas/custom.json",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, h.ResolveForge("github"))
+	require.NotNil(t, h.ValidationLoop)
+	assert.Equal(t, "scripts/validate-common.sh", h.ValidationLoop.Script)
+	assert.Equal(t, "schemas/custom.json", h.ValidationLoop.Schema)
+	assert.Equal(t, 3, h.ValidationLoop.MaxIterations)
+	assert.Equal(t, "append", h.ValidationLoop.FeedbackMode)
+	assert.Equal(t, "python3 -c 'import jsonschema'", h.ValidationLoop.PreflightCheck)
+}
+
+func TestResolveForge_ValidationLoopMergeDoesNotMutateForgeConfig(t *testing.T) {
+	fcLoop := &ValidationLoop{
+		Schema: "schemas/custom.json",
+	}
+	fc := &ForgeConfig{
+		ValidationLoop: fcLoop,
+	}
+	h := &Harness{
+		Agent: "agents/test.md",
+		ValidationLoop: &ValidationLoop{
+			Script:        "scripts/validate.sh",
+			MaxIterations: 2,
+		},
+	}
+
+	mergeForgeConfig(h, fc)
+
+	require.NotNil(t, h.ValidationLoop)
+	assert.Equal(t, "scripts/validate.sh", h.ValidationLoop.Script)
+	assert.Equal(t, "schemas/custom.json", h.ValidationLoop.Schema)
+	assert.Equal(t, 2, h.ValidationLoop.MaxIterations)
+	// Verify fc.ValidationLoop was not mutated
+	assert.Equal(t, "", fcLoop.Script)
+	assert.Equal(t, 0, fcLoop.MaxIterations)
+}
+
 func TestResolveForge_ValidationLoopNilInherits(t *testing.T) {
 	h := &Harness{
 		Agent: "agents/test.md",


### PR DESCRIPTION
### Description
When a child harness inherits from a base harness that defines `validation_loop` and the child only overrides specific fields (such as `validation_loop.schema` to provide a custom validation schema), `mergeBaseIntoChild`, `mergeForgeConfigInto`, and `mergeForgeConfig` previously treated `ValidationLoop` as a whole-struct replacement (only carrying forward `PreflightCheck`). As a result, the base's `script`, `max_iterations`, and `feedback_mode` were silently discarded, causing subsequent validation errors:
`validation_loop.script is required when validation_loop is set`

### Solution
- Implement `mergeValidationLoopInto` to perform field-level merge for `ValidationLoop` across all composition paths (`mergeBaseIntoChild`, `mergeForgeConfigInto`, and `mergeForgeConfig`).
- Ensure child/override values take precedence while preserving base-defined fields for omitted keys.
- Add unit tests across `compose_test.go` and `forge_test.go` verifying field-level merge, conflict resolution, and immutability of source configs.

### Related Issue
Fixes #5448
