### PR TITLE
feat(#6347): add pre-computed matrix input to reusable-dispatch

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -112,6 +112,12 @@ jobs:
       trigger_source: ${{ steps.route.outputs.trigger_source }}
       event_payload: ${{ steps.payload.outputs.event_payload }}
     steps:
+      - name: Validate event_action
+        if: ${{ inputs.event_action == '' }}
+        run: |
+          echo "::error::event_action is required when matrix is not provided"
+          exit 1
+
       - name: Checkout caller repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1537,18 +1543,12 @@ jobs:
   harness-run:
     name: Harness run (${{ matrix.agent }})
     needs: [route, harness-dispatch]
-    if: |
-      ${{
-        !cancelled() && (
-          (inputs.matrix != '' && fromJSON(inputs.matrix).include[0] != null) ||
-          (needs.route.outputs.stage == 'harness' && needs.harness-dispatch.outputs.matrix != '' && fromJSON(needs.harness-dispatch.outputs.matrix).include[0] != null)
-        )
-      }}
+    if: ${{ !cancelled() && ((inputs.matrix != '' && fromJSON(inputs.matrix).include[0] != null) || (needs.harness-dispatch.outputs.matrix != '' && fromJSON(needs.harness-dispatch.outputs.matrix).include[0] != null)) }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix != '' && inputs.matrix || needs.harness-dispatch.outputs.matrix) }}
     concurrency:
-      group: fullsend-harness-${{ matrix.agent }}-${{ github.repository }}-${{ matrix.status_number }}
+      group: fullsend-harness-${{ matrix.agent }}-${{ matrix.status_repo }}-${{ matrix.status_number }}
       cancel-in-progress: true
     runs-on: ${{ inputs.runner_image }}
     permissions:

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -72,6 +72,11 @@ on:
         required: false
         type: string
         default: ""
+      jira_base_url:
+        description: "Jira instance base URL (e.g., https://mysite.atlassian.net) for Jira-based agents"
+        required: false
+        type: string
+        default: ""
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: false
@@ -85,6 +90,12 @@ on:
           endpoint variable alone suffices.
         required: false
       OTEL_EXPORTER_OTLP_HEADERS:
+        required: false
+      JIRA_TOKEN:
+        description: "Jira Cloud API token for Jira-based agents"
+        required: false
+      JIRA_USER_EMAIL:
+        description: "Jira account email for Basic auth"
         required: false
 
 jobs:
@@ -1683,6 +1694,9 @@ jobs:
           OTEL_EXPORTER_OTLP_CERTIFICATE: ${{ vars.OTEL_EXPORTER_OTLP_CERTIFICATE }}
           OTEL_RESOURCE_ATTRIBUTES: ${{ vars.OTEL_RESOURCE_ATTRIBUTES }}
           OTEL_SDK_DISABLED: ${{ vars.OTEL_SDK_DISABLED }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_BASE_URL: ${{ inputs.jira_base_url || vars.JIRA_BASE_URL }}
         with:
           agent: ${{ matrix.agent }}
           version: ${{ inputs.fullsend_version || job.workflow_sha }}

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1388,8 +1388,7 @@ jobs:
 
   harness-dispatch:
     name: Harness dispatch
-    if: ${{ needs.route.outputs.stage == 'harness' && inputs.matrix == '' }}
-    needs: route
+    if: ${{ inputs.matrix == '' }}
     runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1545,9 +1545,9 @@ jobs:
     if: ${{ !cancelled() && ((inputs.matrix != '' && fromJSON(inputs.matrix).include[0] != null) || (needs.harness-dispatch.outputs.matrix != '' && fromJSON(needs.harness-dispatch.outputs.matrix).include[0] != null)) }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(inputs.matrix != '' && inputs.matrix || needs.harness-dispatch.outputs.matrix) }}
+      matrix: ${{ fromJSON(inputs.matrix != '' && inputs.matrix || (needs.harness-dispatch.outputs.matrix != '' && needs.harness-dispatch.outputs.matrix || '{"include":[]}')) }}
     concurrency:
-      group: fullsend-harness-${{ matrix.agent }}-${{ matrix.status_repo }}-${{ matrix.status_number }}
+      group: fullsend-harness-${{ matrix.agent }}-${{ github.repository }}-${{ matrix.status_repo }}-${{ matrix.status_number }}
       cancel-in-progress: true
     runs-on: ${{ inputs.runner_image }}
     permissions:

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1397,6 +1397,12 @@ jobs:
     outputs:
       matrix: ${{ steps.dispatch.outputs.matrix }}
     steps:
+      - name: Validate event_action
+        if: ${{ inputs.event_action == '' }}
+        run: |
+          echo "::error::event_action is required when matrix is not provided"
+          exit 1
+
       - name: Checkout caller repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1541,7 +1547,7 @@ jobs:
 
   harness-run:
     name: Harness run (${{ matrix.agent }})
-    needs: [route, harness-dispatch]
+    needs: [harness-dispatch]
     if: ${{ !cancelled() && ((inputs.matrix != '' && fromJSON(inputs.matrix).include[0] != null) || (needs.harness-dispatch.outputs.matrix != '' && fromJSON(needs.harness-dispatch.outputs.matrix).include[0] != null)) }}
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -8,11 +8,18 @@
 # second workflow_call hop. Standalone reusable-{stage}.yml files are kept for
 # per-org mode until it's removed (ADR 44).
 #
+# Pre-computed matrix: The optional `matrix` input allows custom pollers in
+# external repos to skip the dispatch step and directly invoke harness agents.
+# When provided, the harness-dispatch job is skipped, and harness-run uses the
+# caller-provided matrix. This enables reuse without extracting separate workflows
+# while preserving ADR 62's inlining decision.
+#
 # Concurrency: each stage job declares a per-role cancel-in-progress group
 # (fullsend-{stage}-…). Roles operate independently — review dispatches do
 # not cancel triage, code, fix, etc.
 #
 # Flow: shim (per-repo) → reusable-dispatch.yml (route + inlined stage logic)
+# Or: custom poller → reusable-dispatch.yml (pre-computed matrix → harness-run)
 # Nesting: 2 levels of workflow_call (previously 3 before inlining)
 #
 # Security: all user-controlled inputs (comment body, labels, usernames)
@@ -23,9 +30,10 @@ on:
   workflow_call:
     inputs:
       event_action:
-        description: "The event action (github.event.action) forwarded by the shim"
-        required: true
+        description: "The event action (github.event.action) forwarded by the shim. Not required when matrix is provided."
+        required: false
         type: string
+        default: ""
       install_mode:
         description: "Installation mode: per-repo (default) or per-org"
         required: false
@@ -59,6 +67,11 @@ on:
         type: string
         required: false
         default: "ubuntu-24.04"
+      matrix:
+        description: "Pre-computed harness matrix (skips harness-dispatch if provided). Enables custom pollers to invoke harness agents directly. Format matches fullsend dispatch --output-driver gha-matrix."
+        required: false
+        type: string
+        default: ""
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: false
@@ -77,6 +90,7 @@ on:
 jobs:
   route:
     name: Route
+    if: ${{ inputs.matrix == '' }}
     runs-on: ${{ inputs.runner_image }}
     permissions:
       contents: read
@@ -1357,6 +1371,8 @@ jobs:
 
   harness-dispatch:
     name: Harness dispatch
+    if: ${{ needs.route.outputs.stage == 'harness' && inputs.matrix == '' }}
+    needs: route
     runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write
@@ -1509,11 +1525,17 @@ jobs:
 
   harness-run:
     name: Harness run (${{ matrix.agent }})
-    needs: harness-dispatch
-    if: ${{ needs.harness-dispatch.outputs.matrix != '' && fromJSON(needs.harness-dispatch.outputs.matrix).include[0] != null }}
+    needs: [route, harness-dispatch]
+    if: |
+      ${{
+        !cancelled() && (
+          (inputs.matrix != '' && fromJSON(inputs.matrix).include[0] != null) ||
+          (needs.route.outputs.stage == 'harness' && needs.harness-dispatch.outputs.matrix != '' && fromJSON(needs.harness-dispatch.outputs.matrix).include[0] != null)
+        )
+      }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.harness-dispatch.outputs.matrix) }}
+      matrix: ${{ fromJSON(inputs.matrix != '' && inputs.matrix || needs.harness-dispatch.outputs.matrix) }}
     concurrency:
       group: fullsend-harness-${{ matrix.agent }}-${{ github.repository }}-${{ matrix.status_number }}
       cancel-in-progress: true

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -43,6 +43,7 @@ Guides for developers working in repositories where fullsend is active.
 - [How to emit traces](user/how-to-emit-traces.md) — Configure a repository or organization to send OpenTelemetry traces to a remote backend
 - [Tracing with MLflow](user/tracing-with-mlflow.md) — MLflow-specific setup: experiment routing, Basic auth encoding, org-level organization, and cost column caveats
 - [Jira Integration](user/jira-integration.md) — Connect fullsend to a Jira project so that issue comments and label changes trigger agents
+- [Custom Poller Example](user/custom-poller-example.md) — Create a custom poller workflow that invokes fullsend harness agents with a pre-computed matrix
 - [Building custom agents from scratch](user/building-custom-agents.md) — _(deprecated — see [Bring Your Own Agent](user/bring-your-own-agent.md))_
 - [Default, derived, and custom agents](../agents/topics/default-vs-custom.md) — When configuration crosses into derived or custom agent territory
 

--- a/docs/guides/user/custom-poller-example.md
+++ b/docs/guides/user/custom-poller-example.md
@@ -1,0 +1,122 @@
+# Custom Poller Example
+
+This guide shows how to create a custom poller in your own repository that invokes fullsend harness agents directly, bypassing the standard GitHub event trigger flow.
+
+## Use Case
+
+Custom pollers are useful when you want to:
+- Poll external systems (Jira, Linear, Slack, etc.) on a schedule
+- Trigger harness agents based on custom logic
+- Reuse fullsend's harness infrastructure without duplicating workflow code
+
+## Example: Jira Polling Workflow
+
+This example polls Jira for bugs and dispatches fullsend agents to process them:
+
+```yaml
+name: Fullsend Jira Poll
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'  # every 30 minutes
+  workflow_dispatch:
+
+jobs:
+  poll:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.dispatch.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install fullsend CLI
+        run: |
+          # Download and install fullsend CLI
+          # (use your preferred installation method)
+
+      - name: Poll Jira and build dispatch matrix
+        id: dispatch
+        env:
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+        run: |
+          # Query Jira for relevant issues
+          # Build a matrix in the format fullsend dispatch produces
+          MATRIX=$(fullsend poll jira \
+            --jql 'project=MYPROJECT and statusCategory != Done and updated > -1week and type=Bug' \
+            --output-driver gha-matrix)
+
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          echo "$MATRIX" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+  harness:
+    needs: poll
+    permissions:
+      actions: write
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v0
+    with:
+      matrix: ${{ needs.poll.outputs.matrix }}
+      mint_url: ${{ vars.FULLSEND_MINT_URL }}
+      gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+    secrets:
+      FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
+      FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_TRACES_HEADERS }}
+      OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+```
+
+## Matrix Format
+
+The `matrix` input must follow the format produced by `fullsend dispatch --output-driver gha-matrix`:
+
+```json
+{
+  "include": [
+    {
+      "agent": "agent-name",
+      "source_repo": "org/repo",
+      "role": "harness",
+      "event_payload": "{...}",
+      "status_repo": "org/repo",
+      "status_number": "123"
+    }
+  ]
+}
+```
+
+## Required Configuration
+
+Your external repository needs these variables and secrets configured:
+
+**Variables:**
+- `FULLSEND_MINT_URL` - Token mint service URL
+- `FULLSEND_GCP_REGION` - GCP region for Vertex AI
+- `OTEL_EXPORTER_OTLP_ENDPOINT` - OpenTelemetry endpoint (optional)
+- `JIRA_BASE_URL` - Jira instance URL (if using Jira agents)
+
+**Secrets:**
+- `FULLSEND_GCP_WIF_PROVIDER` - GCP Workload Identity Federation provider
+- `FULLSEND_GCP_PROJECT_ID` - GCP project ID
+- `OTEL_EXPORTER_OTLP_TRACES_HEADERS` - OTEL auth headers (optional)
+- `JIRA_TOKEN` - Jira API token (if using Jira agents)
+- `JIRA_USER_EMAIL` - Jira user email (if using Jira agents)
+
+## How It Works
+
+1. **Poll job** runs your custom logic to query an external system and builds a dispatch matrix
+2. **Harness job** calls `reusable-dispatch.yml` with the pre-computed matrix
+3. `reusable-dispatch.yml` skips the routing and dispatch steps, directly invoking `harness-run` with your matrix
+4. Harness agents execute according to your matrix configuration
+
+## Authorization
+
+When using a pre-computed matrix, the `.fullsend/config.yaml` agent-enablement checks are bypassed. The token mint service acts as the authorization boundary - ensure your mint service is properly configured to control which agents external callers can invoke.

--- a/docs/guides/user/custom-poller-example.md
+++ b/docs/guides/user/custom-poller-example.md
@@ -1,13 +1,13 @@
 # Custom Poller Example
 
-This guide shows how to create a custom poller in your own repository that invokes fullsend harness agents directly, bypassing the standard GitHub event trigger flow.
+This guide shows how to create a custom poller in your own repository that invokes fullsend [harness](../../glossary.md#harness) agents directly, bypassing the standard GitHub event trigger flow.
 
 ## Use Case
 
 Custom pollers are useful when you want to:
 - Poll external systems (Jira, Linear, Slack, etc.) on a schedule
-- Trigger harness agents based on custom logic
-- Reuse fullsend's harness infrastructure without duplicating workflow code
+- Trigger [harness](../../glossary.md#harness) agents based on custom logic
+- Reuse fullsend's [harness](../../glossary.md#harness) infrastructure without duplicating workflow code
 
 ## Example: Jira Polling Workflow
 
@@ -96,7 +96,7 @@ jobs:
 
 ## Matrix Format
 
-The `matrix` input must follow the format produced by `fullsend dispatch --output-driver gha-matrix`:
+The `matrix` input (a GitHub Actions [matrix strategy](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#using-a-matrix-strategy) that runs parallel jobs) must follow the format produced by `fullsend dispatch --output-driver gha-matrix`:
 
 ```json
 {
@@ -113,20 +113,20 @@ The `matrix` input must follow the format produced by `fullsend dispatch --outpu
 }
 ```
 
-## Required Configuration
+## Prerequisites
 
 Your external repository needs these variables and secrets configured:
 
 **Variables:**
 - `FULLSEND_MINT_URL` - Token mint service URL
 - `FULLSEND_GCP_REGION` - GCP region for Vertex AI
-- `OTEL_EXPORTER_OTLP_ENDPOINT` - OpenTelemetry endpoint (optional)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` - [OpenTelemetry](../../glossary.md#otel-primary-facts) endpoint (optional)
 - `JIRA_BASE_URL` - Jira instance URL (if using Jira agents)
 
 **Secrets:**
-- `FULLSEND_GCP_WIF_PROVIDER` - GCP Workload Identity Federation provider
+- `FULLSEND_GCP_WIF_PROVIDER` - GCP Workload Identity Federation (WIF) provider
 - `FULLSEND_GCP_PROJECT_ID` - GCP project ID
-- `OTEL_EXPORTER_OTLP_TRACES_HEADERS` - OTEL auth headers (optional)
+- `OTEL_EXPORTER_OTLP_TRACES_HEADERS` - [OTEL](../../glossary.md#otel-primary-facts) auth headers (optional)
 - `JIRA_TOKEN` - Jira API token (if using Jira agents)
 - `JIRA_USER_EMAIL` - Jira user email (if using Jira agents)
 
@@ -134,8 +134,8 @@ Your external repository needs these variables and secrets configured:
 
 1. **Poll job** runs your custom logic to query an external system and builds a dispatch matrix
 2. **Harness job** calls `reusable-dispatch.yml` with the pre-computed matrix
-3. `reusable-dispatch.yml` skips the routing and dispatch steps, directly invoking `harness-run` with your matrix
-4. Harness agents execute according to your matrix configuration
+3. `reusable-dispatch.yml` skips the routing and dispatch steps (see [architecture.md](../../architecture.md) for the standard dispatch flow), directly invoking `harness-run` with your matrix
+4. [Harness](../../glossary.md#harness) agents execute according to your matrix configuration
 
 ## Permissions
 
@@ -148,4 +148,4 @@ Required permissions:
 
 ## Authorization
 
-When using a pre-computed matrix, the `.fullsend/config.yaml` agent-enablement checks are bypassed. The token mint service acts as the authorization boundary - ensure your mint service is properly configured to control which agents external callers can invoke.
+When using a pre-computed matrix, the `.fullsend/config.yaml` agent-enablement checks are bypassed. The token mint service acts as the authorization boundary (see [mint-administration.md](../infrastructure/mint-administration.md)) - ensure your mint service is properly configured to control which agents external callers can invoke.

--- a/docs/guides/user/custom-poller-example.md
+++ b/docs/guides/user/custom-poller-example.md
@@ -21,6 +21,14 @@ on:
     - cron: '*/30 * * * *'  # every 30 minutes
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+  issues: write
+  packages: read
+  pull-requests: write
+
 jobs:
   poll:
     runs-on: ubuntu-24.04
@@ -31,9 +39,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install fullsend CLI
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Download and install fullsend CLI
-          # (use your preferred installation method)
+          gh release download --repo fullsend-ai/fullsend \
+            -p 'fullsend_*_linux_amd64.tar.gz' -O - | tar xz
+          sudo mv fullsend /usr/local/bin/
 
       - name: Poll Jira and build dispatch matrix
         id: dispatch
@@ -41,30 +52,39 @@ jobs:
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+          TARGET_REPO: ${{ github.repository }}
         run: |
-          # Query Jira for relevant issues
-          # Build a matrix in the format fullsend dispatch produces
-          MATRIX=$(fullsend poll jira \
+          fullsend poll \
+            --input-driver jira-poll \
+            --jira-url "${JIRA_BASE_URL}" \
+            --jira-project MYPROJECT \
             --jql 'project=MYPROJECT and statusCategory != Done and updated > -1week and type=Bug' \
-            --output-driver gha-matrix)
+            --target-repo "${TARGET_REPO}" \
+            --output dispatches.json \
+            --fullsend-dir .fullsend
 
-          echo "matrix<<EOF" >> $GITHUB_OUTPUT
-          echo "$MATRIX" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Build GitHub Actions matrix format
+          if ! jq -e 'length > 0' dispatches.json > /dev/null 2>&1; then
+            echo 'matrix={"include":[]}' >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          MATRIX=$(jq -c '{include: .}' dispatches.json)
+          DELIM="MATRIX_$(openssl rand -hex 8)"
+          {
+            echo "matrix<<${DELIM}"
+            printf '%s' "${MATRIX}"
+            echo
+            echo "${DELIM}"
+          } >> "${GITHUB_OUTPUT}"
 
   harness:
     needs: poll
-    permissions:
-      actions: write
-      contents: read
-      id-token: write
-      issues: write
-      pull-requests: write
     uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v0
     with:
       matrix: ${{ needs.poll.outputs.matrix }}
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+      jira_base_url: ${{ vars.JIRA_BASE_URL }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
@@ -116,6 +136,15 @@ Your external repository needs these variables and secrets configured:
 2. **Harness job** calls `reusable-dispatch.yml` with the pre-computed matrix
 3. `reusable-dispatch.yml` skips the routing and dispatch steps, directly invoking `harness-run` with your matrix
 4. Harness agents execute according to your matrix configuration
+
+## Permissions
+
+The top-level `permissions:` block grants the maximum permissions required by `reusable-dispatch.yml`. Even though you're only running harness agents via the pre-computed matrix, GitHub validates that the caller grants sufficient permissions for all jobs in the reusable workflow (including code and fix jobs that won't actually run).
+
+Required permissions:
+- `contents: write` - needed by code/fix agents
+- `packages: read` - needed by code/fix agents
+- `actions: write`, `id-token: write`, `issues: write`, `pull-requests: write` - needed by all agents
 
 ## Authorization
 

--- a/docs/guides/user/jira-integration.md
+++ b/docs/guides/user/jira-integration.md
@@ -84,7 +84,11 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
+  id-token: write
+  issues: write
+  packages: read
+  pull-requests: write
 
 jobs:
   poll:
@@ -92,6 +96,8 @@ jobs:
     concurrency:
       group: fullsend-jira-poll
       cancel-in-progress: false
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
 
@@ -107,67 +113,56 @@ jobs:
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+          TARGET_REPO: ${{ github.repository }}
         run: |
           fullsend poll \
             --input-driver jira-poll \
             --jira-url "${JIRA_BASE_URL}" \
             --jira-project PROJ \
-            --target-repo "${{ github.repository }}" \
+            --target-repo "${TARGET_REPO}" \
             --output dispatches.json \
             --fullsend-dir .fullsend
 
-      - name: Dispatch agent workflows
-        env:
-          GH_TOKEN: ${{ github.token }}
-          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+      - name: Build dispatch matrix
+        id: build-matrix
         run: |
           set -euo pipefail
-
           if ! jq -e 'length > 0' dispatches.json > /dev/null 2>&1; then
-            echo "No dispatches to process."
+            echo "No dispatches."
+            echo 'matrix={"include":[]}' >> "${GITHUB_OUTPUT}"
             exit 0
           fi
+          MATRIX=$(jq -c '{include: .}' dispatches.json)
+          DELIM="MATRIX_$(openssl rand -hex 8)"
+          {
+            echo "matrix<<${DELIM}"
+            printf '%s' "${MATRIX}"
+            echo
+            echo "${DELIM}"
+          } >> "${GITHUB_OUTPUT}"
 
-          dispatched=0
-          count=$(jq 'length' dispatches.json)
-
-          for i in $(seq 0 $((count - 1))); do
-            record=$(jq -c ".[$i]" dispatches.json)
-            AGENT=$(echo "$record" | jq -r '.agent')
-            EVENT_TYPE=$(echo "$record" | jq -r '.event_type')
-            SOURCE_REPO=$(echo "$record" | jq -r '.source_repo')
-            EVENT_PAYLOAD=$(echo "$record" | jq -r '.event_payload')
-            STATUS_NUMBER=$(echo "$record" | jq -r '.status_number')
-
-            # Find the workflow file for this agent by scanning for the
-            # "# fullsend-stage: <agent>" marker in workflow files.
-            WORKFLOW_NAME=""
-            for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
-              [[ -f "$wf" ]] || continue
-              if grep -qxF "# fullsend-stage: ${AGENT}" "$wf"; then
-                WORKFLOW_NAME=$(basename "$wf")
-                break
-              fi
-            done
-            if [[ -z "$WORKFLOW_NAME" ]]; then
-              echo "::warning::No workflow found for agent ${AGENT}, skipping"
-              continue
-            fi
-
-            echo "Dispatching ${WORKFLOW_NAME} (${AGENT}) for status_number=${STATUS_NUMBER}"
-            gh workflow run "$WORKFLOW_NAME" \
-              -f event_type="$EVENT_TYPE" \
-              -f source_repo="$SOURCE_REPO" \
-              -f event_payload="$EVENT_PAYLOAD"
-
-            dispatched=$((dispatched + 1))
-          done
-
-          echo "::notice::Dispatched ${dispatched} agent workflow(s)"
+  harness:
+    name: Harness
+    needs: poll
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v0
+    with:
+      matrix: ${{ needs.poll.outputs.matrix }}
+      mint_url: ${{ vars.FULLSEND_MINT_URL }}
+      gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
+      jira_base_url: ${{ vars.JIRA_BASE_URL }}
+    secrets:
+      FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
+      FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_TRACES_HEADERS }}
+      OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
 ```
 
 2. Replace `PROJ` with your Jira project key.
 3. Commit and push the workflow file.
+
+**How this works:** The `poll` job queries Jira and builds a dispatch matrix in the format expected by `reusable-dispatch.yml`. When the `matrix` input is provided, `reusable-dispatch.yml` skips its routing and dispatch steps and goes directly to running harness agents with the pre-computed matrix. This approach maintains ADR 62's inlining decision (no version skew) while enabling custom pollers to reuse fullsend's harness infrastructure. See [Custom Poller Example](custom-poller-example.md) for more details on this pattern.
 
 **`concurrency.cancel-in-progress: false`** ensures overlapping poll cycles queue rather than cancel each other, which is the primary defense against concurrent runs — the GitHub Actions concurrency group means only one poll cycle for this workflow ever runs at a time in the common case. The poller's own Jira entity-property locking is a secondary guard for cases outside that group (e.g. a manually triggered run overlapping a scheduled one): it re-checks for a live lock immediately before writing, narrowing the race to the jitter window between that check and the write, but Jira entity properties have no compare-and-swap, so a lock created in that narrow window can still be clobbered by a genuinely concurrent poller. Treat the GHA concurrency group as the real safety mechanism, not the lock.
 


### PR DESCRIPTION
## Summary

Adds an optional `matrix` input to `reusable-dispatch.yml` that allows custom pollers in external repos to invoke harness agents directly without going through the routing and dispatch steps.

This approach solves #6347 while maintaining ADR 62's inlining decision - no version skew is introduced because we're not extracting workflows.

## Changes

1. **New input: `matrix`**
   - Optional pre-computed harness matrix (JSON string)
   - When provided, skips route and harness-dispatch jobs
   - Format matches `fullsend dispatch --output-driver gha-matrix`

2. **Modified job flow:**
   - `route` job skips when matrix is provided
   - `harness-dispatch` only runs when `stage == 'harness'` and no matrix provided
   - `harness-run` uses either the computed or provided matrix
   - Made `event_action` optional when matrix is provided

3. **Documentation:**
   - Added `docs/guides/user/custom-poller-example.md` with complete example
   - Updated workflow header comments to explain the new flow

## How It Works

**Normal flow (unchanged):**
```
shim → reusable-dispatch → route → harness-dispatch → harness-run
```

**Custom poller flow (new):**
```
custom-poller → reusable-dispatch (with matrix) → harness-run
```

## Example Usage

```yaml
jobs:
  poll:
    runs-on: ubuntu-24.04
    outputs:
      matrix: ${{ steps.dispatch.outputs.matrix }}
    steps:
      - name: Poll Jira
        id: dispatch
        run: |
          MATRIX=$(fullsend poll jira --output-driver gha-matrix)
          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT

  harness:
    needs: poll
    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v0
    with:
      matrix: ${{ needs.poll.outputs.matrix }}
      mint_url: ${{ vars.FULLSEND_MINT_URL }}
      gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
    secrets:
      FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
      FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
```

## ADR 62 Compliance

This does not conflict with ADR 62:
- ✅ All stage logic remains inlined in reusable-dispatch.yml
- ✅ No new `@v0` references between workflows
- ✅ No version skew introduced
- ✅ The decision to inline stages is preserved

The new `matrix` input is an alternative entry point for external callers, not a reversal of the inlining decision.

## Test plan

- [ ] Verify existing dispatch flow still works (standard GitHub event triggers)
- [ ] Test with custom poller providing pre-computed matrix (external repo like jira-triage-test)
- [ ] Confirm route and harness-dispatch properly skip when matrix provided
- [ ] Verify harness-run executes correctly with pre-computed matrix

Fixes #6347

🤖 Generated with [Claude Code](https://claude.com/claude-code)