### PR TITLE
fix(#6702): observe GitHub rate-limit state and name it in exhausted-retry errors

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
 // ConfigRepoName is the conventional name for the org-level fullsend
@@ -331,6 +332,41 @@ type ReviewComment struct {
 type PullRequestFileDiff struct {
 	Path  string
 	Patch string
+}
+
+// RateLimit is the most recent GitHub REST rate-limit state a client
+// observed, taken from the X-RateLimit-* response headers.
+type RateLimit struct {
+	Limit     int
+	Remaining int
+	Reset     time.Time
+	Resource  string
+	Observed  time.Time
+}
+
+// String renders the state for log lines and error messages. Fields
+// the response did not carry are rendered as unknown rather than as
+// plausible-looking zero values.
+func (r RateLimit) String() string {
+	remaining := fmt.Sprintf("remaining=%d", r.Remaining)
+	if r.Limit > 0 {
+		remaining += fmt.Sprintf("/%d", r.Limit)
+	}
+	reset := "unknown"
+	if !r.Reset.IsZero() {
+		reset = r.Reset.UTC().Format(time.RFC3339)
+	}
+	resource := r.Resource
+	if resource == "" {
+		resource = "unknown"
+	}
+	return fmt.Sprintf("%s reset=%s resource=%s", remaining, reset, resource)
+}
+
+// RateLimitReporter is implemented by clients that track RateLimit.
+// ok is false until the client has seen a response carrying the headers.
+type RateLimitReporter interface {
+	RateLimit() (state RateLimit, ok bool)
 }
 
 // Installation represents an app installation on an org.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -31,11 +32,65 @@ type LiveClient struct {
 	token     string
 	baseURL   string
 	afterFunc func(time.Duration) <-chan time.Time
+
+	// rate is the last X-RateLimit-* state seen on any response; see
+	// RateLimit. It is the primary-quota view (secondary limits can
+	// fire with remaining > 0), kept so callers can log how a shared
+	// installation token's budget drains and tell primary exhaustion
+	// from secondary throttling (#6702).
+	rateMu   sync.Mutex
+	rate     forge.RateLimit
+	rateSeen bool
 }
 
 // Compile-time interface checks.
 var _ forge.Client = (*LiveClient)(nil)
 var _ forge.GitHubExtensions = (*LiveClient)(nil)
+var _ forge.RateLimitReporter = (*LiveClient)(nil)
+
+// RateLimit returns the most recent rate-limit state observed on a
+// response from this client, and whether one has been observed yet.
+func (c *LiveClient) RateLimit() (forge.RateLimit, bool) {
+	c.rateMu.Lock()
+	defer c.rateMu.Unlock()
+	return c.rate, c.rateSeen
+}
+
+// parseRateLimit reads the X-RateLimit-* headers of one response. ok is
+// false when the response carries no X-RateLimit-Remaining (non-GitHub
+// responses from intermediaries, for example).
+func parseRateLimit(h http.Header) (forge.RateLimit, bool) {
+	remaining, err := strconv.Atoi(h.Get("X-RateLimit-Remaining"))
+	if err != nil {
+		return forge.RateLimit{}, false
+	}
+	limit, _ := strconv.Atoi(h.Get("X-RateLimit-Limit"))
+	var reset time.Time
+	if secs, err := strconv.ParseInt(h.Get("X-RateLimit-Reset"), 10, 64); err == nil && secs > 0 {
+		reset = time.Unix(secs, 0)
+	}
+	return forge.RateLimit{
+		Limit:     limit,
+		Remaining: remaining,
+		Reset:     reset,
+		Resource:  h.Get("X-RateLimit-Resource"),
+		Observed:  time.Now(),
+	}, true
+}
+
+// observeRateLimit records the X-RateLimit-* headers of a response as
+// the client-wide last observation. Responses without the headers leave
+// the previous observation in place.
+func (c *LiveClient) observeRateLimit(h http.Header) {
+	rl, ok := parseRateLimit(h)
+	if !ok {
+		return
+	}
+	c.rateMu.Lock()
+	defer c.rateMu.Unlock()
+	c.rate = rl
+	c.rateSeen = true
+}
 
 // New creates a new GitHub client with the given personal access token.
 func New(token string) *LiveClient {
@@ -192,6 +247,9 @@ func (c *LiveClient) do(ctx context.Context, method, path string, body any) (*ht
 		}
 
 		resp, err := c.http.Do(req)
+		if err == nil {
+			c.observeRateLimit(resp.Header)
+		}
 		if err != nil {
 			// If the caller's context is done, propagate immediately
 			// — retrying is pointless when the parent has cancelled.
@@ -240,6 +298,26 @@ func (c *LiveClient) do(ctx context.Context, method, path string, body any) (*ht
 				msg += fmt.Sprintf(", Retry-After: %s", retryAfter)
 			}
 			msg += ")"
+			// 429 and retryable 403 are rate limits by construction
+			// (isRetryable). Name the cause so IsRateLimitError matches
+			// and carry the budget the headers reported, so a caller
+			// that only has the error can still tell "rate limited"
+			// from a generic 403.
+			if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusForbidden {
+				msg = "rate limit: " + msg
+				// Report the budget from the response that failed —
+				// the client-wide observation may belong to another
+				// goroutine's request. A response without the headers
+				// (secondary limits may omit them) says so, and names
+				// the last observation with its age.
+				if rl, ok := parseRateLimit(resp.Header); ok {
+					msg += " [" + rl.String() + "]"
+				} else if last, seen := c.RateLimit(); seen {
+					msg += fmt.Sprintf(" [rate-limit headers absent; last seen %s, %s ago]", last, time.Since(last.Observed).Round(time.Second))
+				} else {
+					msg += " [rate-limit headers absent; no prior observation]"
+				}
+			}
 			return nil, &APIError{StatusCode: resp.StatusCode, Message: msg}
 		}
 		select {

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -4410,3 +4410,141 @@ func TestUnsupportedMethods(t *testing.T) {
 		assert.ErrorIs(t, err, forge.ErrNotSupported)
 	})
 }
+
+func TestDo_ObservesRateLimitHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4321")
+		w.Header().Set("X-RateLimit-Reset", "1767225600") // 2026-01-01T00:00:00Z
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"name": "test-repo", "full_name": "org/test-repo", "default_branch": "main"})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+
+	_, seen := client.RateLimit()
+	assert.False(t, seen, "nothing observed before the first response")
+
+	_, err := client.GetRepo(context.Background(), "org", "test-repo")
+	require.NoError(t, err)
+
+	rl, seen := client.RateLimit()
+	require.True(t, seen)
+	assert.Equal(t, 5000, rl.Limit)
+	assert.Equal(t, 4321, rl.Remaining)
+	assert.Equal(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), rl.Reset.UTC())
+	assert.Equal(t, "core", rl.Resource)
+	assert.False(t, rl.Observed.IsZero())
+	assert.Equal(t, "remaining=4321/5000 reset=2026-01-01T00:00:00Z resource=core", rl.String())
+}
+
+func TestDo_ResponseWithoutRateLimitHeadersKeepsPreviousObservation(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("X-RateLimit-Limit", "5000")
+			w.Header().Set("X-RateLimit-Remaining", "10")
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"name": "test-repo", "full_name": "org/test-repo", "default_branch": "main"})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+	for i := 0; i < 2; i++ {
+		_, err := client.GetRepo(context.Background(), "org", "test-repo")
+		require.NoError(t, err)
+	}
+	rl, seen := client.RateLimit()
+	require.True(t, seen)
+	assert.Equal(t, 10, rl.Remaining)
+}
+
+func TestDo_RateLimitExhaustedErrorSelfIdentifies(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1767225600")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"message": "API rate limit exceeded for installation ID 1."})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+	origBackoff := secondaryRateLimitBackoff
+	defer func() { secondaryRateLimitBackoff = origBackoff }()
+	secondaryRateLimitBackoff = time.Millisecond
+
+	_, err := client.GetRepo(context.Background(), "org", "test-repo")
+	require.Error(t, err)
+	assert.Equal(t, maxRetries, attempts)
+	assert.True(t, IsRateLimitError(err), "an exhausted-retry 403 must be recognised as a rate limit: %v", err)
+	assert.Contains(t, err.Error(), "rate limit: retryable error after 5 attempts on GET /repos/org/test-repo")
+	assert.Contains(t, err.Error(), "[remaining=0/5000 reset=2026-01-01T00:00:00Z resource=core]")
+}
+
+func TestDo_RateLimitExhaustedWithoutHeadersNamesLastObservation(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			// A healthy response establishes the last observation.
+			w.Header().Set("X-RateLimit-Limit", "5000")
+			w.Header().Set("X-RateLimit-Remaining", "4000")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{"name": "test-repo", "full_name": "org/test-repo", "default_branch": "main"})
+			return
+		}
+		// Secondary-limit shape: Retry-After, no X-RateLimit-* headers.
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"message": "You have exceeded a secondary rate limit"})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+	_, err := client.GetRepo(context.Background(), "org", "test-repo")
+	require.NoError(t, err)
+
+	_, err = client.GetRepo(context.Background(), "org", "test-repo")
+	require.Error(t, err)
+	assert.True(t, IsRateLimitError(err))
+	assert.Contains(t, err.Error(), "rate limit: retryable error after 5 attempts")
+	assert.Contains(t, err.Error(), "[rate-limit headers absent; last seen remaining=4000/5000 reset=unknown resource=unknown, ")
+	assert.NotContains(t, err.Error(), "[remaining=4000", "a stale observation must not be presented as the failing response's budget")
+}
+
+func TestDo_RateLimitExhaustedWithoutAnyObservationSaysSo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"message": "You have exceeded a secondary rate limit"})
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+
+	_, err := client.GetRepo(context.Background(), "org", "test-repo")
+	require.Error(t, err)
+	assert.True(t, IsRateLimitError(err))
+	assert.Contains(t, err.Error(), "[rate-limit headers absent; no prior observation]")
+}
+
+func TestRateLimitString_UnknownFields(t *testing.T) {
+	assert.Equal(t, "remaining=7 reset=unknown resource=unknown", forge.RateLimit{Remaining: 7}.String())
+}
+
+func TestDo_ServerErrorExhaustedIsNotARateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	client := &LiveClient{token: "test-token", baseURL: srv.URL, http: srv.Client(), afterFunc: noWaitAfter}
+
+	_, err := client.GetRepo(context.Background(), "org", "test-repo")
+	require.Error(t, err)
+	assert.False(t, IsRateLimitError(err))
+	assert.NotContains(t, err.Error(), "rate limit:")
+	assert.Contains(t, err.Error(), "retryable error after 5 attempts")
+}

--- a/pkg/behaviourtest/drivers/install/composed.go
+++ b/pkg/behaviourtest/drivers/install/composed.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
 )
 
 // composedDriver wraps a mintDriver, ensurer, and an internal
@@ -17,6 +19,12 @@ type composedDriver struct {
 	mint    mintDriver
 	ensurer ensurer
 	logf    func(string, ...any)
+
+	// rate, when set, samples the shared installation token's primary
+	// rate-limit budget on every allocation and release, so a suite
+	// that later goes blind on 403s shows in its own log how the
+	// budget drained across the run (#6702).
+	rate forge.RateLimitReporter
 
 	names    chan string // buffered channel of available repo names
 	capacity int
@@ -81,6 +89,7 @@ func (d *composedDriver) AllocateRepo(ctx context.Context) (string, error) {
 	}
 
 	d.logf("[driver] allocated %s/%s", d.org, name)
+	d.logRateLimit("after allocating " + d.org + "/" + name)
 	return name, nil
 }
 
@@ -99,6 +108,7 @@ func (d *composedDriver) DeallocateRepo(_ context.Context, repoName string) erro
 	// non-blocking.
 	d.names <- repoName
 	d.logf("[driver] deallocated %s/%s", d.org, repoName)
+	d.logRateLimit("after deallocating " + d.org + "/" + repoName)
 	return nil
 }
 
@@ -139,3 +149,25 @@ func (d *composedDriver) Capacity() int {
 
 // Compile-time check.
 var _ Driver = (*composedDriver)(nil)
+
+// withRateLimitReporter attaches client as the driver's rate-limit
+// sampler when it reports one; other clients leave sampling off.
+func withRateLimitReporter(d Driver, client forge.Client) Driver {
+	if cd, ok := d.(*composedDriver); ok {
+		if r, ok := client.(forge.RateLimitReporter); ok {
+			cd.rate = r
+		}
+	}
+	return d
+}
+
+// logRateLimit writes one primary-quota sample, if a reporter is set
+// and has observed a response.
+func (d *composedDriver) logRateLimit(when string) {
+	if d.rate == nil {
+		return
+	}
+	if rl, seen := d.rate.RateLimit(); seen {
+		d.logf("[driver] rate limit %s: %s", when, rl)
+	}
+}

--- a/pkg/behaviourtest/drivers/install/composed_test.go
+++ b/pkg/behaviourtest/drivers/install/composed_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
 )
 
 // fakeMintDriver is a test double for mintDriver.
@@ -253,4 +255,39 @@ type failingEnsurer struct {
 
 func (f *failingEnsurer) EnsureRepo(_ context.Context, _, _ string) error {
 	return f.err
+}
+
+// rateReportingClient is a forge.Client that also reports a fixed
+// rate-limit observation.
+type rateReportingClient struct {
+	forge.Client
+	rl   forge.RateLimit
+	seen bool
+}
+
+func (c *rateReportingClient) RateLimit() (forge.RateLimit, bool) { return c.rl, c.seen }
+
+func TestComposedDriver_SamplesRateLimitOnAllocateAndDeallocate(t *testing.T) {
+	var lines []string
+	logf := func(format string, args ...any) { lines = append(lines, fmt.Sprintf(format, args...)) }
+	e := newFakeEnsurer()
+	d, err := newComposedDriver("org", &fakeMintDriver{}, e, 2, logf)
+	require.NoError(t, err)
+
+	// A client without a reporter, or one that has observed nothing yet, samples nothing.
+	withRateLimitReporter(d, &rateReportingClient{})
+	name, err := d.AllocateRepo(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, d.DeallocateRepo(context.Background(), name))
+	for _, l := range lines {
+		assert.NotContains(t, l, "rate limit")
+	}
+
+	withRateLimitReporter(d, &rateReportingClient{seen: true, rl: forge.RateLimit{Limit: 5000, Remaining: 42, Reset: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), Resource: "core"}})
+	lines = nil
+	name, err = d.AllocateRepo(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, d.DeallocateRepo(context.Background(), name))
+	assert.Contains(t, lines, "[driver] rate limit after allocating org/"+name+": remaining=42/5000 reset=2026-01-01T00:00:00Z resource=core")
+	assert.Contains(t, lines, "[driver] rate limit after deallocating org/"+name+": remaining=42/5000 reset=2026-01-01T00:00:00Z resource=core")
 }

--- a/pkg/behaviourtest/drivers/install/repopool_cfmint_previews.go
+++ b/pkg/behaviourtest/drivers/install/repopool_cfmint_previews.go
@@ -105,7 +105,11 @@ func buildCFMintDriver(
 	ens := newRepoEnsurer(e2eCfg, client, token, binary, logf)
 
 	// Construct and return the composed driver.
-	return newComposedDriver(org, md, ens, poolSize, logf)
+	d, err := newComposedDriver(org, md, ens, poolSize, logf)
+	if err != nil {
+		return nil, err
+	}
+	return withRateLimitReporter(d, client), nil
 }
 
 // cfmintMintDriver deploys a CF Worker preview mint and uses the derived

--- a/pkg/behaviourtest/drivers/install/repopool_external_mint.go
+++ b/pkg/behaviourtest/drivers/install/repopool_external_mint.go
@@ -44,7 +44,11 @@ func NewRepoPoolExternalMint(
 		GCPProjectID: gcpProjectID,
 	}
 	ens := newRepoEnsurer(ensCfg, client, token, binary, logf)
-	return newComposedDriver(org, md, ens, poolSize, logf)
+	d, err := newComposedDriver(org, md, ens, poolSize, logf)
+	if err != nil {
+		return nil, err
+	}
+	return withRateLimitReporter(d, client), nil
 }
 
 // Compile-time check: NewRepoPoolExternalMint satisfies Factory.

--- a/pkg/e2etest/testutil.go
+++ b/pkg/e2etest/testutil.go
@@ -98,9 +98,19 @@ func acquireOrg(ctx context.Context, cfg envConfig, runID string, pool []string,
 		acquired, err := tryCreateLock(ctx, client, org, runID, logf)
 		if err != nil {
 			logf("[org-pool] Error trying %s: %v", org, err)
-			// Rate limits are per-user, not per-org — trying more orgs
-			// just burns quota and delays recovery. Break immediately.
+			// Rate-limit scope depends on the credential: installation
+			// tokens are minted per org, a shared PAT is limited per user.
 			if gh.IsRateLimitError(err) {
+				if cfg.useMint {
+					// Installation tokens are minted per org, so the
+					// limit is per org too: another org's token still
+					// has its own budget.
+					logf("[org-pool] %s installation token is rate limited, trying the next org", org)
+					sawRateLimit = true // still back off if every org turns out limited
+					continue
+				}
+				// A shared PAT is limited per user: trying more orgs
+				// just burns quota and delays recovery.
 				logf("[org-pool] Hit rate limit, skipping remaining orgs this round")
 				sawRateLimit = true
 				break
@@ -166,6 +176,16 @@ func acquireOrg(ctx context.Context, cfg envConfig, runID string, pool []string,
 			if err != nil {
 				logf("[org-pool] Error trying %s: %v", org, err)
 				if gh.IsRateLimitError(err) {
+					if cfg.useMint {
+						// Installation tokens are minted per org, so the
+						// limit is per org too: another org's token still
+						// has its own budget.
+						logf("[org-pool] %s installation token is rate limited, trying the next org", org)
+						roundRateLimited = true // still back off if every org turns out limited
+						continue
+					}
+					// A shared PAT is limited per user: trying more orgs
+					// just burns quota and delays recovery.
 					logf("[org-pool] Hit rate limit, skipping remaining orgs this round")
 					roundRateLimited = true
 					break


### PR DESCRIPTION
## Summary

Instrumentation step for the first of the two real causes behind the #6647 behaviour-test failures (diagnosed on #6697): the pool-org installation token's API budget is exhausted ~10 minutes into the suite, after which the harness waits poll blind. Two runs on different orgs (halfsend-10 and halfsend-06) showed the same onset; the second already had #6669's backoff.

Which limit fires (primary hourly vs secondary) and who spends the budget cannot be told from today's logs: the client never reads `X-RateLimit-*`, and its exhausted-retry error (`403 retryable error after 5 attempts …`) does not satisfy its own `IsRateLimitError`. This PR makes the numbers visible so the fix (conditional requests / circuit breaker / parallelism) is chosen from evidence rather than guessed — which is how #6697 went wrong the first time.

## Related Issue

Refs #6702 (left open for the fix step)

## Changes

- `forge.RateLimit` + `forge.RateLimitReporter`: the last observed primary-quota state (`X-RateLimit-Limit/Remaining/Reset/Resource`), with a `String()` that renders absent fields as `unknown` rather than plausible zeros.
- `LiveClient` records the headers of every response and implements the reporter.
- Exhausted-retry error for 429 and retryable 403 is now `rate limit: retryable error after N attempts on … [remaining=0/5000 reset=… resource=core]`, so `IsRateLimitError` matches it. The budget in the brackets is parsed from **the response that failed**; when that response carries no `X-RateLimit-*` (secondary-limit shape), the message says so and names the last observation with its age — a stale value is never presented as the failing response's budget. 5xx exhaustion is unchanged.
- Org-pool acquisition (`pkg/e2etest`): with mint, tokens are minted per org so the limit is per org — a rate-limited org is now skipped for the next one instead of aborting the round (the round still records the limit, so if every org turns out limited the existing between-round back-off applies); the shared-PAT path is unchanged. Without this, making the exhausted-retry 403 recognisable would have activated a stale "limits are per user" assumption.
- Behaviour suite: the composed pool driver logs `[driver] rate limit after allocating|deallocating <org/repo>: remaining=…` on **every** allocation and release (not just the first ensure per repo, which the `ensured` cache short-circuits), so the samples span the whole run.

## Testing

- [x] `go vet`, `gofmt`; `go test -race ./internal/forge/... ./pkg/behaviourtest/drivers/install/ ./pkg/e2etest/`
- [x] `TestDo_ObservesRateLimitHeaders`, `TestDo_ResponseWithoutRateLimitHeadersKeepsPreviousObservation`, `TestDo_RateLimitExhaustedErrorSelfIdentifies`, `TestDo_RateLimitExhaustedWithoutHeadersNamesLastObservation` (secondary-limit shape), `TestDo_ServerErrorExhaustedIsNotARateLimit`, `TestRateLimitString_UnknownFields`, `TestComposedDriver_SamplesRateLimitOnAllocateAndDeallocate`
- [ ] One E2E behaviour run to read the drain curve and the resource/limit on the 403s (this PR's purpose)

## Follow-ups (not here)

- Once #6698 lands, the harness-wait timeout diagnostics can append the reporter's state too; kept out to avoid a conflict with that PR.
- `forge.IsTransient` still excludes exhausted rate limits, so `steps/cleanup.go` will not retry them; now that the error self-identifies, it could consult `IsRateLimitError`.

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] I wrote this contribution myself and can explain all changes in it
