### PR TITLE
ci(e2e): bind behaviour job to dev and stage environments

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,15 +182,27 @@ jobs:
 
   behaviour:
     # Same gate authorization as e2e — checks out untrusted PR head with secrets.
+    # Runs only on authorized PRs, merge_group (required check; treated as
+    # PR-class / dev), and push to main (stage). Skip workflow_dispatch.
+    # Environment uses event_name, not github.ref: pull_request_target sets
+    # github.ref to the base branch (usually main).
     needs: gate
     if: >-
       !cancelled() &&
-      (github.event_name != 'pull_request_target' || needs.gate.outputs.authorized == 'true')
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (github.event_name == 'merge_group') ||
+        (github.event_name == 'pull_request_target' && needs.gate.outputs.authorized == 'true')
+      )
+    # Scalar form keeps default deployment: true so runs list under Environments.
+    environment: ${{ github.event_name == 'push' && 'stage' || 'dev' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       contents: read
       id-token: write
+    env:
+      ENVIRONMENT: ${{ github.event_name == 'push' && 'stage' || 'dev' }}
     steps:
       - name: Check for behaviour-relevant changes
         id: changes
@@ -260,6 +272,7 @@ jobs:
           BEHAVIOUR_SCM: github
           BEHAVIOUR_CI: githubactions
           BEHAVIOUR_INSTALL_MODE: per-repo
+          ENVIRONMENT: ${{ github.event_name == 'push' && 'stage' || 'dev' }}
           BEHAVIOUR_ARTIFACT_DIR: ${{ runner.temp }}/behaviour-artifacts
           E2E_GCP_PROJECT_ID: ${{ secrets.E2E_GCP_PROJECT_ID }}
           E2E_GCP_WIF_PROVIDER: ${{ secrets.E2E_GCP_WIF_PROVIDER }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -272,7 +272,6 @@ jobs:
           BEHAVIOUR_SCM: github
           BEHAVIOUR_CI: githubactions
           BEHAVIOUR_INSTALL_MODE: per-repo
-          ENVIRONMENT: ${{ github.event_name == 'push' && 'stage' || 'dev' }}
           BEHAVIOUR_ARTIFACT_DIR: ${{ runner.temp }}/behaviour-artifacts
           E2E_GCP_PROJECT_ID: ${{ secrets.E2E_GCP_PROJECT_ID }}
           E2E_GCP_WIF_PROVIDER: ${{ secrets.E2E_GCP_WIF_PROVIDER }}

--- a/docs/guides/dev/behaviour-drivers.md
+++ b/docs/guides/dev/behaviour-drivers.md
@@ -26,9 +26,10 @@ Set when starting the suite (not in feature files):
 BEHAVIOUR_SCM=github              # future: gitlab, forgejo
 BEHAVIOUR_CI=githubactions        # future: tekton, gitlabci
 BEHAVIOUR_INSTALL_MODE=per-repo   # v1 default and only supported value
+ENVIRONMENT=dev                   # mint/infra target: dev (default) or stage
 ```
 
-The suite in `e2e/behaviour/suite_test.go` (or an external runner) acquires a pool org via `pkg/e2etest`, runs pre-install cleanup, calls an `install.Factory` (e.g. `install.NewRepoPoolCFMintPreviews(...)`) to get a unified `install.Driver` that owns mint deploy, pool allocation, repo ensure, and teardown. The suite constructs SCM and CI drivers, then runs godog with `pkg/behaviourtest/suite.InitScenario`. `InitScenario` clones a template `*world.World` per scenario. When a scenario calls "Given the enrolled test repository", `Driver.AllocateRepo` leases a unique repo name and ensures it is created and installed. `Driver.DeallocateRepo` returns the name in the After hook. `Driver.Finalize` tears down suite-scoped resources (e.g. preview mint) and reclaims outstanding leases. Unsupported `BEHAVIOUR_INSTALL_MODE` values fail at suite startup.
+The suite in `e2e/behaviour/suite_test.go` (or an external runner) acquires a pool org via `pkg/e2etest`, runs pre-install cleanup, calls an `install.Factory` (e.g. `install.NewRepoPoolCFMintPreviews(...)`) to get a unified `install.Driver` that owns mint deploy, pool allocation, repo ensure, and teardown. The suite constructs SCM and CI drivers, then runs godog with `pkg/behaviourtest/suite.InitScenario`. `InitScenario` clones a template `*world.World` per scenario. When a scenario calls "Given the enrolled test repository", `Driver.AllocateRepo` leases a unique repo name and ensures it is created and installed. `Driver.DeallocateRepo` returns the name in the After hook. `Driver.Finalize` tears down suite-scoped resources (e.g. preview mint) and reclaims outstanding leases. Unsupported `BEHAVIOUR_INSTALL_MODE` or `ENVIRONMENT` values fail at suite startup. `ENVIRONMENT` is `dev` or `stage` (empty defaults to `dev`).
 
 ### Install driver (unified)
 

--- a/docs/guides/dev/behaviour-testing.md
+++ b/docs/guides/dev/behaviour-testing.md
@@ -229,12 +229,15 @@ Runner env (defaults shown):
 BEHAVIOUR_SCM=github
 BEHAVIOUR_CI=githubactions
 BEHAVIOUR_INSTALL_MODE=per-repo
+ENVIRONMENT=dev               # mint/infra target: dev (default, local and PRs) or stage (push to main)
 E2E_GCP_PROJECT_ID=...        # inference project; install runs inference provision per pool repo
 E2E_GCP_WIF_PROVIDER=...      # CI job GCP auth (not written to pool test-repo secrets)
 TEST_ACTOR_WRITE_PAT=...      # write-level human-like actor PAT (CI: same-named repo secret)
 TEST_ACTOR_TRIAGE_PAT=...     # triage-level human-like actor PAT
 TEST_ACTOR_OUTSIDER_PAT=...   # outsider human-like actor PAT (no org write on base)
 ```
+
+`ENVIRONMENT` is `dev` or `stage`. Local runs default to `dev` when unset. CI sets it to match the GitHub Environment on the behaviour job (`dev` on pull requests and the merge queue, `stage` on push to `main`).
 
 Triage scenarios apply the `ready-for-triage` label (not `/fs-triage` comments) because the per-repo shim ignores `issue_comment` events from bot users and CI uses minted e2e installation tokens.
 

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -70,7 +70,13 @@ Mint URL uses the hosted public endpoint by default (same as `fullsend admin --m
 
 ### Behaviour job GitHub Environments
 
-The behaviour job in `e2e.yml` binds to GitHub Environments `dev` (authorized pull requests and the merge queue) and `stage` (push to `main`). It skips `workflow_dispatch` and other triggers. GitHub auto-creates those environments on first use. Restrict `stage` to the `main` branch once they exist (operator step). The job sets `ENVIRONMENT` to the same value for the suite (`dev` or `stage`).
+The behaviour job in `e2e.yml` binds to GitHub Environments `dev` (authorized pull requests and the merge queue) and `stage` (push to `main`). It skips `workflow_dispatch` and other triggers. The job sets `ENVIRONMENT` to the same value for the suite (`dev` or `stage`). GitHub auto-creates those environments on first use.
+
+After the environments exist, restrict `stage` to `main`:
+
+1. Open the repository **Settings → Environments → `stage`**.
+2. Under **Deployment branches and tags**, choose **Selected branches and tags**.
+3. Add a branch rule for `main`.
 
 ### Cloudflare Worker mint BT credentials
 

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -68,6 +68,10 @@ Required repository secrets:
 
 Mint URL uses the hosted public endpoint by default (same as `fullsend admin --mint-url`). Override with org/repo variable `FULLSEND_MINT_URL` if needed; no separate e2e secret.
 
+### Behaviour job GitHub Environments
+
+The behaviour job in `e2e.yml` binds to GitHub Environments `dev` (authorized pull requests and the merge queue) and `stage` (push to `main`). It skips `workflow_dispatch` and other triggers. GitHub auto-creates those environments on first use. Restrict `stage` to the `main` branch once they exist (operator step). The job sets `ENVIRONMENT` to the same value for the suite (`dev` or `stage`).
+
 ### Cloudflare Worker mint BT credentials
 
 The behaviour job wires `TEST_CLOUDFLARE_*` into Wrangler’s standard `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` env names so CF mint BT (#5109) can upload versions of Worker **`mint-test`**. These secrets must **not** reuse the production site-deploy `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` used by `site-deploy.yml` (Worker `site`).

--- a/pkg/behaviourtest/drivers/env/env.go
+++ b/pkg/behaviourtest/drivers/env/env.go
@@ -11,6 +11,11 @@ type RunnerConfig struct {
 	SCM         string
 	CI          string
 	InstallMode string
+	// Environment is the mint/infra target the suite is talking to
+	// (`dev` or `stage`), from ENVIRONMENT. Empty defaults to `dev`
+	// so local `make behaviour-test` works without setting it. CI
+	// sets this to match the GitHub Environment on the behaviour job.
+	Environment string
 
 	// Capabilities lists environment capabilities the runner declares,
 	// from the comma-separated BEHAVIOUR_CAPABILITIES env var. Scenarios
@@ -25,6 +30,7 @@ func LoadRunnerConfig() RunnerConfig {
 		SCM:          stringsTrimOrDefault(os.Getenv("BEHAVIOUR_SCM"), "github"),
 		CI:           stringsTrimOrDefault(os.Getenv("BEHAVIOUR_CI"), "githubactions"),
 		InstallMode:  stringsTrimOrDefault(os.Getenv("BEHAVIOUR_INSTALL_MODE"), "per-repo"),
+		Environment:  stringsTrimOrDefault(os.Getenv("ENVIRONMENT"), "dev"),
 		Capabilities: splitCapabilities(os.Getenv("BEHAVIOUR_CAPABILITIES")),
 	}
 }
@@ -58,6 +64,9 @@ func (c RunnerConfig) Validate() error {
 	}
 	if c.CI != "githubactions" {
 		return fmt.Errorf("unsupported BEHAVIOUR_CI %q", c.CI)
+	}
+	if c.Environment != "dev" && c.Environment != "stage" {
+		return fmt.Errorf("unsupported ENVIRONMENT %q (want dev or stage)", c.Environment)
 	}
 	return nil
 }

--- a/pkg/behaviourtest/drivers/env/env_test.go
+++ b/pkg/behaviourtest/drivers/env/env_test.go
@@ -1,0 +1,66 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadRunnerConfig_EnvironmentDefault(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "")
+
+	cfg := LoadRunnerConfig()
+	assert.Equal(t, "dev", cfg.Environment)
+}
+
+func TestLoadRunnerConfig_EnvironmentFromEnv(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "stage")
+
+	cfg := LoadRunnerConfig()
+	assert.Equal(t, "stage", cfg.Environment)
+}
+
+func TestLoadRunnerConfig_EnvironmentTrimsWhitespace(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "  stage  ")
+
+	cfg := LoadRunnerConfig()
+	assert.Equal(t, "stage", cfg.Environment)
+}
+
+func TestValidate_AcceptsDevAndStage(t *testing.T) {
+	for _, envName := range []string{"dev", "stage"} {
+		t.Run(envName, func(t *testing.T) {
+			cfg := RunnerConfig{
+				SCM:         "github",
+				CI:          "githubactions",
+				InstallMode: "per-repo",
+				Environment: envName,
+			}
+			require.NoError(t, cfg.Validate())
+		})
+	}
+}
+
+func TestValidate_RejectsUnknownEnvironment(t *testing.T) {
+	cfg := RunnerConfig{
+		SCM:         "github",
+		CI:          "githubactions",
+		InstallMode: "per-repo",
+		Environment: "prod",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unsupported ENVIRONMENT "prod"`)
+}
+
+func TestValidate_RejectsEmptyEnvironment(t *testing.T) {
+	cfg := RunnerConfig{
+		SCM:         "github",
+		CI:          "githubactions",
+		InstallMode: "per-repo",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unsupported ENVIRONMENT ""`)
+}


### PR DESCRIPTION
## Summary
- Bind the behaviour job to GitHub Environments `dev` (authorized PRs and merge queue) and `stage` (push to `main`); skip `workflow_dispatch` and other triggers.
- Expose a matching `ENVIRONMENT` env var to the suite (`dev`/`stage`, local default `dev`) so later STAGE-infra work does not have to guess the trigger.
- Job listing in Environments uses the default `deployment: true` from the scalar `environment:` key; the job token is not granted `deployments: write`.

Part of the work for #5115. This PR does not close that issue.

## Test plan
- [ ] Confirm a PR run of the behaviour job appears under the `dev` environment and has `ENVIRONMENT=dev`.
- [ ] Confirm a push-to-`main` run appears under `stage` and has `ENVIRONMENT=stage`.
- [ ] Confirm `workflow_dispatch` of E2E Tests skips the behaviour job (admin `e2e` job still runs).
- [ ] Confirm merge-queue still gets a `behaviour` check (required) bound to `dev`.
- [ ] `go test ./pkg/behaviourtest/drivers/env/` passes locally.