### PR TITLE
chore(dispatch): provide FULLSEND_WORK_ITEM_URL in addition to GITHUB_ISSUE_URL

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -682,7 +682,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
-          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          FULLSEND_WORK_ITEM_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
@@ -803,7 +803,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
-          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          FULLSEND_WORK_ITEM_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           ISSUE_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
           # Reaches the harness pre-script inside fullsend run, which reads it
           # for its --force override of the existing-PR check (pre-script
@@ -931,7 +931,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
-          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          FULLSEND_WORK_ITEM_URL: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.html_url || fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           GITHUB_PR_URL: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.html_url || fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
           PR_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.number || fromJSON(needs.route.outputs.event_payload).issue.number }}
@@ -1403,7 +1403,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
-          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          FULLSEND_WORK_ITEM_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
@@ -1730,7 +1730,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ steps.dispatch-env.outputs.issue_url }}
-          TRIGGER_ENTITY_URL: ${{ steps.dispatch-env.outputs.issue_url }}
+          FULLSEND_WORK_ITEM_URL: ${{ steps.dispatch-env.outputs.issue_url }}
           REPO_FULL_NAME: ${{ matrix.source_repo }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -682,6 +682,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
@@ -802,6 +803,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           ISSUE_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
           # Reaches the harness pre-script inside fullsend run, which reads it
           # for its --force override of the existing-PR check (pre-script
@@ -929,6 +931,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           GITHUB_PR_URL: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.html_url || fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
           PR_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.number || fromJSON(needs.route.outputs.event_payload).issue.number }}
@@ -1400,6 +1403,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          TRIGGER_ENTITY_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
@@ -1726,6 +1730,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ steps.dispatch-env.outputs.issue_url }}
+          TRIGGER_ENTITY_URL: ${{ steps.dispatch-env.outputs.issue_url }}
           REPO_FULL_NAME: ${{ matrix.source_repo }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}

--- a/docs/normative/normalized-event/v1/jira-poll-adapter.md
+++ b/docs/normative/normalized-event/v1/jira-poll-adapter.md
@@ -94,8 +94,10 @@ When `source.system` is `jira`, projection supplements the GitHub-shaped
 | `GITHUB_ISSUE_URL` | Omit or empty — not a GitHub issue |
 | `status-number` | `entity.id` (numeric Jira id) |
 
-Harnesses and pre-scripts that require forge URLs MUST use `FULLSEND_WORK_ITEM_*`
-for Jira-sourced runs.
+Harnesses and pre-scripts that require forge-agnostic work item URLs SHOULD use
+`FULLSEND_WORK_ITEM_*` rather than forge-specific variables like
+`GITHUB_ISSUE_URL`. The dispatch workflow sets `FULLSEND_WORK_ITEM_URL` to
+`entity.url` for both GitHub and Jira events.
 
 ## Example
 


### PR DESCRIPTION
As part of the CEL overlays work, it is now possible for generic dispatch to run either in response to a jira event or a github event. This means we cannot assume that the issue url is a github issue.

All of the default agents today depend on that GITHUB_ISSUE_URL var. We need to keep this as a backwards-compatible thing for a while.

Add a new FULLSEND_WORK_ITEM_URL that exposes the entity.url of the triggering normalized event for agents to use.

For a moment, the proposed var here was TRIGGER_ENTITY_URL based off some old issue about it. @waynesun09 pointed out in review that we already have a normative spec doc merged that defines `FULLSEND_WORK_ITEM_URL` as the correct var to use here - so, I've switched to that.

Fixes https://github.com/fullsend-ai/fullsend/issues/6609