### PR TITLE
fix: gitignore outputs/ so custom-agent artifacts don't land in PR history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docs/.vitepress/cache/
 docs/.vitepress/.temp/
 docs/.vitepress/dist/
 coverage.out
+outputs/

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,9 @@ docs/.vitepress/cache/
 docs/.vitepress/.temp/
 docs/.vitepress/dist/
 coverage.out
-outputs/
+# QualityFlow intermediates (STP/STD/reviews). outputs/<id>/{go,python}-tests/
+# is the agent's documented fallback for the generated tests themselves and
+# stays committable so a fallback-mode run fails visibly in CI, not silently.
+**/outputs/*/stp/
+**/outputs/*/std/
+**/outputs/*/reviews/


### PR DESCRIPTION
### Problem

QualityFlow (BYOA custom agent) writes its pipeline artifacts to `outputs/<id>/` in the target repo and then commits and pushes to the PR branch. Its own [integration docs](https://github.com/redhat-community-ai-tools/qualityflow-fullsend/blob/main/docs/fullsend-integration.md) call `outputs/` "intermediate, can be cleaned", but nothing stopped it from being committed: [PR #6290](https://github.com/fullsend-ai/fullsend/pull/6290) picked up three commits under `outputs/6290/{stp,std,reviews}/` (flagged by @rh-hemartin).

### Fix

Ignore `outputs/` wholesale. It is QualityFlow's working directory (STP/STD drafts, reviews, pipeline state, test drafts, LSP pattern files), and nothing under it belongs in a commit.

Generated tests are integrated into the repo's existing test suite instead of being committed from `outputs/`: redhat-community-ai-tools/qualityflow#101 and redhat-community-ai-tools/qualityflow-fullsend#3. `.gitignore` is advisory; those changes are what stop the agent from staging `outputs/`.

No `outputs/` path is tracked anywhere in the repo, so nothing already committed is affected.
