### PR TITLE
chore: update fullsend per-repo installation

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -1,0 +1,33 @@
+# fullsend per-repo configuration
+# https://github.com/fullsend-ai/fullsend
+#
+# This file configures fullsend for per-repo installation mode.
+# See ADR 0033 for details.
+version: "1"
+runtime: claude
+roles:
+    - fullsend
+    - triage
+    - coder
+    - review
+    - retro
+    - prioritize
+agents:
+    - source: https://raw.githubusercontent.com/fullsend-ai/agents/816b89be3a8d129cb9305ae492d4af145d6ac25a/harness/triage.yaml#sha256=5943b5cb543289c6f49adbedec48c7a6c6a9def2414e99e32ab28fbddd04ef41
+    - source: https://raw.githubusercontent.com/fullsend-ai/agents/816b89be3a8d129cb9305ae492d4af145d6ac25a/harness/code.yaml#sha256=195193a356e61e9a5180ea56ee1313c7901df9ef74b15b0ca9205f32787f5042
+    - source: https://raw.githubusercontent.com/fullsend-ai/agents/816b89be3a8d129cb9305ae492d4af145d6ac25a/harness/fix.yaml#sha256=f95bfe44d6602a1ce9d8983aa88151f11c788af0e5dcce03811e92fb45a80513
+    - source: https://raw.githubusercontent.com/fullsend-ai/agents/816b89be3a8d129cb9305ae492d4af145d6ac25a/harness/review.yaml#sha256=f4255898011e3c171dab074479da9509b2c6c38c2aabc7f32f9a0a1f7ef5c183
+    - source: https://raw.githubusercontent.com/fullsend-ai/agents/816b89be3a8d129cb9305ae492d4af145d6ac25a/harness/retro.yaml#sha256=35c67a40611f86e126b72e6f5b901585ebe6298494bb327cf09015b549ee44fc
+    - source: https://raw.githubusercontent.com/fullsend-ai/agents/816b89be3a8d129cb9305ae492d4af145d6ac25a/harness/prioritize.yaml#sha256=fd0e89a74eb6cdff58f6e703a40ed54a9911ac2ac2328fd39804bf006f4200fa
+    - source: https://raw.githubusercontent.com/fullsend-ai/agents/816b89be3a8d129cb9305ae492d4af145d6ac25a/harness/scribe.yaml#sha256=3ac49476b414857058fa1142b77a64d93b3595551642fe9319456168f98bc749
+    - source: https://raw.githubusercontent.com/redhat-community-ai-tools/qualityflow-fullsend/f6311b4f30ee5c23c597dba07bccc8ac0aa991be/harness/qualityflow.yaml#sha256=c0a51b2f75172aebd577fd38c8012a7c566a84f84812ebd9aa4cc07ad3b2220e
+allowed_remote_resources:
+    - https://raw.githubusercontent.com/fullsend-ai/fullsend/
+    - https://raw.githubusercontent.com/fullsend-ai/agents/
+    - https://raw.githubusercontent.com/redhat-community-ai-tools/qualityflow-fullsend/
+create_issues:
+    allow_targets:
+        orgs:
+            - fullsend-ai
+        repos:
+            - fullsend-ai/fullsend

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -1,24 +1,22 @@
 # This file is managed by fullsend. Do not edit it directly.
-# Upstream: https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
+# Upstream: https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/.github/workflows/fullsend.yaml
 ---
-# --- fullsend managed below - do not edit ---
-# lint-workflow-size: max-lines=280
-# fullsend shim workflow (workflow_call mode)
-# Routes events to agent workflows in .fullsend via workflow_call.
-# No secrets are needed in the enrolled repo — agents fetch scoped tokens
-# from the centralized token mint using GitHub OIDC.
+# fullsend shim workflow (per-repo installation mode)
+# Routes events to agent workflows via reusable-dispatch.yml.
+# All agent execution happens in this repo's context — no external
+# config repo is needed.
 #
 # Security: pull_request_target runs the BASE branch version of this workflow,
 # preventing PRs from modifying it to exfiltrate credentials.
 # This shim never checks out PR code, so it is not vulnerable to "pwn request"
 # attacks.
 #
-# fullsend-ai is replaced by reconcile-repos.sh at deploy time.
+# Routing: this shim forwards the raw event context to reusable-dispatch.yml,
+# which determines the stage and runs the agent inline (ADR 62).
+# Adding a new stage requires only a job in reusable-dispatch.yml — zero changes to this repo.
 #
-# Routing: this shim forwards the raw event context to dispatch.yml, which
-# determines the stage from event_type + event_action + payload fields.
-# Adding a new stage requires only a case branch in dispatch.yml — zero
-# changes to enrolled repos.
+# Concurrency: per-role cancel-in-progress groups live in reusable-dispatch.yml
+# stage jobs with -agent- suffix. Roles operate independently (#2452).
 name: fullsend
 
 on:
@@ -35,31 +33,30 @@ permissions: {}
 
 jobs:
   dispatch:
-    concurrency:
-      # Label-derived suffix for labeled events so routing labels
-      # get isolated concurrency slots (#2452).
-      group: >-
-        fullsend-dispatch-${{ github.event.issue.number || github.event.pull_request.number }}-${{
-          github.event.action == 'labeled' && format('label-{0}', github.event.label.name) || 'dispatch'
-        }}
-      cancel-in-progress: false
     if: >-
       (github.event_name != 'pull_request_target' && github.event_name != 'pull_request_review'
        || github.event.pull_request.head.ref != 'fullsend/scaffold-install')
       && (github.event_name != 'issue_comment'
        || github.event.comment.user.type != 'Bot')
-      && (
-        github.event.action != 'labeled'
-        || startsWith(github.event.label.name, 'ready-')
-      )
     permissions:
       actions: write
       id-token: write
-      contents: read
-      pull-requests: read
-    uses: fullsend-ai/.fullsend/.github/workflows/dispatch.yml@main
+      contents: write
+      issues: write
+      packages: read
+      pull-requests: write
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@main
     with:
       event_action: ${{ github.event.action }}
+      install_mode: per-repo
+      mint_url: ${{ vars.FULLSEND_MINT_URL }}
+      gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+      runner_image: ubuntu-24.04
+    secrets:
+      FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
+      FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_TRACES_HEADERS }}
+      OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
 
   stop-fix:
     # Job-level if: is intentionally coarse — it only screens for the

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -841,7 +841,7 @@ func TestShimLabeledEventFiltering(t *testing.T) {
 	}
 
 	cases := []shimCase{
-		{"fullsend.yaml", loadRepoFile(".github/workflows/fullsend.yaml"), true},
+		{"fullsend.yaml", loadRepoFile(".github/workflows/fullsend.yaml"), false},
 		{"scaffold/shim-workflow-call.yaml", loadScaffoldFile("templates/shim-workflow-call.yaml"), true},
 		{"scaffold/shim-per-repo.yaml", loadScaffoldFile("templates/shim-per-repo.yaml"), false},
 	}


### PR DESCRIPTION
The default branch (main) has branch protection rules that prevent direct pushes.

Merge this PR to deliver the scaffold files.