### PR TITLE
feat(review): skip docs/test-only PRs via exit-78 precheck + review-spend measurement (POC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ script-test:
 	$(call run-timed,bash .github/scripts/redact-behaviour-artifacts-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/review-scope-precheck-test.sh)
 	$(call run-timed,bash hack/gitlab-runner-vm/executor/prepare_validation_test.sh)
 	$(call run-timed,python3 skills/topissues/scripts/topissues_test.py)
 	$(call run-timed,python3 skills/nextwork/scripts/nextwork_test.py)

--- a/docs/agents/review.md
+++ b/docs/agents/review.md
@@ -93,6 +93,23 @@ defense-in-depth. When filtering removes all findings from a
 `request-changes` or `reject` verdict, the post-script downgrades the
 verdict to `comment` (applying the `requires-manual-review` label).
 
+### Skipping docs-only and test-only PRs
+
+The scaffold ships `scripts/review-scope-precheck.sh`, a harness `pre_script`
+that exits 78 (neutral skip, see the
+[pre-script output protocol](../normative/prescript-output/v1/README.md))
+when every changed file matches a docs/test pattern (`\.md$`, `^docs/`,
+`_test\.go$`, `^tests?/`, `\.txt$` — override with
+`REVIEW_SCOPE_SKIP_PATTERNS`, comma-separated ERE). It reads the file list
+from `BASE`/`HEAD` (git) or `PR_NUMBER`/`REPO_FULL_NAME` (`gh pr view`).
+Wire it with `base:` composition; note that `pre_script` is replaced, not
+chained, so this override drops the upstream input-validation pre-script:
+
+```yaml
+base: https://raw.githubusercontent.com/fullsend-ai/agents/<ref>/harness/review.yaml
+pre_script: scripts/review-scope-precheck.sh
+```
+
 ## Source
 
 [`fullsend-ai/agents` — `harness/review.yaml`](https://github.com/fullsend-ai/agents/blob/main/harness/review.yaml)

--- a/hack/review-spend.sh
+++ b/hack/review-spend.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# review-spend.sh — How much review-agent spend goes to docs/test-only PRs?
+#
+# For the last N merged PRs of a repo, counts review-agent runs (PR reviews
+# authored by the review bot) and flags PRs whose changed files are all
+# docs/test-only — the ones scripts/review-scope-precheck.sh would skip.
+# Uses gh only.
+#
+# Usage: hack/review-spend.sh <owner/repo> [N=50]
+# Env:   REVIEW_BOT (default fullsend-ai-review; gh JSON omits the [bot] suffix)
+#        REVIEW_SCOPE_SKIP_PATTERNS (comma-separated ERE, same as the precheck)
+set -euo pipefail
+
+REPO="${1:?usage: $0 <owner/repo> [N]}"
+N="${2:-50}"
+BOT="${REVIEW_BOT:-fullsend-ai-review}"
+DEFAULT_PATTERNS='\.md$,^docs/,_test\.go$,^tests?/,\.txt$'
+IFS=',' read -r -a PATTERNS <<< "${REVIEW_SCOPE_SKIP_PATTERNS:-${DEFAULT_PATTERNS}}"
+
+# docs_only <newline-separated files> → 0 if every file matches a pattern
+docs_only() {
+  local f p matched
+  while IFS= read -r f; do
+    [[ -z "${f}" ]] && continue
+    matched=0
+    for p in "${PATTERNS[@]}"; do [[ "${f}" =~ ${p} ]] && { matched=1; break; }; done
+    [[ "${matched}" -eq 0 ]] && return 1
+  done
+  return 0
+}
+
+total_prs=0 total_runs=0 skippable_prs=0 skippable_runs=0
+printf '%-7s %-6s %-9s %s\n' PR RUNS SCOPE TITLE
+printf '%-7s %-6s %-9s %s\n' ------- ------ --------- -----
+
+# ponytail: one gh call per PR (files + reviews); fine for N<=200.
+while IFS=$'\t' read -r num title; do
+  json="$(gh pr view "${num}" --repo "${REPO}" --json files,reviews)"
+  files="$(jq -r '.files[].path' <<< "${json}")"
+  runs="$(jq -r --arg bot "${BOT}" '[.reviews[] | select(.author.login == $bot)] | length' <<< "${json}")"
+  scope=code
+  if docs_only <<< "${files}"; then scope=docs/test; fi
+  total_prs=$((total_prs + 1))
+  total_runs=$((total_runs + runs))
+  if [[ "${scope}" == "docs/test" ]]; then
+    skippable_prs=$((skippable_prs + 1))
+    skippable_runs=$((skippable_runs + runs))
+  fi
+  printf '#%-6s %-6s %-9s %s\n' "${num}" "${runs}" "${scope}" "${title:0:60}"
+done < <(gh pr list --repo "${REPO}" --state merged --limit "${N}" --json number,title --jq '.[] | [.number, .title] | @tsv')
+
+pct() { [[ "$2" -eq 0 ]] && echo 0 || echo $(( 100 * $1 / $2 )); }
+echo
+echo "PRs: ${total_prs} (docs/test-only: ${skippable_prs}, $(pct "${skippable_prs}" "${total_prs}")%)"
+echo "Review runs by ${BOT}: ${total_runs} (on docs/test-only PRs: ${skippable_runs}, $(pct "${skippable_runs}" "${total_runs}")%)"

--- a/internal/scaffold/fullsend-repo/scripts/review-scope-precheck-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/review-scope-precheck-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# review-scope-precheck-test.sh — Self-check for review-scope-precheck.sh
+# using a throwaway git repo (BASE/HEAD path, no gh needed).
+#
+# Run from the repo root:
+#   bash internal/scaffold/fullsend-repo/scripts/review-scope-precheck-test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/review-scope-precheck.sh"
+FAILURES=0
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+REPO="${TMP}/repo"
+git init -q "${REPO}"
+git -C "${REPO}" -c user.name=t -c user.email=t@t commit -q --allow-empty -m base
+BASE_SHA="$(git -C "${REPO}" rev-parse HEAD)"
+
+# commit_files <name> <file>... — commit files on top of BASE, echo the sha
+commit_files() {
+  local name="$1"; shift
+  git -C "${REPO}" checkout -q "${BASE_SHA}"
+  for f in "$@"; do
+    mkdir -p "${REPO}/$(dirname "${f}")"
+    echo x > "${REPO}/${f}"
+    git -C "${REPO}" add "${f}"
+  done
+  git -C "${REPO}" -c user.name=t -c user.email=t@t commit -q -m "${name}"
+  git -C "${REPO}" rev-parse HEAD
+}
+
+# expect <label> <expected-exit> <file>...
+expect() {
+  local label="$1" want="$2"; shift 2
+  local head rc=0
+  head="$(commit_files "${label}" "$@")"
+  BASE="${BASE_SHA}" HEAD="${head}" REVIEW_TARGET_REPO_DIR="${REPO}" \
+    bash "${SCRIPT}" >/dev/null 2>&1 || rc=$?
+  if [[ "${rc}" -eq "${want}" ]]; then
+    echo "PASS: ${label} (exit ${rc})"
+  else
+    echo "FAIL: ${label} — want exit ${want}, got ${rc}"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+expect "docs-only"          78 README.md docs/guide.md
+expect "test-only"          78 internal/x/x_test.go tests/fixture.txt
+expect "mixed"              0  README.md internal/x/x.go
+expect "code-only"          0  cmd/main.go
+expect "md-in-code-path"    78 internal/x/notes.md
+
+# Reason must be on stdout as the last line (protocol fallback reason).
+head="$(commit_files reason README.md)"
+out="$(BASE="${BASE_SHA}" HEAD="${head}" REVIEW_TARGET_REPO_DIR="${REPO}" bash "${SCRIPT}" 2>/dev/null || true)"
+if [[ "$(tail -n1 <<< "${out}")" == "docs/test-only change, review skipped" ]]; then
+  echo "PASS: reason on stdout"
+else
+  echo "FAIL: reason on stdout — got: ${out}"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# No inputs → inconclusive → proceed.
+rc=0; env -u BASE -u HEAD -u PR_NUMBER -u REPO_FULL_NAME bash "${SCRIPT}" >/dev/null 2>&1 || rc=$?
+if [[ "${rc}" -eq 0 ]]; then echo "PASS: no inputs proceeds"; else echo "FAIL: no inputs exit ${rc}"; FAILURES=$((FAILURES + 1)); fi
+
+# Custom patterns via env.
+head="$(commit_files custom foo.rst)"
+rc=0; BASE="${BASE_SHA}" HEAD="${head}" REVIEW_TARGET_REPO_DIR="${REPO}" REVIEW_SCOPE_SKIP_PATTERNS='\.rst$' \
+  bash "${SCRIPT}" >/dev/null 2>&1 || rc=$?
+if [[ "${rc}" -eq 78 ]]; then echo "PASS: custom patterns"; else echo "FAIL: custom patterns exit ${rc}"; FAILURES=$((FAILURES + 1)); fi
+
+if [[ "${FAILURES}" -gt 0 ]]; then
+  echo "${FAILURES} failure(s)"
+  exit 1
+fi
+echo "All review-scope-precheck tests passed"

--- a/internal/scaffold/fullsend-repo/scripts/review-scope-precheck.sh
+++ b/internal/scaffold/fullsend-repo/scripts/review-scope-precheck.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# review-scope-precheck.sh — Skip the review agent on docs-only / test-only PRs.
+#
+# Runs on the host as a harness pre_script. Uses the pre-script output
+# protocol (docs/normative/prescript-output/v1): exit 78 = neutral skip,
+# with the last stdout line as the skip reason.
+#
+# File list source (first that applies):
+#   BASE + HEAD (env)          — `git diff --name-only BASE HEAD` in
+#                                ${REVIEW_TARGET_REPO_DIR:-.}
+#   PR_NUMBER + REPO_FULL_NAME — `gh pr view --json files` (needs GH_TOKEN)
+# If neither is available the check is inconclusive and the run proceeds.
+#
+# Optional:
+#   REVIEW_SCOPE_SKIP_PATTERNS — comma-separated ERE list overriding the
+#                                default docs/test patterns.
+set -euo pipefail
+
+DEFAULT_PATTERNS='\.md$,^docs/,_test\.go$,^tests?/,\.txt$'
+IFS=',' read -r -a PATTERNS <<< "${REVIEW_SCOPE_SKIP_PATTERNS:-${DEFAULT_PATTERNS}}"
+
+files=""
+if [[ -n "${BASE:-}" && -n "${HEAD:-}" ]]; then
+  files="$(git -C "${REVIEW_TARGET_REPO_DIR:-.}" diff --name-only "${BASE}" "${HEAD}")"
+elif [[ -n "${PR_NUMBER:-}" && -n "${REPO_FULL_NAME:-}" ]] && command -v gh >/dev/null 2>&1; then
+  files="$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" --json files --jq '.files[].path' 2>/dev/null || true)"
+fi
+
+if [[ -z "${files}" ]]; then
+  echo "review-scope-precheck: no changed files determined — proceeding with review"
+  exit 0
+fi
+
+# ponytail: linear scan over files x patterns; PRs are small.
+while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+  matched=0
+  for p in "${PATTERNS[@]}"; do
+    if [[ "${f}" =~ ${p} ]]; then matched=1; break; fi
+  done
+  if [[ "${matched}" -eq 0 ]]; then
+    echo "review-scope-precheck: ${f} is in scope — proceeding with review"
+    exit 0
+  fi
+done <<< "${files}"
+
+echo "review-scope-precheck: all changed files are docs/test-only — skipping review" >&2
+echo "docs/test-only change, review skipped"
+exit 78

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -29,6 +29,7 @@ var executableFiles = map[string]struct{}{
 	"scripts/prepare-sandbox-credentials.sh": {},
 	"scripts/reconcile-repos.sh":             {},
 	"scripts/resolve-precommit-tools.py":     {},
+	"scripts/review-scope-precheck.sh":       {},
 	"scripts/setup-prioritize.sh":            {},
 	"scripts/validate-source-repo.sh":        {},
 }


### PR DESCRIPTION
**Draft / POC for the 2026-08-19 contributors meeting — not ready for review.**

Review spend lever: skip review runs on docs-only / test-only PRs using the existing exit-78 pre-script skip path (no Go run-path change needed — `internal/prescript` already emits `fullsend.prescript.skipped` / `skip_reason`).

- `internal/scaffold/fullsend-repo/scripts/review-scope-precheck.sh`: exits 78 with a reason when every changed file matches `\.md$ ^docs/ _test\.go$ ^tests?/ \.txt$` (override via `REVIEW_SCOPE_SKIP_PATTERNS`). Sources files from `BASE`/`HEAD` diff or `PR_NUMBER`+`REPO_FULL_NAME` via gh; no inputs → proceed.
- `…/review-scope-precheck-test.sh`: fixture repo, 8 cases; wired into `make script-test`. Registered as executable in `scaffold.go`.
- `hack/review-spend.sh <owner/repo> [N]`: measures review runs per PR and the docs/test-only share. Live on fullsend-ai/fullsend (last 8): 25% docs/test-only, 14 review runs.
- `docs/agents/review.md`: how to wire it as `pre_script`.

Note: the review harness lives in `fullsend-ai/agents` (`harness/review.yaml` → `scripts/pre-review.sh`); the real wiring is a call to this precheck at the end of `pre-review.sh` there — `pre_script` overrides replace rather than chain, so a `base:` override would drop upstream validation. Follow-up PR in agents.

Verified: `go build ./...`; `go test ./internal/scaffold/...` (264 pass); precheck self-test green.
