### PR TITLE
fix(#2528): sync VALID_ROLES with Go's ValidRoles()

### DIFF
--- a/web/admin/src/lib/layers/orgConfigParse.test.ts
+++ b/web/admin/src/lib/layers/orgConfigParse.test.ts
@@ -65,6 +65,22 @@ repos: {}
     expect(validateOrgConfig(cfg)).toMatch(/non-negative integer/);
   });
 
+  it.each(["fullsend", "triage", "coder", "review", "fix", "retro", "prioritize", "e2e"])(
+    "accepts role %s",
+    (role) => {
+      const cfg = parseOrgConfigYaml(`version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles: [${role}]
+agents:
+  - role: ${role}
+repos: {}
+`);
+      expect(validateOrgConfig(cfg)).toBeNull();
+    },
+  );
+
   it("rejects invalid agent role", () => {
     const cfg = parseOrgConfigYaml(`version: "1"
 dispatch:

--- a/web/admin/src/lib/layers/orgConfigParse.ts
+++ b/web/admin/src/lib/layers/orgConfigParse.ts
@@ -13,7 +13,7 @@ export type OrgConfigYaml = {
   repos?: Record<string, { enabled?: boolean; roles?: string[] }>;
 };
 
-const VALID_ROLES = new Set(["fullsend", "triage", "coder", "review"]);
+const VALID_ROLES = new Set(["fullsend", "triage", "coder", "review", "fix", "retro", "prioritize", "e2e"]);
 
 /** 512 KiB — more than sufficient for any realistic org `config.yaml`. */
 export const MAX_ORG_CONFIG_YAML_UTF8_BYTES = 512 * 1024;
@@ -153,12 +153,12 @@ export function validateOrgConfig(cfg: OrgConfigYaml): string | null {
   }
   for (const role of cfg.defaults?.roles ?? []) {
     if (!VALID_ROLES.has(role)) {
-      return `invalid role ${JSON.stringify(role)}: must be one of fullsend, triage, coder, review`;
+      return `invalid role ${JSON.stringify(role)}: must be one of fullsend, triage, coder, review, fix, retro, prioritize, e2e`;
     }
   }
   for (const agent of cfg.agents ?? []) {
     if (!VALID_ROLES.has(agent.role)) {
-      return `invalid agent role ${JSON.stringify(agent.role)}: must be one of fullsend, triage, coder, review`;
+      return `invalid agent role ${JSON.stringify(agent.role)}: must be one of fullsend, triage, coder, review, fix, retro, prioritize, e2e`;
     }
   }
   return null;


### PR DESCRIPTION
## Summary

- Add missing `fix`, `retro`, `prioritize`, and `e2e` roles to `VALID_ROLES` in `web/admin/src/lib/layers/orgConfigParse.ts`, matching Go's `ValidRoles()`
- Update both error messages to list all 8 valid roles
- Add parameterized test covering all 8 roles to prevent future drift

Closes #2528

## Test plan

- [x] `vitest run orgConfigParse.test.ts` — 18/18 pass (8 parameterized role tests + 10 existing)
- [x] Live browser verification via Vite dev server console: all 8 roles return VALID, invalid role correctly rejected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)