### PR TITLE
feat(review): route trivial diffs to a cheaper model

### DIFF
--- a/.github/scripts/route-review-model-test.sh
+++ b/.github/scripts/route-review-model-test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# route-review-model-test.sh — Tests for route-review-model.sh.
+#
+# `gh` is stubbed so the script's real logic runs against a controlled file
+# list. The classifier is exercised through the script itself rather than a
+# copy, so the tests cannot drift from what ships.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/route-review-model.sh"
+
+FAILURES=0
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+# run <files-json-lines> [env assignments...] -> echoes the FULLSEND_MODEL
+# line the script exported, or "" when it left the model alone.
+run() {
+  local files="$1"
+  shift
+  local dir
+  dir="$(mktemp -d "${TMPROOT}/case.XXXXXX")"
+
+  # Stub gh: prints the supplied file list, ignores its arguments.
+  printf '#!/usr/bin/env bash\ncat <<'\''PAYLOAD'\''\n%s\nPAYLOAD\n' "${files}" >"${dir}/gh"
+  chmod +x "${dir}/gh"
+
+  : >"${dir}/env"
+  ( PATH="${dir}:${PATH}" \
+    GH_TOKEN=x SOURCE_REPO=o/r PR_NUMBER=1 \
+    GITHUB_ENV="${dir}/env" GITHUB_STEP_SUMMARY="${dir}/summary" \
+    env "$@" bash "${SCRIPT}" >"${dir}/out" 2>&1 )
+  local rc=$?
+  if [[ ${rc} -ne 0 ]]; then
+    echo "SCRIPT_EXIT_${rc}"
+    return
+  fi
+  grep '^FULLSEND_MODEL=' "${dir}/env" 2>/dev/null | tail -1 || true
+}
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "${actual}" == "${expected}" ]]; then
+    echo "PASS: ${name}"
+  else
+    echo "FAIL: ${name}"
+    echo "      expected: '${expected}'"
+    echo "      actual:   '${actual}'"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+DATA='{"filename":"versions.json","status":"modified","changes":2}'
+CODE='{"filename":"internal/cli/run.go","status":"modified","changes":2}'
+WORKFLOW='{"filename":".github/workflows/ci.yml","status":"modified","changes":2}'
+LOCKFILE='{"filename":"package-lock.json","status":"modified","changes":2}'
+ADDED='{"filename":"config/new.yaml","status":"added","changes":2}'
+RENAMED='{"filename":"config/old.yaml","status":"renamed","changes":2}'
+SKILL='{"filename":"skills/pr-review/SKILL.md","status":"modified","changes":2}'
+BIG='{"filename":"versions.json","status":"modified","changes":40}'
+
+# The case from #5777: a one-line versions.json bump that cost $0.40 on Opus.
+check "trivial data edit routes to the cheap model" \
+  "FULLSEND_MODEL=sonnet" "$(run "${DATA}")"
+
+# Code is never trivial, however small.
+check "code is never trivial" "" "$(run "${CODE}")"
+
+# A small YAML edit under .github/ is a CI change, not a value edit.
+check "workflow files are not trivial" "" "$(run "${WORKFLOW}")"
+
+# npm resolves from the lockfile: a one-line integrity swap is a
+# supply-chain change wearing a trivial diff.
+check "lockfiles are not trivial" "" "$(run "${LOCKFILE}")"
+
+# Structural changes are not value edits even when they are small.
+check "an added file is not trivial" "" "$(run "${ADDED}")"
+check "a renamed file is not trivial" "" "$(run "${RENAMED}")"
+
+# Agent-behaviour markdown is executable instruction, not prose data.
+check "skills markdown is not trivial" "" "$(run "${SKILL}")"
+
+# One offending file poisons an otherwise trivial diff.
+check "a mixed diff is not trivial" "" "$(run "${DATA}
+${CODE}")"
+
+# Size gate.
+check "a large data edit is not trivial" "" "$(run "${BIG}")"
+check "the threshold is configurable upward" \
+  "FULLSEND_MODEL=sonnet" "$(run "${BIG}" TRIVIAL_MAX_LINES=100)"
+
+# Several small data files still add up.
+check "line counts accumulate across files" "" \
+  "$(run '{"filename":"a.yaml","status":"modified","changes":6}
+{"filename":"b.yaml","status":"modified","changes":6}')"
+
+# Opt-out and model selection.
+check "routing can be disabled" "" "$(run "${DATA}" TRIVIAL_MODEL=off)"
+check "the target model is configurable" \
+  "FULLSEND_MODEL=haiku" "$(run "${DATA}" TRIVIAL_MODEL=haiku)"
+
+# Never fail the review over cost routing: a malformed threshold, an empty
+# diff, or an unreadable file list all leave the harness model standing.
+check "a non-numeric threshold is ignored" "" "$(run "${DATA}" TRIVIAL_MAX_LINES=abc)"
+check "an empty file list changes nothing" "" "$(run "")"
+check "a missing PR number changes nothing" "" "$(run "${DATA}" PR_NUMBER=)"
+
+echo
+if [[ ${FAILURES} -eq 0 ]]; then
+  echo "All route-review-model tests passed"
+else
+  echo "${FAILURES} test(s) failed"
+  exit 1
+fi

--- a/.github/scripts/route-review-model.sh
+++ b/.github/scripts/route-review-model.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# route-review-model.sh — Route a trivial diff to a cheaper review model.
+#
+# Author type is a proxy for complexity, not complexity itself: a one-line
+# human edit to versions.json costs the same as a refactor when the model is
+# fixed by the harness. This classifies the diff and, when it is trivial,
+# exports FULLSEND_MODEL so the review runs on a cheaper tier. See #5777.
+#
+# Inputs (env vars):
+#   GH_TOKEN           — GitHub token for API calls
+#   SOURCE_REPO        — Repository in owner/repo format
+#   PR_NUMBER          — Pull request number
+#   TRIVIAL_MODEL      — Model to route trivial diffs to. "off"/"none"/empty
+#                        disables routing entirely. Default: sonnet
+#   TRIVIAL_MAX_LINES  — Upper bound on additions+deletions. Default: 10
+#   GITHUB_ENV         — Set by Actions; the export target
+#
+# Always exits 0. Cost routing must never be the reason a review fails to
+# run: every uncertain path leaves the model untouched, which means the
+# harness default (the more capable model) stands.
+#
+# Precedence: this runs *before* setup-agent-env.sh, which re-exports
+# FULLSEND_MODEL from the REVIEW_FULLSEND_MODEL / FULLSEND_MODEL repository
+# variables. A repo that pins a model therefore keeps it — explicit
+# configuration outranks inferred routing.
+
+set -euo pipefail
+
+TRIVIAL_MODEL="${TRIVIAL_MODEL:-sonnet}"
+TRIVIAL_MAX_LINES="${TRIVIAL_MAX_LINES:-10}"
+
+case "${TRIVIAL_MODEL}" in
+  "" | off | none | false)
+    echo "Complexity-based model routing disabled (TRIVIAL_MODEL=${TRIVIAL_MODEL:-unset})"
+    exit 0
+    ;;
+esac
+
+if [[ ! "${TRIVIAL_MAX_LINES}" =~ ^[0-9]+$ ]]; then
+  echo "::warning::REVIEW_TRIVIAL_MAX_LINES is not a number (${TRIVIAL_MAX_LINES}) — leaving the model unchanged"
+  exit 0
+fi
+
+if [[ -z "${PR_NUMBER:-}" || "${PR_NUMBER}" == "null" ]]; then
+  exit 0
+fi
+
+# jq classifier. Kept as one program so the whole verdict is computed from a
+# single pass over the file list, and so the test can exercise exactly what
+# ships rather than a paraphrase of it.
+#
+# A diff is trivial only when every changed file is:
+#   - status "modified" — an added, removed or renamed file is structural
+#     even when it is small, and a renamed config file is not a value edit;
+#   - a data/config extension — code is never trivial regardless of size;
+#   - not a dependency lockfile — npm resolves from the lockfile, so a
+#     one-line integrity swap is a supply-chain change wearing a trivial
+#     diff, and is the last thing to review on a cheaper model;
+#   - not a path that executes or governs — anything under a dot directory
+#     (.github/, .claude/), scripts/, hack/, or the agent-behaviour and
+#     policy trees, plus root files like CODEOWNERS and Dockerfile. This is
+#     deliberately a subset of REVIEW_PROTECTED_PATHS: that list decides
+#     whether a review may auto-approve, this one decides whether a cheaper
+#     model may form the opinion.
+read -r -d '' JQ_CLASSIFIER <<'JQEOF' || true
+def is_data:    test("\\.(json|ya?ml|toml|txt|md|ini|cfg|conf|properties)$"; "i");
+def is_lock:    test("(^|/)(package-lock\\.json|yarn\\.lock|pnpm-lock\\.yaml|npm-shrinkwrap\\.json|go\\.sum|Cargo\\.lock|Gemfile\\.lock|poetry\\.lock|composer\\.lock)$"; "i");
+def is_guarded: test("(^|/)\\.[^/]+/") or test("^(scripts|hack|agents|skills|harness|images|plugins|policies|profiles|providers|api-servers)/")
+                or test("^(CODEOWNERS|AGENTS\\.md|CLAUDE\\.md|Dockerfile|Containerfile)$");
+{
+  files: length,
+  total: (map(.changes // 0) | add // 0),
+  blockers: [
+    .[]
+    | select(
+        (.status != "modified")
+        or ((.filename | is_data) | not)
+        or (.filename | is_lock)
+        or (.filename | is_guarded)
+      )
+    | .filename
+  ],
+}
+JQEOF
+
+if ! FILES_JSON=$(gh api "repos/${SOURCE_REPO}/pulls/${PR_NUMBER}/files" \
+  --paginate -F per_page=100 --jq '{filename, status, changes}' 2>/dev/null); then
+  echo "::warning::Could not read changed files for PR #${PR_NUMBER} — leaving the model unchanged"
+  exit 0
+fi
+
+if [[ -z "${FILES_JSON}" ]]; then
+  exit 0
+fi
+
+if ! VERDICT=$(printf '%s\n' "${FILES_JSON}" | jq -s "${JQ_CLASSIFIER}" 2>/dev/null); then
+  echo "::warning::Could not classify the diff for PR #${PR_NUMBER} — leaving the model unchanged"
+  exit 0
+fi
+
+FILE_COUNT=$(jq -r '.files' <<<"${VERDICT}")
+TOTAL_LINES=$(jq -r '.total' <<<"${VERDICT}")
+BLOCKERS=$(jq -r '.blockers | join(", ")' <<<"${VERDICT}")
+
+# GitHub caps this endpoint at 3000 files and stops paginating without
+# erroring, so a larger PR would look small from a truncated head.
+if ((FILE_COUNT >= 3000)); then
+  echo "PR #${PR_NUMBER} file list may be truncated — leaving the model unchanged"
+  exit 0
+fi
+
+if [[ -n "${BLOCKERS}" ]]; then
+  echo "Not trivial: ${BLOCKERS}"
+  exit 0
+fi
+
+if ((TOTAL_LINES >= TRIVIAL_MAX_LINES)); then
+  echo "Not trivial: ${TOTAL_LINES} lines changed (threshold ${TRIVIAL_MAX_LINES})"
+  exit 0
+fi
+
+echo "FULLSEND_MODEL=${TRIVIAL_MODEL}" >>"${GITHUB_ENV}"
+SUMMARY="Review model routed to \`${TRIVIAL_MODEL}\`: ${TOTAL_LINES} line(s) changed across ${FILE_COUNT} data file(s), all value edits."
+echo "${SUMMARY}"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "${SUMMARY}" >>"${GITHUB_STEP_SUMMARY}"
+fi

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -910,6 +910,20 @@ jobs:
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
           fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
+      # Complexity-based model routing (#5777). Runs before the setup step
+      # below on purpose: setup-agent-env.sh re-exports FULLSEND_MODEL from
+      # the REVIEW_FULLSEND_MODEL / FULLSEND_MODEL repository variables, so a
+      # repo that pins a model keeps it — explicit configuration outranks an
+      # inferred route.
+      - name: Route trivial diffs to a cheaper review model
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.number || fromJSON(needs.route.outputs.event_payload).issue.number }}
+          TRIVIAL_MODEL: ${{ vars.REVIEW_TRIVIAL_MODEL }}
+          TRIVIAL_MAX_LINES: ${{ vars.REVIEW_TRIVIAL_MAX_LINES }}
+        run: bash .defaults/.github/scripts/route-review-model.sh
+
       - name: Setup agent environment
         env:
           AGENT_PREFIX: REVIEW_

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -160,6 +160,20 @@ jobs:
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
           fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
+      # Complexity-based model routing (#5777). Runs before the setup step
+      # below on purpose: setup-agent-env.sh re-exports FULLSEND_MODEL from
+      # the REVIEW_FULLSEND_MODEL / FULLSEND_MODEL repository variables, so a
+      # repo that pins a model keeps it — explicit configuration outranks an
+      # inferred route.
+      - name: Route trivial diffs to a cheaper review model
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ fromJSON(inputs.event_payload).pull_request.number || fromJSON(inputs.event_payload).issue.number }}
+          TRIVIAL_MODEL: ${{ vars.REVIEW_TRIVIAL_MODEL }}
+          TRIVIAL_MAX_LINES: ${{ vars.REVIEW_TRIVIAL_MAX_LINES }}
+        run: bash .defaults/.github/scripts/route-review-model.sh
+
       - name: Setup agent environment
         env:
           AGENT_PREFIX: REVIEW_

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ script-test:
 	$(call run-timed,bash scripts/check-e2e-authorization-test.sh)
 	$(call run-timed,bash scripts/redact-behaviour-artifacts-test.sh)
 	$(call run-timed,bash .github/scripts/check-fix-eligibility-test.sh)
+	$(call run-timed,bash .github/scripts/route-review-model-test.sh)
 	$(call run-timed,bash scripts/check-agents-gate-pin-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh)

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -88,6 +88,28 @@ In CI these are repository variables of the same name, plain or role-prefixed
 (`TRIAGE_FULLSEND_MODEL`), so a repo can switch one role's model without a pull request. Harness
 `env.runner` does **not** reach the `fullsend` process.
 
+### Trivial-diff routing for review
+
+The review agent routes provably trivial diffs to a cheaper model before the
+agent starts, so a one-line version bump does not cost what a refactor costs.
+A diff qualifies only when **every** changed file is a modified data/config
+file (`.json`, `.ya?ml`, `.toml`, `.txt`, `.md`, …) and the whole diff is under
+the line threshold. Added, removed and renamed files are structural rather than
+value edits; code, dependency lockfiles, and paths that execute or govern
+(anything under a dot directory, `scripts/`, `skills/`, `harness/`, `CODEOWNERS`,
+`Dockerfile`, …) never qualify, whatever their size.
+
+| Repository variable | Default | Meaning |
+|---|---|---|
+| `REVIEW_TRIVIAL_MODEL` | `sonnet` | Model for trivial diffs. `off` disables routing. |
+| `REVIEW_TRIVIAL_MAX_LINES` | `10` | Upper bound on additions + deletions. |
+
+An explicit `REVIEW_FULLSEND_MODEL` or `FULLSEND_MODEL` repository variable
+outranks this: routing runs first and the repo's own setting overwrites it.
+Every uncertain path — an unreadable file list, a malformed threshold, a
+truncated listing — leaves the harness model in place, so cost routing can
+never be the reason a review fails to run.
+
 Set the runtime per repo with `fullsend github setup <owner/repo> --runtime pi`. Repos on pi need a
 sandbox image that carries `PI_VERSION`.
 


### PR DESCRIPTION
Closes #5777.

Author type is a proxy for complexity, not complexity itself. The harness fixes the review model before anything has looked at the diff, so the one-line `versions.json` bump in #5777 — human-authored, created through the web UI — was reviewed on Opus for **$0.40** and correctly approved in about a minute. The verdict was right; the price was not.

The existing cheap-review proposals (#2842, #2639, #3240, #3347) all gate on **bot authorship**, so none of them would have caught that PR. #1900 covers human-authored changes but only for docs/prompt-only Markdown. This routes on the diff instead, which catches both.

## What qualifies

A step ahead of the review agent classifies the changed files and, when the diff is provably trivial, exports `FULLSEND_MODEL` so the review runs on a cheaper tier. It lives in the dispatch layer, so it applies to every enrolled repo without a per-repo harness change.

Trivial means **every** changed file is a *modified* data/config file (`.json`, `.ya?ml`, `.toml`, `.txt`, `.md`, `.ini`, `.cfg`, `.conf`, `.properties`) and the whole diff is under the line threshold.

The exclusions are where the safety lives:

| Excluded | Why |
|---|---|
| added / removed / renamed files | structural, not a value edit — even at one line |
| any code file | never trivial, whatever its size |
| dependency lockfiles | npm resolves from the lockfile, so a one-line `integrity` swap is a supply-chain change wearing a trivial diff |
| paths that execute or govern | dot directories (`.github/`, `.claude/`), `scripts/`, `hack/`, `skills/`, `harness/`, `agents/`, `policies/`, and root files like `CODEOWNERS`, `Dockerfile`, `CLAUDE.md` |

That last list is deliberately **smaller** than `REVIEW_PROTECTED_PATHS`. The two answer different questions: protected paths decide whether a review may auto-approve; this decides whether a cheaper model may form the opinion in the first place.

## Tuning and precedence

The issue is explicit that the thresholds need tuning, so both are repository variables:

| Variable | Default | Meaning |
|---|---|---|
| `REVIEW_TRIVIAL_MODEL` | `sonnet` | Model for trivial diffs. `off` disables routing entirely. |
| `REVIEW_TRIVIAL_MAX_LINES` | `10` | Upper bound on additions + deletions. |

Routing runs **before** `setup-agent-env.sh`, which re-exports `FULLSEND_MODEL` from the `REVIEW_FULLSEND_MODEL` / `FULLSEND_MODEL` repository variables. A repo that pins a model therefore keeps it — explicit configuration outranks inferred routing, and the ordering is what enforces that rather than a special case in the script.

## Failure mode

Every uncertain path leaves the model untouched, so the harness default (the more capable model) stands: an unreadable file list, a malformed threshold, a truncated listing (GitHub caps the files endpoint at 3000 and stops paginating without erroring), an empty diff, a missing PR number. **The failure mode of cost routing must be a more expensive review, never a missing one.**

## Testing

`.github/scripts/route-review-model-test.sh` stubs `gh` and runs the real script — not a paraphrase of its logic — across 16 cases, wired into `make script-test`. It covers the issue's own example, each exclusion class, threshold accumulation across files, both repository variables, the opt-out, and every degrade-safely path.

`shellcheck` and `actionlint` are clean; I diffed actionlint against pristine `origin/main` and this adds **zero** new findings (the 31 existing ones are the `job.workflow_sha` context actionlint doesn't know). `go test ./internal/scaffold/` passes, which covers the cross-workflow alignment since the step is mirrored into `reusable-review.yml` as well.

## On the validation criteria

Criteria 1, 2 and 4 are observable once this runs. **Criterion 3 (≥50% cost drop) is worth measuring rather than assuming** — the `$0.40` baseline is a single data point from July, and per-dimension model tiering has landed since. The review agent's own `metrics.json` already records per-run cost, so the number is available from the next trivial PR that goes through this path.
