### PR TITLE
fix(#6397): add missing status comment params to prioritize job

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1350,6 +1350,9 @@ jobs:
           agent: prioritize
           fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
           version: ${{ inputs.fullsend_version || job.workflow_sha }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status-repo: ${{ github.repository }}
+          status-number: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
           mint-url: ${{ inputs.mint_url }}
 
   harness-dispatch:

--- a/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
@@ -49,6 +49,7 @@ jobs:
       install_mode: per-repo
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+      project_number: ${{ vars.FULLSEND_PROJECT_NUMBER }}
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -782,6 +782,51 @@ func TestReusableDispatchPRHeadSHAPassthrough(t *testing.T) {
 	})
 }
 
+// TestReusableDispatchStatusCommentPassthrough validates that all agent jobs in
+// reusable-dispatch.yml pass run-url, status-repo, and status-number to the
+// action, enabling status comments for every stage (#6397).
+func TestReusableDispatchStatusCommentPassthrough(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "reusable-dispatch.yml"))
+	require.NoError(t, err)
+	s := string(content)
+
+	stages := []string{"triage", "code", "review", "fix", "retro", "prioritize"}
+	for _, stage := range stages {
+		t.Run(stage, func(t *testing.T) {
+			marker := fmt.Sprintf("Run %s agent", stage)
+			section := extractStepSection(t, s, marker)
+			assert.Contains(t, section, "run-url:",
+				"%s agent step must pass run-url to action.yml", stage)
+			assert.Contains(t, section, "status-repo:",
+				"%s agent step must pass status-repo to action.yml", stage)
+			assert.Contains(t, section, "status-number:",
+				"%s agent step must pass status-number to action.yml", stage)
+		})
+	}
+
+	t.Run("harness-run", func(t *testing.T) {
+		marker := "Run harness agent"
+		section := extractStepSection(t, s, marker)
+		assert.Contains(t, section, "run-url:",
+			"harness-run agent step must pass run-url to action.yml")
+		assert.Contains(t, section, "status-repo:",
+			"harness-run agent step must pass status-repo to action.yml")
+		assert.Contains(t, section, "status-number:",
+			"harness-run agent step must pass status-number to action.yml")
+	})
+}
+
+// TestShimPerRepoProjectNumberPassthrough validates that the per-repo shim
+// template passes project_number to reusable-dispatch.yml (#6397).
+func TestShimPerRepoProjectNumberPassthrough(t *testing.T) {
+	content := loadScaffoldFile("templates/shim-per-repo.yaml")(t)
+	s := string(content)
+	assert.Contains(t, s, "project_number:",
+		"per-repo shim must pass project_number to reusable-dispatch.yml")
+	assert.Contains(t, s, "vars.FULLSEND_PROJECT_NUMBER",
+		"per-repo shim project_number must read from vars.FULLSEND_PROJECT_NUMBER")
+}
+
 // TestShimLabeledEventFiltering validates that shim workflows use the ready-
 // prefix filter at the if: guard level and label-aware concurrency keys so
 // routing labels don't cancel each other (#2452).


### PR DESCRIPTION
## Summary

- Add `run-url`, `status-repo`, and `status-number` to the prioritize job's `with:` block in `reusable-dispatch.yml`, matching the pattern used by all other stage jobs (triage, code, review, fix, retro)
- Add `project_number` passthrough (`vars.FULLSEND_PROJECT_NUMBER`) to the per-repo shim template so per-repo installs can configure GitHub Projects V2 board integration for the prioritize agent
- Add regression tests: `TestReusableDispatchStatusCommentPassthrough` validates all stages (including prioritize and harness-run) pass status comment params; `TestShimPerRepoProjectNumberPassthrough` validates the shim forwards `project_number`

Closes #6397

## Test plan

- [x] `go test ./internal/scaffold/ -count=1` — all tests pass
- [x] New `TestReusableDispatchStatusCommentPassthrough` covers all 6 stages + harness-run
- [x] New `TestShimPerRepoProjectNumberPassthrough` validates shim template
- [x] Pre-commit hooks pass (yaml, pinact, actionlint, gofmt, govet)