### PR TITLE
fix(mint): return 403 for undeclared role instead of 502

### DIFF
--- a/internal/mintcore/handler.go
+++ b/internal/mintcore/handler.go
@@ -515,6 +515,21 @@ func (h *Handler) handleStatus(w http.ResponseWriter, claims *Claims) {
 }
 
 func (h *Handler) mintToken(ctx context.Context, org, role string, repos []string) (string, string, *GrantedScope, error) {
+	// Fail closed for an undeclared/unknown role. A role with no permission
+	// definition is a client authorization error, not an upstream failure.
+	// Reject it deterministically with 403 before making any GitHub API
+	// calls; otherwise the missing definition only surfaces deep inside
+	// CreateInstallationToken, whose errors are uniformly mapped to 502,
+	// turning a clean authorization denial into an opaque Bad Gateway.
+	if RolePermissionsFor(role) == nil {
+		umsg := fmt.Sprintf("role %q is not declared in .fullsend/config.yaml roles", role)
+		return "", "", nil, &mintError{
+			status:  http.StatusForbidden,
+			msg:     fmt.Sprintf("undeclared role %q: no permissions defined", role),
+			userMsg: umsg,
+		}
+	}
+
 	appID, err := h.lookupRoleAppID(role)
 	if err != nil {
 		return "", "", nil, &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("looking up app ID for role %s: %v", role, err)}

--- a/internal/mintcore/handler_test.go
+++ b/internal/mintcore/handler_test.go
@@ -591,6 +591,31 @@ func TestHandler_RoleNotAllowed(t *testing.T) {
 	}
 }
 
+// TestHandler_MintToken_UndeclaredRole verifies that requesting a token for a
+// role with no permission definition (undeclared in .fullsend/config.yaml
+// roles) is rejected with a clean 403 and a descriptive, client-safe message
+// before any GitHub API call — rather than surfacing as an opaque 502 from
+// CreateInstallationToken.
+func TestHandler_MintToken_UndeclaredRole(t *testing.T) {
+	t.Setenv("ROLE_APP_IDS", `{"coder":"200"}`)
+	h := mustNewHandler(t, &fakePEMAccessor{}, &fakeOIDCVerifier{})
+
+	_, _, _, err := h.mintToken(context.Background(), "test-org", "nonexistent", []string{"repo"})
+	if err == nil {
+		t.Fatal("expected error for undeclared role, got nil")
+	}
+	me, ok := err.(*mintError)
+	if !ok {
+		t.Fatalf("expected *mintError, got %T: %v", err, err)
+	}
+	if me.status != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", me.status)
+	}
+	if !strings.Contains(me.userMsg, "nonexistent") || !strings.Contains(me.userMsg, "config.yaml") {
+		t.Fatalf("expected descriptive client-safe userMsg, got %q", me.userMsg)
+	}
+}
+
 func TestHandler_InvalidRepoName(t *testing.T) {
 	t.Setenv("ALLOWED_ROLES", "coder")
 	t.Setenv("ROLE_APP_IDS", `{"coder":"200"}`)


### PR DESCRIPTION
## Problem

The token-mint service returns **HTTP 502 (Bad Gateway)** instead of a clean **HTTP 403 (Forbidden)** when a repo requests a token for a role that is **not declared** in that repo's `.fullsend/config.yaml` `roles:` list. The backend errors on the undeclared-role path rather than rejecting it deterministically.

## Evidence

- Mint endpoint: `POST /v1/token`.
- Service is healthy: unauthenticated `GET /` and `GET /v1/token` return a clean `405 Method Not Allowed`.
- An authenticated `POST /v1/token` with `role="coder"` for a repo whose config has `roles: []` (i.e. `coder` not declared) returns `502` on every attempt (initial + retries), never a clean 4xx.
- Expected: an undeclared/unauthorized role should yield a deterministic `403` with a descriptive JSON error body, e.g. `{"error":"role \"coder\" is not declared in .fullsend/config.yaml roles"}`.

## Root cause

`Handler.mintToken` (`internal/mintcore/handler.go`) makes GitHub API calls and then hands any `CreateInstallationToken` error to the response boundary as `http.StatusBadGateway`:

```go
token, expiresAt, granted, err := CreateInstallationToken(ctx, ...)
if err != nil {
    return "", "", nil, &mintError{status: http.StatusBadGateway, msg: err.Error()}
}
```

A role with no permission definition is only detected deep inside `CreateInstallationToken`, which returns `no permissions defined for role %q`. Because that error is mapped uniformly to `502`, an undeclared/unauthorized role — a **client authorization error** — is reported as an upstream **gateway failure**. The same class of error also risks surfacing as a 502 via the intervening `FindInstallation` / installation-token calls before it is ever classified.

## The fix

Fail closed at the top of `mintToken`, before any GitHub API call: if the requested role has no permission definition (`RolePermissionsFor(role) == nil`), return a deterministic `403` carrying a descriptive, client-safe `userMsg`:

```json
{"error":"role \"coder\" is not declared in .fullsend/config.yaml roles"}
```

This covers both the same-org and cross-org mint paths, since both funnel through `mintToken`. The internal log message keeps the precise reason (`undeclared role %q: no permissions defined`) while the client sees the actionable guidance. It is defense-in-depth: the request-time role allowlist (`checkAllowedRole`) and `NewHandler` startup validation already guard the common case, but the mint path itself must not depend on those alone — it now fails closed with a clean 403 rather than an opaque 502.

## Verification

- Added `TestHandler_MintToken_UndeclaredRole` (`internal/mintcore/handler_test.go`): asserts an undeclared role yields a `*mintError` with status `403` and a descriptive client-safe message referencing the role and `config.yaml`.
- `go test ./...` passes for `internal/mintcore` (full package suite green).
- `go build ./...` and `go vet ./...` clean.
