### PR TITLE
fix(#6701): wait for the actor's role on a recreated pool repo

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -2182,6 +2182,31 @@ func (c *LiveClient) IsInstallationToken(ctx context.Context) (bool, error) {
 	return ProbeInstallationToken(ctx, c.http, c.baseURL, c.token)
 }
 
+// LatestCommitAuthorLogin returns the GitHub login attributed as author
+// of the newest commit on the repository's default branch, or "" when
+// the commit has no linked account. Commits made through the API with a
+// GitHub App installation token are attributed to the app's bot user
+// ("<slug>[bot]"), which lets a caller learn the identity its own token
+// acts as without an app slug in configuration.
+func (c *LiveClient) LatestCommitAuthorLogin(ctx context.Context, owner, repo string) (string, error) {
+	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/commits?per_page=1", owner, repo))
+	if err != nil {
+		return "", fmt.Errorf("list commits for %s/%s: %w", owner, repo, err)
+	}
+	var commits []struct {
+		Author *struct {
+			Login string `json:"login"`
+		} `json:"author"`
+	}
+	if err := decodeJSON(resp, &commits); err != nil {
+		return "", fmt.Errorf("decode commits for %s/%s: %w", owner, repo, err)
+	}
+	if len(commits) == 0 || commits[0].Author == nil {
+		return "", nil
+	}
+	return commits[0].Author.Login, nil
+}
+
 // GetAuthenticatedUserIdentity returns the display name and email of
 // the authenticated user by calling GET /user.
 //

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -4548,3 +4548,45 @@ func TestDo_ServerErrorExhaustedIsNotARateLimit(t *testing.T) {
 	assert.NotContains(t, err.Error(), "rate limit:")
 	assert.Contains(t, err.Error(), "retryable error after 5 attempts")
 }
+
+func TestLatestCommitAuthorLogin(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{{"sha": "abc", "author": map[string]any{"login": "fullsend-ai-e2e[bot]"}}})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+
+	login, err := client.LatestCommitAuthorLogin(context.Background(), "org", "repo")
+	require.NoError(t, err)
+	assert.Equal(t, "fullsend-ai-e2e[bot]", login)
+	assert.Equal(t, "/repos/org/repo/commits?per_page=1", gotPath)
+}
+
+func TestLatestCommitAuthorLogin_NoLinkedAccount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{{"sha": "abc", "author": nil}})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+
+	login, err := client.LatestCommitAuthorLogin(context.Background(), "org", "repo")
+	require.NoError(t, err)
+	assert.Equal(t, "", login)
+}
+
+func TestLatestCommitAuthorLogin_EmptyRepo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+
+	login, err := client.LatestCommitAuthorLogin(context.Background(), "org", "repo")
+	require.NoError(t, err)
+	assert.Equal(t, "", login)
+}

--- a/pkg/behaviourtest/drivers/install/ensure.go
+++ b/pkg/behaviourtest/drivers/install/ensure.go
@@ -26,6 +26,11 @@ const (
 	// reset cycle. With exponential backoff (2×) and a 1s initial
 	// delay, 5 attempts cover up to ~1+2+4+8 = 15s of API lag.
 	resetMaxAttempts = 5
+
+	// actorAccessMaxAttempts bounds awaitActorAccess. With the same
+	// 1s-doubling backoff as the reset waits, 7 attempts cover
+	// ~1+2+4+8+16+32 = 63s of collaborator-index lag.
+	actorAccessMaxAttempts = 7
 )
 
 // resetRetryDelay is the initial delay for exponential backoff when
@@ -172,7 +177,10 @@ func (e *repoEnsurer) doEnsure(ctx context.Context, org, repoName string) error 
 		}
 	}
 
-	return nil
+	// Step 6: wait until the recreated repo resolves a role for the
+	// account this token acts as, so the first event the scenario
+	// raises is dispatched with the actor's real role.
+	return e.awaitActorAccess(ctx, org, repoName, target)
 }
 
 // resetRepo deletes an existing repo to clear accumulated git history.
@@ -321,6 +329,98 @@ func (e *repoEnsurer) awaitCreation(ctx context.Context, org, repoName, target s
 		}
 	}
 	return fmt.Errorf("repo %s not visible after %d attempts following creation", target, resetMaxAttempts)
+}
+
+// commitAuthorLister is implemented by clients that can report the
+// account attributed as author of a repo's newest commit.
+type commitAuthorLister interface {
+	LatestCommitAuthorLogin(ctx context.Context, owner, repo string) (string, error)
+}
+
+// collaboratorPermissionGetter is the GitHub-specific lookup the harness
+// dispatch relies on (forge.GitHubExtensions); the ensurer probes it
+// through the same narrow method so test doubles need not implement the
+// whole extension set.
+type collaboratorPermissionGetter interface {
+	GetCollaboratorPermission(ctx context.Context, owner, repo, username string) (role string, err error)
+}
+
+// actorLogin returns the login the ensurer's token acts as. Installation
+// tokens cannot ask GET /user, but every commit the install flow just
+// made through the API is attributed to the app's bot user, so the
+// newest commit on the repo names it. GET /user is the fallback for
+// PATs used in local runs. "" means the identity could not be learned.
+func (e *repoEnsurer) actorLogin(ctx context.Context, org, repoName string) (string, error) {
+	if lister, ok := e.client.(commitAuthorLister); ok {
+		login, err := lister.LatestCommitAuthorLogin(ctx, org, repoName)
+		if err != nil {
+			return "", err
+		}
+		if login != "" {
+			return login, nil
+		}
+	}
+	login, err := e.client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		// Installation tokens are refused by GET /user; that is not
+		// a fault, just no identity to probe with.
+		return "", nil
+	}
+	return login, nil
+}
+
+// awaitActorAccess waits until GetCollaboratorPermission on the
+// recreated repo resolves a role for the account the token acts as.
+// Repo visibility (awaitCreation) and the collaborator view of an
+// account on a new repo ID are separate GitHub consistency domains: on
+// a recreated pool repo the suite labelled the issue as soon as the
+// repo object existed, the harness dispatch's permission lookup for the
+// labelling actor answered 200 with an empty role_name (github.go's
+// GetCollaboratorPermission maps that to ErrNotFound: "no permission
+// for fullsend-ai-e2e[bot]"), the role fell to none and the matrix came
+// back empty (#6701). The probe here is the same endpoint from the
+// ensurer's own token; whether that view and the workflow token's view
+// converge at exactly the same moment is not documented by GitHub, so
+// this is the closest available signal, to be validated in E2E.
+//
+// A client without the permission lookup (GitLab, plain test doubles)
+// skips the wait; one that cannot name its own account skips it with a
+// log line rather than block the suite.
+func (e *repoEnsurer) awaitActorAccess(ctx context.Context, org, repoName, target string) error {
+	perms, ok := e.client.(collaboratorPermissionGetter)
+	if !ok {
+		return nil
+	}
+	login, err := e.actorLogin(ctx, org, repoName)
+	if err != nil {
+		return fmt.Errorf("resolving actor login for %s: %w", target, err)
+	}
+	if login == "" {
+		e.logf("[ensure] cannot determine the account this token acts as; skipping actor access wait for %s", target)
+		return nil
+	}
+	e.logf("[ensure] waiting for %s to resolve a role for %s", target, login)
+	delay := resetRetryDelay
+	for attempt := 1; attempt <= actorAccessMaxAttempts; attempt++ {
+		role, err := perms.GetCollaboratorPermission(ctx, org, repoName, login)
+		if err == nil {
+			e.logf("[ensure] %s resolves role %q for %s after %d attempt(s)", target, role, login, attempt)
+			return nil
+		}
+		if !forge.IsNotFound(err) {
+			return fmt.Errorf("checking %s access to %s: %w", login, target, err)
+		}
+		if attempt < actorAccessMaxAttempts {
+			e.logf("[ensure] %s resolves no role for %s yet, attempt %d/%d — backing off %v", target, login, attempt, actorAccessMaxAttempts, delay)
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled while waiting for %s access to %s: %w", login, target, ctx.Err())
+			case <-time.After(delay):
+			}
+			delay *= 2
+		}
+	}
+	return fmt.Errorf("%s resolves no role for %s after %d attempts following creation; dispatch would resolve no role for the labelling actor", target, login, actorAccessMaxAttempts)
 }
 
 // installFullsend runs inference provision (when a GCP project is

--- a/pkg/behaviourtest/drivers/install/ensure_test.go
+++ b/pkg/behaviourtest/drivers/install/ensure_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -1016,4 +1017,192 @@ func TestAwaitCreation_ContextCancellation(t *testing.T) {
 	err := e.awaitCreation(ctx, "org", "repo", "org/repo")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context cancelled")
+}
+
+// --- awaitActorAccess unit tests ---
+
+// actorClient wraps a forge.Client with a commit-author identity and a
+// collaborator-permission answer that flips after a configurable number
+// of lookups.
+type actorClient struct {
+	forge.Client
+	mu          sync.Mutex
+	authorLogin string
+	authorErr   error
+	userLogin   string
+	userErr     error
+	lookups     int
+	roleAfter   int   // lookups before a role resolves (0 = immediately)
+	lookupErr   error // returned instead of ErrNotFound while unresolved
+	role        string
+	lookedUp    []string
+}
+
+func (c *actorClient) LatestCommitAuthorLogin(_ context.Context, _, _ string) (string, error) {
+	return c.authorLogin, c.authorErr
+}
+
+func (c *actorClient) GetAuthenticatedUser(_ context.Context) (string, error) {
+	return c.userLogin, c.userErr
+}
+
+func (c *actorClient) GetCollaboratorPermission(_ context.Context, _, _, username string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lookups++
+	c.lookedUp = append(c.lookedUp, username)
+	if c.lookups > c.roleAfter {
+		return c.role, nil
+	}
+	if c.lookupErr != nil {
+		return "", c.lookupErr
+	}
+	return "", forge.ErrNotFound
+}
+
+func TestAwaitActorAccess_ProbesCommitAuthorAndConfirmsImmediately(t *testing.T) {
+	speedUpResetRetries(t)
+	client := &actorClient{authorLogin: "fullsend-ai-e2e[bot]", userErr: errors.New("403 for installation tokens"), role: "write"}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+
+	require.NoError(t, e.awaitActorAccess(context.Background(), "org", "repo", "org/repo"))
+	assert.Equal(t, []string{"fullsend-ai-e2e[bot]"}, client.lookedUp)
+}
+
+func TestAwaitActorAccess_RetriesUntilRoleResolves(t *testing.T) {
+	speedUpResetRetries(t)
+	client := &actorClient{authorLogin: "fullsend-ai-e2e[bot]", roleAfter: 3, role: "write"}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+
+	require.NoError(t, e.awaitActorAccess(context.Background(), "org", "repo", "org/repo"))
+	assert.Equal(t, 4, client.lookups)
+}
+
+func TestAwaitActorAccess_FailsAfterMaxAttempts(t *testing.T) {
+	speedUpResetRetries(t)
+	client := &actorClient{authorLogin: "fullsend-ai-e2e[bot]", roleAfter: actorAccessMaxAttempts + 1}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+
+	err := e.awaitActorAccess(context.Background(), "org", "repo", "org/repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "org/repo resolves no role for fullsend-ai-e2e[bot] after 7 attempts")
+	assert.Equal(t, actorAccessMaxAttempts, client.lookups)
+}
+
+func TestAwaitActorAccess_FallsBackToAuthenticatedUserForPATs(t *testing.T) {
+	speedUpResetRetries(t)
+	client := &actorClient{authorLogin: "", userLogin: "wayne", role: "admin"}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+
+	require.NoError(t, e.awaitActorAccess(context.Background(), "org", "repo", "org/repo"))
+	assert.Equal(t, []string{"wayne"}, client.lookedUp)
+}
+
+func TestAwaitActorAccess_SkipsWhenIdentityUnknown(t *testing.T) {
+	speedUpResetRetries(t)
+	client := &actorClient{authorLogin: "", userErr: errors.New("403")}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+
+	require.NoError(t, e.awaitActorAccess(context.Background(), "org", "repo", "org/repo"))
+	assert.Equal(t, 0, client.lookups, "no identity, no probe")
+}
+
+func TestAwaitActorAccess_PropagatesNonNotFoundErrors(t *testing.T) {
+	speedUpResetRetries(t)
+	client := &actorClient{authorLogin: "fullsend-ai-e2e[bot]", roleAfter: 5, lookupErr: errors.New("github api: 403 rate limit")}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+
+	err := e.awaitActorAccess(context.Background(), "org", "repo", "org/repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking fullsend-ai-e2e[bot] access to org/repo: github api: 403 rate limit")
+	assert.Equal(t, 1, client.lookups)
+}
+
+func TestAwaitActorAccess_PropagatesAuthorLookupError(t *testing.T) {
+	speedUpResetRetries(t)
+	client := &actorClient{authorErr: errors.New("boom")}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+
+	err := e.awaitActorAccess(context.Background(), "org", "repo", "org/repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving actor login for org/repo: boom")
+}
+
+func TestAwaitActorAccess_SkipsClientsWithoutPermissionLookup(t *testing.T) {
+	e := &repoEnsurer{client: &countingRepoClient{}, logf: t.Logf}
+	require.NoError(t, e.awaitActorAccess(context.Background(), "org", "repo", "org/repo"))
+}
+
+func TestAwaitActorAccess_HonoursContextCancellation(t *testing.T) {
+	client := &actorClient{authorLogin: "fullsend-ai-e2e[bot]", roleAfter: actorAccessMaxAttempts + 1}
+	e := &repoEnsurer{client: client, logf: t.Logf}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := e.awaitActorAccess(ctx, "org", "repo", "org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// actorStubClient gives the doEnsure stub an identity and a permission
+// answer, recording when the permission probe ran relative to settle.
+type actorStubClient struct {
+	*stubClient
+	mu       sync.Mutex
+	probed   int
+	probeErr error
+}
+
+func (c *actorStubClient) LatestCommitAuthorLogin(_ context.Context, _, _ string) (string, error) {
+	return "fullsend-ai-e2e[bot]", nil
+}
+
+func (c *actorStubClient) GetCollaboratorPermission(_ context.Context, _, _, _ string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.probed++
+	if c.probeErr != nil {
+		return "", c.probeErr
+	}
+	return "write", nil
+}
+
+func TestDoEnsure_ProbesActorAccessAfterSettle(t *testing.T) {
+	speedUpResetRetries(t)
+	sc := &actorStubClient{stubClient: &stubClient{installed: true}}
+	var order []string
+	e := &repoEnsurer{
+		e2eCfg:  e2etest.EnvConfig{},
+		client:  sc,
+		runCLI:  noopCLI,
+		logf:    t.Logf,
+		ensured: make(map[string]struct{}),
+		settle: func(context.Context, forge.Client, string, string, string, func(string, ...any)) error {
+			order = append(order, "settle")
+			sc.mu.Lock()
+			require.Equal(t, 0, sc.probed, "the actor probe must not run before settle")
+			sc.mu.Unlock()
+			return nil
+		},
+	}
+
+	require.NoError(t, e.EnsureRepo(context.Background(), "org", "test-repo-01"))
+	assert.Equal(t, []string{"settle"}, order)
+	assert.Equal(t, 1, sc.probed)
+}
+
+func TestDoEnsure_ActorAccessErrorSurfaces(t *testing.T) {
+	speedUpResetRetries(t)
+	sc := &actorStubClient{stubClient: &stubClient{installed: true}, probeErr: errors.New("github api: 403 rate limit")}
+	e := &repoEnsurer{
+		e2eCfg:  e2etest.EnvConfig{},
+		client:  sc,
+		runCLI:  noopCLI,
+		logf:    t.Logf,
+		ensured: make(map[string]struct{}),
+	}
+
+	err := e.EnsureRepo(context.Background(), "org", "test-repo-01")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking fullsend-ai-e2e[bot] access to org/test-repo-01: github api: 403 rate limit")
 }


### PR DESCRIPTION
## Summary

Second of the two real causes behind the #6647 behaviour-test failures (diagnosed on #6697; the harness-wait diagnostics that make it visible are #6698).

Since `f317cdb5` pool repos are deleted and recreated on allocation. `awaitCreation` waits only until `GetRepo` stops 404ing — repo *visibility*. On the failing run (33108146650) the suite had already pushed files into the recreated repo with its installation token, yet when it labelled the issue, the harness dispatch's permission lookup for the labelling actor — made with the workflow's `github.token` — answered **200 with an empty `role_name`** (the `no permission for fullsend-ai-e2e[bot]` string comes from `github.go`'s `GetCollaboratorPermission`, not from a 404). The role fell to `none`, the matrix came back empty, the placeholder job was skipped, 0 artifacts. The stale state is the collaborator/permission view of the bot on the new repo ID, which is a different consistency domain from repo visibility and from the installation→repository edge.

## Related Issue

Closes #6701

## Changes

- `awaitActorAccess` — new final step of `doEnsure` (after Actions settle): poll `GetCollaboratorPermission(org, repo, <actor login>)` with the existing 1s-doubling reset backoff until it resolves a role (7 attempts ≈ 63s); `ErrNotFound` means "not yet", any other error fails allocation immediately with the cause. This probes the same endpoint the dispatch relies on, from the ensurer's own token.
- Actor login is **self-discovered**: every commit the install flow just made through the API is attributed to the app's bot user (`author.login = fullsend-ai-e2e[bot]`, verified on live pool repos), so the newest commit on the repo names the identity the token acts as — no app slug in configuration. `GET /user` is the fallback for PATs in local runs. If neither yields a login, or the client has no permission lookup (GitLab, plain test doubles), the wait is skipped with a log line.
- Fails allocation with `<org/repo> resolves no role for <login> after 7 attempts …` instead of letting the scenario run into a 12-minute harness wait.
- `LiveClient.LatestCommitAuthorLogin` — one `GET /repos/{o}/{r}/commits?per_page=1` through the client's retrying `do()`.

## What this does not prove

Whether the ensurer token's view of the bot's permission and the workflow token's view converge at the same moment is not documented by GitHub; this is the closest available signal and the E2E run is the validation. The earlier cut of this PR probed `GET /installation/repositories` — reviewers showed that edge was already effective before the label in the failing run (the token had pushed files), so it would have passed on attempt 1 in exactly the failing case; it has been dropped.

## Testing

- [x] `go vet`, `gofmt`; `go test -race ./pkg/behaviourtest/drivers/install/ ./internal/forge/github/`
- [x] `TestAwaitActorAccess_*`: confirms immediately with the commit-author login, retries until a role resolves, fails after max attempts, falls back to `GET /user` for PATs, skips when the identity is unknown or the client has no permission lookup, propagates non-not-found errors and author-lookup errors, honours cancellation
- [x] `TestDoEnsure_ProbesActorAccessAfterSettle` (step order) and `TestDoEnsure_ActorAccessErrorSurfaces` (error propagates from `EnsureRepo`)
- [x] `TestLatestCommitAuthorLogin*`
- [ ] E2E behaviour run on freshly reset pool repos: at least one `resolves no role for … yet` line on some allocation, and zero `harness matrix not expanded` diagnostics (needs #6698 merged for the string)

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] I wrote this contribution myself and can explain all changes in it
