### PR TITLE
ci(release): prepare v0.39.0 — bump agents gate pin past agents#1010, tag the gate-validated SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,16 +64,13 @@ jobs:
     #   id-token: write      — GCP WIF auth in functional-tests
     #   pull-requests: write — gate job (pull_request_target only; skipped
     #                          on tag pushes, but still validated)
-    #   checks: read         — functional-tests-complete roll-up on agents
-    #                          main (not used by the pinned gate yet;
-    #                          granted now so a pin bump cannot
-    #                          reintroduce the startup failure)
+    #   checks: read         — functional-tests-complete roll-up job
     permissions:
       contents: read
       id-token: write
       pull-requests: write
       checks: read
-    uses: fullsend-ai/agents/.github/workflows/functional-tests.yml@a8566cd5305fe094b96588690118022967ad0061 # main
+    uses: fullsend-ai/agents/.github/workflows/functional-tests.yml@b9c0745580084af09d1f1e2df8448d1d478458c6 # main (includes agents#1010 cross-repo checkout fix)
     with:
       fullsend_ref: ${{ github.ref_name }}
     secrets:
@@ -85,13 +82,11 @@ jobs:
       EVAL_GH_TOKEN: ${{ secrets.EVAL_GH_TOKEN }}
 
   resolve-agents:
-    # Resolve the agents tree to tag exactly once, when the release starts.
-    # tag-agents previously re-resolved agents main at tag time, so anything
-    # merged into agents while the gate ran was tagged unvalidated (#6512).
-    # Until the agents gate exposes the SHA it checked out as a
-    # workflow_call output, validate-agents still exercises the pinned
-    # gate's agents tree; this at least makes the tagged tree deterministic
-    # from the moment the release begins.
+    # Resolve agents main once at release start. Since agents#1010 the gate
+    # itself reports the SHA it validated (validate-agents' agents_sha
+    # output), and tag-agents prefers that; this job's resolution is the
+    # fallback if that output is ever empty, and the input for the
+    # informational pin-drift check below (#6512).
     needs: release
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -129,8 +124,10 @@ jobs:
     # Sync the version tag to fullsend-ai/agents. Runs for all tags
     # including pre-releases — agents' own release.yml handles
     # pre-release semantics. Only runs after agents functional tests
-    # pass against the release tag. Tags the SHA resolve-agents captured
-    # at release start — never re-resolves main here (#6512).
+    # pass against the release tag. Tags the SHA the gate actually
+    # validated (validate-agents' agents_sha output, agents#1010), falling
+    # back to the SHA resolve-agents captured at release start — never
+    # re-resolves main here (#6512).
     needs: [release, validate-agents, resolve-agents]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -148,13 +145,19 @@ jobs:
       - name: Push tag to fullsend-ai/agents
         env:
           GH_TOKEN: ${{ steps.agents-token.outputs.token }}
-          AGENTS_SHA: ${{ needs.resolve-agents.outputs.agents_sha }}
+          GATE_SHA: ${{ needs.validate-agents.outputs.agents_sha }}
+          RESOLVED_SHA: ${{ needs.resolve-agents.outputs.agents_sha }}
         run: |
           set -euo pipefail
+          AGENTS_SHA="${GATE_SHA:-${RESOLVED_SHA}}"
           if [[ ! "${AGENTS_SHA}" =~ ^[a-f0-9]{40}$ ]]; then
-            echo "::error::resolve-agents output is not a commit SHA: ${AGENTS_SHA//::/}"
+            echo "::error::no usable agents SHA (gate='${GATE_SHA//::/}' resolved='${RESOLVED_SHA//::/}')"
             exit 1
           fi
+          if [[ -n "${GATE_SHA}" && "${GATE_SHA}" != "${RESOLVED_SHA}" ]]; then
+            echo "::notice::tagging the gate-validated SHA ${GATE_SHA} (agents main was ${RESOLVED_SHA} at release start)"
+          fi
+          echo "Tagging fullsend-ai/agents at ${AGENTS_SHA} (source: $([[ -n "${GATE_SHA}" ]] && echo validate-agents || echo resolve-agents))"
           TAG="${GITHUB_REF_NAME}"
 
           HTTP_CODE=$(gh api "repos/fullsend-ai/agents/git/ref/tags/${TAG}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       id-token: write
       pull-requests: write
       checks: read
-    uses: fullsend-ai/agents/.github/workflows/functional-tests.yml@b9c0745580084af09d1f1e2df8448d1d478458c6 # main (includes agents#1010 cross-repo checkout fix)
+    uses: fullsend-ai/agents/.github/workflows/functional-tests.yml@beed20e7e85f7f7cf9678a78fd1f440755560ca3 # main (includes agents#1010 cross-repo checkout fix)
     with:
       fullsend_ref: ${{ github.ref_name }}
     secrets:


### PR DESCRIPTION
## Summary

**Preparation for the next release (v0.38.0).** Two changes to `release.yml`, both maintainer-owned (workflow file):

1. **Bump the agents gate pin** `a8566cd5 → b9c07455` (agents main). This includes **agents#1010**, which makes the gate check out `fullsend-ai/agents` at an explicit ref instead of `github.workflow_sha` — proven on the v0.37.0 run to be the *caller's* commit (`not our ref`). With this pin, a fullsend release can validate agents content cross-repo for the first time, and the gate exposes the validated commit as the `agents_sha` `workflow_call` output.
2. **`tag-agents` tags the gate-validated SHA** (`needs.validate-agents.outputs.agents_sha`), falling back to `resolve-agents`' release-start resolution only if the gate output is empty, and logs which source it used. Closes the resolve-once loop end to end (fullsend#6512): the tree the gate validated is the tree that gets tagged.

Also: the `checks: read` grant pre-granted in #6513 is now actually exercised by the gate's roll-up job; comments updated to match.

## Why now

v0.38.0 carries the user-facing pi-runtime readiness (#6583 per-agent `runtime`/`model`/`effort` in `config.yaml`, #6540 local-run flow, #6523 provider-update retry) plus the #6585 SSRF fix; the agents tag it cuts will carry agents#1010, #1025 (harness images repinned to release builds, shipping the xai-vertex extension) and the risk-assessment review feature. This PR is what lets that release's gate do its job instead of taking the manual-recovery path again.

## What to watch on the release run

- `validate-agents / detect` checkout log shows an **agents** ref (not the caller SHA) — first time ever
- `tag-agents` logs `source: validate-agents` and the SHA matches the gate's
- The pin-drift annotation should be quiet or near-zero (pin = agents main at PR time)
- After release: repin `agents/harness/*.yaml` image digests to the new `:0.38.0` builds (#6607 tracks automating this)

## Validation

- [x] YAML parses; `actionlint` clean (tag-triggered workflow gets no CI parse until the next tag)
- [x] `b9c07455` verified to contain agents#1010 (`dd9ca90`) via `merge-base --is-ancestor`
- [ ] Next tag push exercises it end to end

Related: fullsend#6512, agents#1001, agents#1010, #6513
