### PR TITLE
feat(normevent): surface check_run to CEL + ready-tests label workflow (POC)

### DIFF
--- a/.github/workflows/check-run-ready-label.yml
+++ b/.github/workflows/check-run-ready-label.yml
@@ -1,0 +1,112 @@
+# Reusable check_run → ready-tests label workflow (POC).
+#
+# When a check run whose name starts with `check_name_prefix` (default
+# `codecov/`) completes on a PR:
+#   success → add `label` (default `ready-tests`) to every associated PR
+#   failure → remove `label` and comment "coverage below patch target"
+# Other conclusions (neutral, skipped, cancelled, …) are ignored.
+#
+# Label names MUST keep the `ready-` prefix — fullsend routing (per-org shim
+# `if:` guard, per-repo CEL triggers) treats `ready-*` labels as dispatch
+# signals; `ready-tests` is the hand-off to a test-planning agent.
+#
+# Caller (in the repo where the checks run):
+#
+#   on:
+#     check_run:
+#       types: [completed]
+#   jobs:
+#     ready-tests:
+#       permissions:
+#         pull-requests: write
+#         issues: write
+#       uses: fullsend-ai/fullsend/.github/workflows/check-run-ready-label.yml@main
+#
+# Security: check name / conclusion / SHA are read via env:, never
+# interpolated into run: blocks.
+# Timeout: a handful of gh calls; callers should set timeout-minutes: 5.
+name: Check run ready label
+
+on:
+  workflow_call:
+    inputs:
+      check_name_prefix:
+        description: Only check runs whose name starts with this prefix are considered.
+        type: string
+        required: false
+        default: "codecov/"
+      label:
+        description: Label to add on success / remove on failure. Must start with `ready-`.
+        type: string
+        required: false
+        default: "ready-tests"
+      failure_comment:
+        description: PR comment posted when the check run fails.
+        type: string
+        required: false
+        default: "coverage below patch target"
+
+permissions: {}
+
+jobs:
+  label:
+    name: Apply ready label
+    if: github.event_name == 'check_run' && github.event.action == 'completed'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Label associated PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          CHECK_NAME: ${{ github.event.check_run.name }}
+          CONCLUSION: ${{ github.event.check_run.conclusion }}
+          HEAD_SHA: ${{ github.event.check_run.head_sha }}
+          PR_NUMBERS: ${{ join(github.event.check_run.pull_requests.*.number, ' ') }}
+          PREFIX: ${{ inputs.check_name_prefix }}
+          LABEL: ${{ inputs.label }}
+          FAILURE_COMMENT: ${{ inputs.failure_comment }}
+        run: |
+          set -euo pipefail
+
+          case "${LABEL}" in
+            ready-*) ;;
+            *) echo "::error::label must start with 'ready-' (got '${LABEL}')"; exit 1 ;;
+          esac
+
+          if [[ "${CHECK_NAME}" != "${PREFIX}"* ]]; then
+            echo "check '${CHECK_NAME}' does not match prefix '${PREFIX}'; skipping"
+            exit 0
+          fi
+
+          # check_run.pull_requests is empty for fork PRs; fall back to the
+          # commits→pulls API (same-repo + forks) so we still find the PR.
+          if [[ -z "${PR_NUMBERS// /}" ]]; then
+            PR_NUMBERS=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" --jq '.[].number' | tr '\n' ' ')
+          fi
+          if [[ -z "${PR_NUMBERS// /}" ]]; then
+            echo "no PR associated with ${HEAD_SHA}; skipping"
+            exit 0
+          fi
+
+          case "${CONCLUSION}" in
+            success)
+              gh label create "${LABEL}" --description "Coverage check passed; ready for test planning" --color 0E8A16 --force >/dev/null
+              for pr in ${PR_NUMBERS}; do
+                gh pr edit "${pr}" --add-label "${LABEL}"
+                echo "added ${LABEL} to #${pr}"
+              done
+              ;;
+            failure)
+              for pr in ${PR_NUMBERS}; do
+                gh pr edit "${pr}" --remove-label "${LABEL}" || true
+                gh pr comment "${pr}" --body "${FAILURE_COMMENT} (\`${CHECK_NAME}\` on ${HEAD_SHA:0:7})"
+                echo "removed ${LABEL} from #${pr}, commented"
+              done
+              ;;
+            *)
+              echo "conclusion '${CONCLUSION}' ignored"
+              ;;
+          esac

--- a/docs/normative/normalized-event/v1/README.md
+++ b/docs/normative/normalized-event/v1/README.md
@@ -83,10 +83,11 @@ Transition-specific fields are present only when required by `transition.kind`:
 
 | `transition.kind` | Required sub-object | Forbidden otherwise |
 |-------------------|---------------------|---------------------|
-| `label_changed` | `label` | `comment`, `review` |
-| `comment_added` | `comment` | `label`, `review` |
-| `review_submitted` | `review` | `label`, `comment` |
-| all other kinds | none | `label`, `comment`, `review` |
+| `label_changed` | `label` | `comment`, `review`, `check` |
+| `comment_added` | `comment` | `label`, `review`, `check` |
+| `review_submitted` | `review` | `label`, `comment`, `check` |
+| `check_completed` | `check` | `label`, `comment`, `review` |
+| all other kinds | none | `label`, `comment`, `review`, `check` |
 
 The schema enforces presence/absence of transition sub-objects via conditional
 `required` / `false` properties. Cross-field ID consistency (below) is
@@ -104,6 +105,7 @@ cross-field equality.
 | `updated` | Legacy umbrella; prefer `edited` or `synchronized` for new adapters |
 | `merged` | Change proposal merged into target branch |
 | `closed`, `marked_ready`, `label_changed`, `comment_added`, `review_submitted` | As named |
+| `check_completed` | A CI check run finished on a change proposal (GitHub `check_run` `completed`); `check` carries `name`, `conclusion`, `head_sha`, `change_proposal_ids`. Entity is the first attached change proposal; runs with no attached PR are not dispatched |
 
 ### Comment extraction
 
@@ -168,6 +170,11 @@ event.transition.kind == "review_submitted"
 event.transition.kind == "comment_added"
   && event.transition.comment.command == "/fs-fix"
   && !event.state.change_proposal.is_fork
+
+// Plan tests when a coverage check run fails on a PR
+event.transition.kind == "check_completed"
+  && event.transition.check.name.startsWith("codecov/")
+  && event.transition.check.conclusion == "failure"
 ```
 
 See [`examples/`](examples/) for matching `NormalizedEvent` fixtures.

--- a/docs/normative/normalized-event/v1/examples/check-run-completed.json
+++ b/docs/normative/normalized-event/v1/examples/check-run-completed.json
@@ -1,0 +1,31 @@
+{
+  "repo": "acme/widgets",
+  "entity": {
+    "kind": "change_proposal",
+    "id": 42,
+    "url": "https://github.com/acme/widgets/pull/42"
+  },
+  "transition": {
+    "kind": "check_completed",
+    "check": {
+      "name": "codecov/patch",
+      "conclusion": "failure",
+      "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+      "change_proposal_ids": [42]
+    }
+  },
+  "actor": {
+    "id": "codecov[bot]",
+    "kind": "bot",
+    "role": "none",
+    "is_entity_author": false
+  },
+  "state": {
+    "labels": []
+  },
+  "source": {
+    "system": "github",
+    "raw_type": "check_run",
+    "raw_action": "completed"
+  }
+}

--- a/docs/normative/normalized-event/v1/normalized-event.schema.json
+++ b/docs/normative/normalized-event/v1/normalized-event.schema.json
@@ -160,7 +160,8 @@
             "marked_ready",
             "label_changed",
             "comment_added",
-            "review_submitted"
+            "review_submitted",
+            "check_completed"
           ],
           "description": "Semantic lifecycle transition. Prefer edited/synchronized over updated; adapters MAY map reopened to opened when distinction is unnecessary."
         },
@@ -223,6 +224,41 @@
               "description": "Forge login of the reviewer (bot accounts end with [bot] on GitHub)."
             }
           }
+        },
+        "check": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "conclusion", "head_sha", "change_proposal_ids"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255,
+              "description": "Check run name as shown in the forge UI (e.g. codecov/patch)."
+            },
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "success",
+                "failure",
+                "neutral",
+                "cancelled",
+                "skipped",
+                "timed_out",
+                "action_required",
+                "stale"
+              ]
+            },
+            "head_sha": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "change_proposal_ids": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 },
+              "description": "All change proposals the check run is attached to; entity.id is the first."
+            }
+          }
         }
       },
       "allOf": [
@@ -249,6 +285,14 @@
           },
           "then": { "required": ["review"] },
           "else": { "properties": { "review": false } }
+        },
+        {
+          "if": {
+            "properties": { "kind": { "const": "check_completed" } },
+            "required": ["kind"]
+          },
+          "then": { "required": ["check"] },
+          "else": { "properties": { "check": false } }
         }
       ]
     },

--- a/internal/harnessdispatch/input/ghaevent.go
+++ b/internal/harnessdispatch/input/ghaevent.go
@@ -124,6 +124,8 @@ func mapGitHubWebhook(ctx context.Context, opts GHAEventOptions, raw map[string]
 		return mapPRReviewEvent(ev, raw, action, actorID)
 	case "issue_comment":
 		return mapIssueCommentEvent(ctx, opts, raw, action, actorID)
+	case "check_run":
+		return mapCheckRunEvent(ev, raw, action)
 	default:
 		return nil, fmt.Errorf("unsupported github event name %q", opts.EventName)
 	}
@@ -350,6 +352,46 @@ func mapIssueCommentEvent(ctx context.Context, opts GHAEventOptions, raw map[str
 		Command:     cmd,
 		Body:        truncateRunes(body, 4096),
 		Instruction: truncateRunes(instr, 4096),
+	}
+	return ev, nil
+}
+
+// mapCheckRunEvent maps a GitHub check_run event to a check_completed
+// transition on the first attached PR. Check runs with no attached PR (push to
+// default branch, fork PRs where GitHub omits pull_requests) are rejected —
+// there is no entity to route on.
+func mapCheckRunEvent(ev *normevent.Event, raw map[string]any, action string) (*normevent.Event, error) {
+	if action != "completed" {
+		return nil, fmt.Errorf("unsupported check_run action %q", action)
+	}
+	cr := nestedMap(raw, "check_run")
+	if cr == nil {
+		return nil, fmt.Errorf("check_run event missing check_run")
+	}
+	prs, _ := cr["pull_requests"].([]any)
+	var ids []int
+	for _, p := range prs {
+		if m, ok := p.(map[string]any); ok {
+			if n := intField(m, "number"); n > 0 {
+				ids = append(ids, n)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("check_run event has no associated pull requests")
+	}
+	// ponytail: entity = first PR; the full list rides in transition.check.change_proposal_ids.
+	ev.Entity = normevent.Entity{
+		Kind: normevent.EntityChangeProposal,
+		ID:   ids[0],
+		URL:  issuePullRequestURL(stringField(cr, "html_url"), ev.Repo, ids[0]),
+	}
+	ev.Transition.Kind = normevent.TransitionCheckCompleted
+	ev.Transition.Check = &normevent.Check{
+		Name:              stringField(cr, "name"),
+		Conclusion:        stringField(cr, "conclusion"),
+		HeadSHA:           stringField(cr, "head_sha"),
+		ChangeProposalIDs: ids,
 	}
 	return ev, nil
 }

--- a/internal/harnessdispatch/input/ghaevent_test.go
+++ b/internal/harnessdispatch/input/ghaevent_test.go
@@ -607,3 +607,60 @@ func writeEventFile(t *testing.T, raw map[string]any) string {
 	require.NoError(t, os.WriteFile(path, data, 0o644))
 	return path
 }
+
+func TestLoadGHAEvent_CheckRunCompleted(t *testing.T) {
+	raw := map[string]any{
+		"action": "completed",
+		"check_run": map[string]any{
+			"name":       "codecov/patch",
+			"conclusion": "success",
+			"head_sha":   "cccccccccccccccccccccccccccccccccccccccc",
+			"html_url":   "https://github.com/o/r/runs/1",
+			"pull_requests": []any{
+				map[string]any{"number": float64(7)},
+				map[string]any{"number": float64(9)},
+			},
+		},
+		"sender": map[string]any{"login": "codecov[bot]", "type": "Bot"},
+	}
+	path := writeEventFile(t, raw)
+
+	ev, err := input.LoadGHAEvent(context.Background(), input.GHAEventOptions{
+		EventPath:  path,
+		EventName:  "check_run",
+		Repository: "o/r",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, normevent.EntityChangeProposal, ev.Entity.Kind)
+	assert.Equal(t, 7, ev.Entity.ID)
+	assert.Equal(t, "https://github.com/o/r/pull/7", ev.Entity.URL)
+	assert.Equal(t, normevent.TransitionCheckCompleted, ev.Transition.Kind)
+	require.NotNil(t, ev.Transition.Check)
+	assert.Equal(t, "codecov/patch", ev.Transition.Check.Name)
+	assert.Equal(t, "success", ev.Transition.Check.Conclusion)
+	assert.Equal(t, "cccccccccccccccccccccccccccccccccccccccc", ev.Transition.Check.HeadSHA)
+	assert.Equal(t, []int{7, 9}, ev.Transition.Check.ChangeProposalIDs)
+	assert.Equal(t, normevent.ActorBot, ev.Actor.Kind)
+
+	// CEL sees it via ToMap.
+	m, err := ev.ToMap()
+	require.NoError(t, err)
+	check := m["transition"].(map[string]any)["check"].(map[string]any)
+	assert.Equal(t, "codecov/patch", check["name"])
+
+	// No PRs → no entity → rejected.
+	raw["check_run"].(map[string]any)["pull_requests"] = []any{}
+	path = writeEventFile(t, raw)
+	_, err = input.LoadGHAEvent(context.Background(), input.GHAEventOptions{
+		EventPath: path, EventName: "check_run", Repository: "o/r",
+	})
+	assert.ErrorContains(t, err, "no associated pull requests")
+
+	// Only completed is mapped.
+	raw["action"] = "created"
+	path = writeEventFile(t, raw)
+	_, err = input.LoadGHAEvent(context.Background(), input.GHAEventOptions{
+		EventPath: path, EventName: "check_run", Repository: "o/r",
+	})
+	assert.ErrorContains(t, err, "unsupported check_run action")
+}

--- a/internal/normevent/event.go
+++ b/internal/normevent/event.go
@@ -58,6 +58,7 @@ const (
 	TransitionCommentEdited   TransitionKind = "comment_edited"
 	TransitionCommentDeleted  TransitionKind = "comment_deleted"
 	TransitionReviewSubmitted TransitionKind = "review_submitted"
+	TransitionCheckCompleted  TransitionKind = "check_completed"
 )
 
 // Transition describes what changed on the entity.
@@ -66,6 +67,16 @@ type Transition struct {
 	Label   *LabelChange   `json:"label,omitempty"`
 	Comment *Comment       `json:"comment,omitempty"`
 	Review  *Review        `json:"review,omitempty"`
+	Check   *Check         `json:"check,omitempty"`
+}
+
+// Check describes a check_completed transition (GitHub check_run completed).
+type Check struct {
+	Name       string `json:"name"`
+	Conclusion string `json:"conclusion"` // success | failure | neutral | cancelled | skipped | timed_out | action_required | stale
+	HeadSHA    string `json:"head_sha"`
+	// ChangeProposalIDs lists every change proposal the check run is attached to.
+	ChangeProposalIDs []int `json:"change_proposal_ids"`
 }
 
 // LabelChange describes a label add/remove transition.
@@ -217,6 +228,13 @@ func (e *Event) Validate() error {
 	case TransitionReviewSubmitted:
 		if e.Transition.Review == nil {
 			return fmt.Errorf("normalized event: transition.review required for review_submitted")
+		}
+	case TransitionCheckCompleted:
+		if e.Transition.Check == nil {
+			return fmt.Errorf("normalized event: transition.check required for check_completed")
+		}
+		if e.Transition.Check.Name == "" || e.Transition.Check.Conclusion == "" {
+			return fmt.Errorf("normalized event: transition.check.name and conclusion are required")
 		}
 	}
 

--- a/internal/normevent/validate_test.go
+++ b/internal/normevent/validate_test.go
@@ -84,3 +84,19 @@ func TestMapGitHubPermission_AllRoles(t *testing.T) {
 	assert.Equal(t, RoleTriage, MapGitHubPermission("triage"))
 	assert.Equal(t, RoleRead, MapGitHubPermission("read"))
 }
+
+func TestValidate_CheckCompletedRequiresCheck(t *testing.T) {
+	ev := &Event{
+		Repo:       "o/r",
+		Entity:     Entity{Kind: EntityChangeProposal, ID: 1, URL: "https://github.com/o/r/pull/1"},
+		Transition: Transition{Kind: TransitionCheckCompleted},
+		Actor:      Actor{ID: "codecov[bot]", Kind: ActorBot, Role: RoleNone},
+		State:      State{Labels: []string{}},
+		Source:     Source{System: SystemGitHub, RawType: "check_run"},
+	}
+	assert.Error(t, ev.Validate())
+	ev.Transition.Check = &Check{Name: "codecov/patch"}
+	assert.Error(t, ev.Validate())
+	ev.Transition.Check.Conclusion = "success"
+	require.NoError(t, ev.Validate())
+}


### PR DESCRIPTION
**Draft / POC for the 2026-08-19 contributors meeting — not ready for review.**

Makes coverage results visible to dispatch so a coverage gate can drive test planning:

- `internal/normevent`: new `check_completed` transition with `check.{name, conclusion, head_sha, change_proposal_ids}`; schema, README kind vocabulary, `examples/check-run-completed.json`, validation tests.
- `internal/harnessdispatch/input/ghaevent.go`: maps GitHub `check_run` (completed only) → normalized event; entity = first attached PR; rejects check runs with no PR.
- `.github/workflows/check-run-ready-label.yml` (reusable, `workflow_call`): on `codecov/*` success → add `ready-tests` label to associated PRs; failure → remove label + comment. Enforces the `ready-` prefix; falls back to `commits/{sha}/pulls` for fork PRs.

CEL example now possible: `event.transition.check.name.startsWith("codecov/") && event.transition.check.conclusion == "failure"`.

Deliberately not done: adding `check_run` to the per-repo shim template (would fire the whole dispatch chain on every check run) — the label workflow is the delivery path for now; GitLab mapping.

Verified: `go build ./...`; `go test ./internal/normevent/... ./internal/harnessdispatch/input/... ./internal/scaffold/...`; actionlint clean. Note `internal/harnessdispatch TestEnumerate…` fails identically on clean main (pre-existing).
