### PR TITLE
fix(pre-fetch): extract the prior SHA with sed, not BSD-incompatible grep -P

### DIFF
--- a/internal/scaffold/fullsend-repo-gitlab/.gitlab/ci/fullsend-agent.yml
+++ b/internal/scaffold/fullsend-repo-gitlab/.gitlab/ci/fullsend-agent.yml
@@ -458,8 +458,10 @@ stages:
                 : > "${PRIOR_REVIEW_FILE}"
               elif [ "${BYTE_COUNT}" -gt 1 ]; then
                 CURRENT_SECTION=$(awk '/<!-- sticky:history-start -->/{exit} {print}' "${PRIOR_REVIEW_FILE}")
+                # sed -nE, not grep -oP — kept in lockstep with the GitHub
+                # scaffold's pre-fetch-prior-review.sh (see its comment for why).
                 PRIOR_REVIEW_SHA=$(printf '%s' "${CURRENT_SECTION}" \
-                  | grep -oP '(?<=\*\*Head SHA:\*\* )[0-9a-f]{7,64}' | head -1 || true)
+                  | sed -nE 's/.*\*\*Head SHA:\*\* ([0-9a-f]{7,64}).*/\1/p' | head -1)
               fi
             else
               PRIOR_REVIEW_PROVENANCE="unverifiable-wrong-user"

--- a/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review.sh
@@ -93,8 +93,14 @@ echo "prior_review_file=${PRIOR_FILE}" >> "${GITHUB_OUTPUT:-/dev/null}"
 if [[ "${BYTE_COUNT}" -gt 1 ]]; then
     # Extract SHA from current section only (before sticky history sentinels)
     CURRENT_SECTION="$(awk '/<!-- sticky:history-start -->/{exit} {print}' "${PRIOR_FILE}")"
+    # sed -nE, not grep -oP: BSD grep (macOS) has no -P, so the PCRE
+    # lookbehind exited with "invalid option" and the `|| true` swallowed
+    # it — PRIOR_SHA came back empty and the two SHA tests failed on every
+    # macOS checkout. sed -nE is the same expression in POSIX ERE and works
+    # on both. A no-match prints nothing and still exits 0, so this keeps
+    # the no-SHA case off pipefail too (body-without-sha-no-crash).
     PRIOR_SHA="$(echo "${CURRENT_SECTION}" \
-        | grep -oP '(?<=\*\*Head SHA:\*\* )[0-9a-f]{7,64}' | head -1 || true)"
+        | sed -nE 's/.*\*\*Head SHA:\*\* ([0-9a-f]{7,64}).*/\1/p' | head -1)"
     echo "prior_sha=${PRIOR_SHA}" >> "${GITHUB_OUTPUT:-/dev/null}"
     echo "Prior review SHA: ${PRIOR_SHA:-none}"
 else


### PR DESCRIPTION
Heyaaaa : )

## Summary
`pre-fetch-prior-review.sh` extracts the prior review SHA with `grep -oP`. BSD grep (macOS) has no `-P`, the `|| true` swallows the failure, and `PRIOR_SHA` comes back empty — two script tests fail on every macOS checkout. Replaced with `sed -nE`, the same expression in POSIX ERE. Second commit applies the identical swap to the GitLab scaffold twin (its comment declares it "equivalent" to this script) so the pair stays in lockstep — caught in review by @waynesun09.

## Related Issue
None — found running the script test suite on macOS.

## Changes
- `sed -nE 's/.*\*\*Head SHA:\*\* ([0-9a-f]{7,64}).*/\1/p' | head -1` replaces the grep; the `|| true` goes too, since a sed no-match exits 0.
- Same swap at `fullsend-repo-gitlab/.gitlab/ci/fullsend-agent.yml:462`, with a lockstep pointer comment.
- One deliberate edge change: two `**Head SHA:**` markers on one line now yield the last, not the first. Across lines — the only shape the pipeline writes — behavior is identical, and the tests cover it.

Sweep status: `hack/lint-docs-links` had the same bug class and is macOS-reachable via pre-commit — fixed in #6728. The guard at `reconcile-repos.sh:208` is inert on macOS (BSD grep exits non-zero, the `if` reads that as false) but harmless: the anchored allowlist at :212 already rejects control characters. Still unswept, genuinely Linux-only: `scripts/renovate/*`, `hack/gitlab-runner-vm/setup.sh`.

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [x] Tests added/updated for new or modified logic

`pre-fetch-prior-review-test.sh`: 2 failures → all pass on macOS. GitLab twin pipeline run on the same fixtures, identical output. CI (GNU grep) behaviorally unchanged.

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it
