### PR TITLE
test(cli): resolve the temp dir in the agents-repo-fallback path test

### DIFF
--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -6036,7 +6036,9 @@ func TestRunCommand_HasEventFileFlag(t *testing.T) {
 }
 
 func TestResolveAgentSource_OverrideOnlyEntryUsesAgentsRepoFallback(t *testing.T) {
-	dir := t.TempDir()
+	// canonTempDir, not t.TempDir: the sourced-entry assertion below compares
+	// against containedLocalPath's symlink-resolved output.
+	dir := canonTempDir(t)
 	printer := ui.New(io.Discard)
 	cfg, err := config.ParsePerRepoConfig([]byte(`# fullsend per-repo configuration
 version: "1"


### PR DESCRIPTION
Heyaaaa : )

## Summary
`TestResolveAgentSource_OverrideOnlyEntryUsesAgentsRepoFallback` fails on every macOS checkout of main: it compares `containedLocalPath`'s symlink-resolved output (`/private/var/...`) against a raw `t.TempDir()` (`/var/...` — macOS keeps `/var` as a symlink to `/private/var`). The production code is correct — the resolver follows symlinks deliberately so it can re-check containment against the real path — only the assertion is wrong.

## Related Issue
No tracking issue — found while running the suite on a macOS checkout. The test arrived in #6581.

## Changes
- Switch the test's temp dir to the file's existing `canonTempDir(t)` helper (defined twenty lines above for exactly this, and used by the two older `resolveAgentSource` tests that compare resolved paths), with a comment saying why.

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [x] Tests added/updated for new or modified logic

Fails on current main without the change, passes with it:

```
expected: "/var/folders/.../harness/lint.yaml"
actual  : "/private/var/folders/.../harness/lint.yaml"
```

`go test ./internal/cli/ ./internal/harness/` green (exit 0) on darwin/arm64, go1.25.5. The other `TestResolveAgentSource_*` cases assert on error strings and are unaffected — which is why this was the only red one.

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it

