### PR TITLE
ci: trigger scaffold sync on every push to main

### DIFF
--- a/.github/workflows/notify-scaffold-sync.yml
+++ b/.github/workflows/notify-scaffold-sync.yml
@@ -14,6 +14,8 @@
 name: Notify Scaffold Sync
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add `push` trigger on `main` to the `notify-scaffold-sync` workflow so it fires automatically on every merge, not just via manual `workflow_dispatch`.

## Test plan
- [ ] Verify the workflow appears in the Actions tab after merge
- [ ] Merge a test PR and confirm the scaffold sync dispatch fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)