### PR TITLE
fix(runtime): terminate stray sandbox processes between iterations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 	@echo "  go-vet               - Run go vet"
 	@echo "  go-tidy              - Run go mod tidy"
 	@echo "  lint-md-links        - Check markdown files for broken in-repo links and anchors"
-	@echo "  script-test          - Run shell script tests (reconcile-repos, topissues, gitlint-rules, artifact redaction)"
+	@echo "  script-test          - Run shell script tests (reconcile-repos, topissues, gitlint-rules, artifact redaction, kill_stray_processes)"
 	@echo "  test                 - Run all checks: lint-all, go-test, script-test, lint-eval-cases"
 	@echo "  e2e-test             - Run admin e2e tests (CI: OIDC mint; local: gh auth login or GH_TOKEN)"
 	@echo "  behaviour-test       - Run Gherkin behaviour tests (installs fullsend per-repo; CI: OIDC mint)"
@@ -196,6 +196,7 @@ script-test:
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/.github/scripts/setup-agent-env-test.sh)
 	$(call run-timed,bash hack/gitlab-runner-vm/executor/prepare_validation_test.sh)
+	$(call run-timed,bash internal/runtime/kill_stray_processes_test.sh)
 	$(call run-timed,python3 skills/topissues/scripts/topissues_test.py)
 	$(call run-timed,python3 skills/nextwork/scripts/nextwork_test.py)
 	$(call run-timed,python3 skills/analyze-transcript/analyze_transcript_test.py)

--- a/docs/contributing/runtime-implementation.md
+++ b/docs/contributing/runtime-implementation.md
@@ -121,12 +121,14 @@ Harness `security.fail_mode` controls whether critical findings **block** the ru
 
 | Interface | Responsibility |
 |-----------|----------------|
-| `runtime.Runtime` | Name, config dir, env exports, bootstrap, run loop, per-iteration cleanup — `ClearIterationArtifacts` sweeps stray sandbox-user processes first, then deletes the iteration's files; a failed sweep is a warning, never an iteration failure |
+| `runtime.Runtime` | Name, config dir, env exports, bootstrap, run loop, per-iteration cleanup, user processes cleanup |
 | `runtime.BootstrapInput` | Portable agent name/path, skill dirs, and plugin dirs to upload |
 | `runtime.SandboxHooksBootstrap` | Optional `BootstrapInput` extension — runtime-neutral sandbox tool hook config (`security.SandboxHookConfig`); every runtime should honour it |
 | `runtime.TranscriptHandler` | Extract transcripts/debug logs; parse errors for CI annotations |
 | `runtime.DebugLogNamer` | Optional — names the per-iteration debug-log artifact (default `agent-debug.log`) |
 | `runtime.ContextBridger` | Optional — runtime auto-loads only `CLAUDE.md`, so the runner injects a `CLAUDE.md`→`AGENTS.md` pointer (Claude Code: yes; runtimes that read `AGENTS.md` natively: omit) |
+
+**Per-iteration cleanup contract.** When a validation retry reuses the sandbox, the runner calls `ClearIterationArtifacts` before the next iteration. Every runtime runs the shared `clearStrayProcesses` sweep first (it terminates the processes the previous iteration left running as the sandbox user, sparing the exec channel and the `sandbox.KeepAliveCommand` main process), then deletes the iteration's output, sessions and debug log. A failed sweep is reported as a warning and never fails the iteration. The runner holds its sandbox lock (`withSandboxLock` in `internal/cli/run.go`) across the call so the credential refreshers' uploads are never killed mid-write.
 
 A runtime whose `Bootstrap` does not type-assert `SandboxHooksBootstrap` will **not** install Tirith, SSRF, canary, or the other hook scripts. The primary security boundary is the OpenShell sandbox, its L7 egress policy, and credential placeholders (ADR 0017, ADR 0025); the hooks are defense-in-depth that every runtime should wire rather than silently drop ([ADR 0090](../ADRs/0090-runtime-neutral-sandbox-hooks-contract.md)). Fill in the matrix column above either way.
 

--- a/docs/contributing/runtime-implementation.md
+++ b/docs/contributing/runtime-implementation.md
@@ -121,7 +121,7 @@ Harness `security.fail_mode` controls whether critical findings **block** the ru
 
 | Interface | Responsibility |
 |-----------|----------------|
-| `runtime.Runtime` | Name, config dir, env exports, bootstrap, run loop, per-iteration artifact cleanup |
+| `runtime.Runtime` | Name, config dir, env exports, bootstrap, run loop, per-iteration cleanup — `ClearIterationArtifacts` sweeps stray sandbox-user processes first, then deletes the iteration's files; a failed sweep is a warning, never an iteration failure |
 | `runtime.BootstrapInput` | Portable agent name/path, skill dirs, and plugin dirs to upload |
 | `runtime.SandboxHooksBootstrap` | Optional `BootstrapInput` extension — runtime-neutral sandbox tool hook config (`security.SandboxHookConfig`); every runtime should honour it |
 | `runtime.TranscriptHandler` | Extract transcripts/debug logs; parse errors for CI annotations |

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -481,6 +481,8 @@ Vendoring commit messages use title + body (upload and stale delete). `github st
 │  │                                          │                   │
 │  │ Phase 1 — inline validation:             │                   │
 │  │ for i := 1; i <= max_iterations; i++ {   │                   │
+│  │   if i > 1: ClearIterationArtifacts      │                   │
+│  │     (sweep stray processes, clear output)│                   │
 │  │   run agent → extract output             │                   │
 │  │   SafeDownload repo (non-fatal on fail)  │                   │
 │  │   run validation script                  │                   │

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -34,6 +34,7 @@ sequenceDiagram
   R->>S: .env, host files
   R->>S: Bootstrap
   R->>S: OIDC token (4-min refresh)
+  R->>S: clean up stray processes (between iterations)
   R->>S: Run (per iteration)
   S->>A: start + hook wiring
   loop tool-use loop
@@ -45,16 +46,6 @@ sequenceDiagram
   R->>S: extract artifacts
   R->>R: verdict, metrics.json
 ```
-
-- **Between iterations** (a validation retry reuses the same sandbox), the runner calls the runtime's
-  `ClearIterationArtifacts`. It first terminates any processes the previous iteration left running as
-  the sandbox user — a backgrounded tool command (`nohup … &`) is reparented and survives the agent
-  process's exit (pi's bash tool kills its process tree only on abort/timeout; the same survivors are
-  observed after a Claude Code run), and would otherwise keep holding files, burning CPU and writing
-  into the workspace the next iteration reads — and then removes the previous iteration's output,
-  sessions/transcripts and debug log. The sandbox's keep-alive main process and the exec channel
-  itself are spared, the sweep is serialized against the credential refreshers' writes into the
-  sandbox, and a failed sweep is a warning, never an iteration failure.
 
 ## Choosing between claude and pi
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -46,6 +46,16 @@ sequenceDiagram
   R->>R: verdict, metrics.json
 ```
 
+- **Between iterations** (a validation retry reuses the same sandbox), the runner calls the runtime's
+  `ClearIterationArtifacts`. It first terminates any processes the previous iteration left running as
+  the sandbox user — a backgrounded tool command (`nohup … &`) is reparented and survives the agent
+  process's exit (pi's bash tool kills its process tree only on abort/timeout; the same survivors are
+  observed after a Claude Code run), and would otherwise keep holding files, burning CPU and writing
+  into the workspace the next iteration reads — and then removes the previous iteration's output,
+  sessions/transcripts and debug log. The sandbox's keep-alive main process and the exec channel
+  itself are spared, the sweep is serialized against the credential refreshers' writes into the
+  sandbox, and a failed sweep is a warning, never an iteration failure.
+
 ## Choosing between claude and pi
 
 | | Claude Code | pi |

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1922,8 +1922,8 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		// Clear sandbox-side output and transcripts so the next iteration starts fresh.
 		if iteration > 1 {
 			// Held across the sweep so a credential refresher's upload/exec
-			// is never caught mid-write (see sandboxQuiesceMu).
-			clearErr := withSandboxQuiesce(func(waited time.Duration) {
+			// is never caught mid-write (see sandboxMu).
+			clearErr := withSandboxLock(ctx, func(waited time.Duration) {
 				printer.StepInfo(fmt.Sprintf(
 					"Waiting %s for a credential refresh to finish before clearing the sandbox", waited))
 			}, func() error {
@@ -3629,7 +3629,7 @@ func readOIDCAuthFile(path string) (string, error) {
 
 var oidcRefreshInterval = 4 * time.Minute
 
-// sandboxQuiesceMu serializes the between-iteration stray-process sweep
+// sandboxMu serializes the between-iteration stray-process sweep
 // (runtime.ClearIterationArtifacts TERM/KILLs every sandbox-user process
 // outside its own exec) against the background credential refreshers that
 // write into the sandbox from the host. refreshOIDCToken's
@@ -3651,49 +3651,53 @@ var oidcRefreshInterval = 4 * time.Minute
 // ClearIterationArtifacts, has to be checked against that margin: once the
 // worst-case hold approaches the tick interval a refresh can miss its slot
 // and the token can expire before the next one lands. Take the lock through
-// withSandboxQuiesce rather than directly, so a panic inside the critical
+// withSandboxLock rather than directly, so a panic inside the critical
 // section cannot leave it held — the deferred oidcWg/refreshWg waits would
 // then hang the run instead of surfacing the panic.
-var sandboxQuiesceMu sync.Mutex
+var sandboxMu sync.Mutex
 
-// sandboxQuiesceWarnAfter is how long withSandboxQuiesce waits for the lock
+// sandboxLockWarnAfter is how long withSandboxLock waits for the lock
 // before telling the caller's notify that something else holds it;
-// sandboxQuiescePoll is how often it retries meanwhile. Only the iteration
+// sandboxLockPoll is how often every waiter retries meanwhile. Only the iteration
 // loop passes a notify: a sweep waiting on a refresher stalls visible
 // progress, while a refresher waiting on a sweep is routine.
 var (
-	sandboxQuiesceWarnAfter = 5 * time.Second
-	sandboxQuiescePoll      = 100 * time.Millisecond
+	sandboxLockWarnAfter = 5 * time.Second
+	sandboxLockPoll      = 100 * time.Millisecond
 )
 
-// withSandboxQuiesce runs fn holding sandboxQuiesceMu (see there for what it
+// withSandboxLock runs fn holding sandboxMu (see there for what it
 // protects and for the hold budget); the lock is released even if fn panics.
 // notify, when non-nil, is called once if the lock is still not free after
-// sandboxQuiesceWarnAfter, with the time waited so far.
-func withSandboxQuiesce(notify func(waited time.Duration), fn func() error) error {
-	acquireSandboxQuiesce(notify)
-	defer sandboxQuiesceMu.Unlock()
+// sandboxLockWarnAfter, with the time waited so far. A ctx cancelled while
+// waiting returns ctx.Err() without running fn, so a run shutting down is
+// not held up by a holder's in-flight sandbox exec.
+func withSandboxLock(ctx context.Context, notify func(waited time.Duration), fn func() error) error {
+	if err := acquireSandboxLock(ctx, notify); err != nil {
+		return err
+	}
+	defer sandboxMu.Unlock()
 	return fn()
 }
 
-func acquireSandboxQuiesce(notify func(waited time.Duration)) {
-	if sandboxQuiesceMu.TryLock() {
-		return
+func acquireSandboxLock(ctx context.Context, notify func(waited time.Duration)) error {
+	if sandboxMu.TryLock() {
+		return nil
 	}
-	if notify == nil {
-		sandboxQuiesceMu.Lock()
-		return
-	}
-	// TryLock in a loop, so the wait can be reported while it is happening
-	// rather than only after the fact.
+	// TryLock in a loop rather than Lock, so the wait can be reported while
+	// it is happening and abandoned when ctx is cancelled.
 	start := time.Now()
 	warned := false
 	for {
-		time.Sleep(sandboxQuiescePoll)
-		if sandboxQuiesceMu.TryLock() {
-			return
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sandboxLockPoll):
 		}
-		if waited := time.Since(start); !warned && waited >= sandboxQuiesceWarnAfter {
+		if sandboxMu.TryLock() {
+			return nil
+		}
+		if waited := time.Since(start); notify != nil && !warned && waited >= sandboxLockWarnAfter {
 			notify(waited.Round(time.Second))
 			warned = true
 		}
@@ -3765,8 +3769,8 @@ func refreshOIDCToken(ctx context.Context, sandboxName, oidcURL, oidcAuth string
 
 	remotePath := sandbox.SandboxWorkspace + "/.gcp-oidc-token"
 	// The upload's in-sandbox tar truncates the token on open; hold the
-	// quiesce lock so the between-iteration sweep cannot kill it mid-write.
-	uploadErr := withSandboxQuiesce(nil, func() error {
+	// sandbox lock so the between-iteration sweep cannot kill it mid-write.
+	uploadErr := withSandboxLock(ctx, nil, func() error {
 		return sandbox.UploadFile(sandboxName, tmpFile.Name(), remotePath)
 	})
 	if uploadErr != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1921,7 +1921,15 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 
 		// Clear sandbox-side output and transcripts so the next iteration starts fresh.
 		if iteration > 1 {
-			if clearErr := rt.ClearIterationArtifacts(sandboxName); clearErr != nil {
+			// Held across the sweep so a credential refresher's upload/exec
+			// is never caught mid-write (see sandboxQuiesceMu).
+			clearErr := withSandboxQuiesce(func(waited time.Duration) {
+				printer.StepInfo(fmt.Sprintf(
+					"Waiting %s for a credential refresh to finish before clearing the sandbox", waited))
+			}, func() error {
+				return rt.ClearIterationArtifacts(sandboxName)
+			})
+			if clearErr != nil {
 				printer.StepWarn("Failed to clear sandbox output: " + clearErr.Error())
 			}
 		}
@@ -3621,6 +3629,77 @@ func readOIDCAuthFile(path string) (string, error) {
 
 var oidcRefreshInterval = 4 * time.Minute
 
+// sandboxQuiesceMu serializes the between-iteration stray-process sweep
+// (runtime.ClearIterationArtifacts TERM/KILLs every sandbox-user process
+// outside its own exec) against the background credential refreshers that
+// write into the sandbox from the host. refreshOIDCToken's
+// `openshell sandbox upload` runs a sandbox-user `/bin/bash -c 'mkdir -p …
+// && cat | tar xf - -C …'` chain (ppid 1, indistinguishable from a stray)
+// and tar truncates the target on open, so a kill mid-write would leave an
+// empty .gcp-oidc-token until the next 4-minute tick. The whole tick is the
+// expired-token window, not part of it: the truncation destroyed the token
+// that was there, and GHA OIDC tokens live 5 minutes. reseedOpenAIAuth's
+// seed exec is the other writer. Both hold the lock across the write; the
+// iteration loop holds it across ClearIterationArtifacts.
+//
+// Lock-hold budget. The iteration side is the long holder:
+// ClearIterationArtifacts is the sweep exec (runtime's 15s snippet timeout
+// plus sandbox.ExecContext's 10s slack) followed by the file removal (10s
+// plus the same 10s slack), so about 45s worst case. That is how long a
+// refresher can be held off, against a 4-minute OIDC tick and a 5-minute
+// token life. Raising either timeout, or adding a third exec to
+// ClearIterationArtifacts, has to be checked against that margin: once the
+// worst-case hold approaches the tick interval a refresh can miss its slot
+// and the token can expire before the next one lands. Take the lock through
+// withSandboxQuiesce rather than directly, so a panic inside the critical
+// section cannot leave it held — the deferred oidcWg/refreshWg waits would
+// then hang the run instead of surfacing the panic.
+var sandboxQuiesceMu sync.Mutex
+
+// sandboxQuiesceWarnAfter is how long withSandboxQuiesce waits for the lock
+// before telling the caller's notify that something else holds it;
+// sandboxQuiescePoll is how often it retries meanwhile. Only the iteration
+// loop passes a notify: a sweep waiting on a refresher stalls visible
+// progress, while a refresher waiting on a sweep is routine.
+var (
+	sandboxQuiesceWarnAfter = 5 * time.Second
+	sandboxQuiescePoll      = 100 * time.Millisecond
+)
+
+// withSandboxQuiesce runs fn holding sandboxQuiesceMu (see there for what it
+// protects and for the hold budget); the lock is released even if fn panics.
+// notify, when non-nil, is called once if the lock is still not free after
+// sandboxQuiesceWarnAfter, with the time waited so far.
+func withSandboxQuiesce(notify func(waited time.Duration), fn func() error) error {
+	acquireSandboxQuiesce(notify)
+	defer sandboxQuiesceMu.Unlock()
+	return fn()
+}
+
+func acquireSandboxQuiesce(notify func(waited time.Duration)) {
+	if sandboxQuiesceMu.TryLock() {
+		return
+	}
+	if notify == nil {
+		sandboxQuiesceMu.Lock()
+		return
+	}
+	// TryLock in a loop, so the wait can be reported while it is happening
+	// rather than only after the fact.
+	start := time.Now()
+	warned := false
+	for {
+		time.Sleep(sandboxQuiescePoll)
+		if sandboxQuiesceMu.TryLock() {
+			return
+		}
+		if waited := time.Since(start); !warned && waited >= sandboxQuiesceWarnAfter {
+			notify(waited.Round(time.Second))
+			warned = true
+		}
+	}
+}
+
 func runOIDCRefresh(ctx context.Context, sandboxName, oidcURL, oidcAuth string, printer *ui.Printer) {
 	ticker := time.NewTicker(oidcRefreshInterval)
 	defer ticker.Stop()
@@ -3685,8 +3764,13 @@ func refreshOIDCToken(ctx context.Context, sandboxName, oidcURL, oidcAuth string
 	tmpFile.Close()
 
 	remotePath := sandbox.SandboxWorkspace + "/.gcp-oidc-token"
-	if err := sandbox.UploadFile(sandboxName, tmpFile.Name(), remotePath); err != nil {
-		return fmt.Errorf("copying token to sandbox: %w", err)
+	// The upload's in-sandbox tar truncates the token on open; hold the
+	// quiesce lock so the between-iteration sweep cannot kill it mid-write.
+	uploadErr := withSandboxQuiesce(nil, func() error {
+		return sandbox.UploadFile(sandboxName, tmpFile.Name(), remotePath)
+	})
+	if uploadErr != nil {
+		return fmt.Errorf("copying token to sandbox: %w", uploadErr)
 	}
 
 	return nil

--- a/internal/cli/run_openai.go
+++ b/internal/cli/run_openai.go
@@ -137,10 +137,10 @@ var openAIDeleteBackoff = 3 * time.Second
 // process in the sandbox receives right now.
 func sandboxOpenAIPlaceholder(ctx context.Context, sandboxName string) (string, error) {
 	// ExecContext already wraps the command in `sh -c`. Held under the
-	// quiesce lock so the between-iteration sweep never kills this exec.
+	// sandbox lock so the between-iteration sweep never kills this exec.
 	var out, stderr string
 	var code int
-	err := withSandboxQuiesce(nil, func() error {
+	err := withSandboxLock(ctx, nil, func() error {
 		var execErr error
 		out, stderr, code, execErr = sandbox.ExecContext(ctx, sandboxName, `printf %s "${OPENAI_API_KEY:-}"`, openAIPlaceholderExecTimeout)
 		return execErr
@@ -213,17 +213,17 @@ func reseedOpenAIAuth(ctx context.Context, h openAIProviderHandle, previous stri
 	// starting at this very moment seeds too (from its own exec
 	// environment, which may still carry the previous placeholder), and
 	// whichever write lands last wins. One re-seed closes that window.
-	// Only the write is taken under the quiesce lock, and one exec at a
+	// Only the write is taken under the sandbox lock, and one exec at a
 	// time: the seed writes atomically (mv -f) but the between-iteration
 	// sweep must not kill it mid-run, whereas the grep below only reads and
 	// costs nothing if it is killed. Each hold is one exec (30s + slack), so
-	// a sweep never waits on the whole retry loop — see sandboxQuiesceMu's
+	// a sweep never waits on the whole retry loop — see sandboxMu's
 	// hold budget.
 	seed := func() error {
 		for attempt := 0; attempt < 2; attempt++ {
 			var stderr string
 			var code int
-			err := withSandboxQuiesce(nil, func() error {
+			err := withSandboxLock(ctx, nil, func() error {
 				var execErr error
 				_, stderr, code, execErr = sandbox.ExecContext(ctx, h.sandbox, h.authSeed, openAIPlaceholderExecTimeout)
 				return execErr

--- a/internal/cli/run_openai.go
+++ b/internal/cli/run_openai.go
@@ -136,8 +136,15 @@ var openAIDeleteBackoff = 3 * time.Second
 // sandboxOpenAIPlaceholder returns the OPENAI_API_KEY placeholder a new
 // process in the sandbox receives right now.
 func sandboxOpenAIPlaceholder(ctx context.Context, sandboxName string) (string, error) {
-	// ExecContext already wraps the command in `sh -c`.
-	out, stderr, code, err := sandbox.ExecContext(ctx, sandboxName, `printf %s "${OPENAI_API_KEY:-}"`, openAIPlaceholderExecTimeout)
+	// ExecContext already wraps the command in `sh -c`. Held under the
+	// quiesce lock so the between-iteration sweep never kills this exec.
+	var out, stderr string
+	var code int
+	err := withSandboxQuiesce(nil, func() error {
+		var execErr error
+		out, stderr, code, execErr = sandbox.ExecContext(ctx, sandboxName, `printf %s "${OPENAI_API_KEY:-}"`, openAIPlaceholderExecTimeout)
+		return execErr
+	})
 	if err != nil {
 		return "", err
 	}
@@ -206,21 +213,39 @@ func reseedOpenAIAuth(ctx context.Context, h openAIProviderHandle, previous stri
 	// starting at this very moment seeds too (from its own exec
 	// environment, which may still carry the previous placeholder), and
 	// whichever write lands last wins. One re-seed closes that window.
-	for attempt := 0; attempt < 2; attempt++ {
-		_, stderr, code, err := sandbox.ExecContext(ctx, h.sandbox, h.authSeed, openAIPlaceholderExecTimeout)
-		if err != nil {
-			return "", fmt.Errorf("re-seeding pi auth.json: %w", err)
+	// Only the write is taken under the quiesce lock, and one exec at a
+	// time: the seed writes atomically (mv -f) but the between-iteration
+	// sweep must not kill it mid-run, whereas the grep below only reads and
+	// costs nothing if it is killed. Each hold is one exec (30s + slack), so
+	// a sweep never waits on the whole retry loop — see sandboxQuiesceMu's
+	// hold budget.
+	seed := func() error {
+		for attempt := 0; attempt < 2; attempt++ {
+			var stderr string
+			var code int
+			err := withSandboxQuiesce(nil, func() error {
+				var execErr error
+				_, stderr, code, execErr = sandbox.ExecContext(ctx, h.sandbox, h.authSeed, openAIPlaceholderExecTimeout)
+				return execErr
+			})
+			if err != nil {
+				return fmt.Errorf("re-seeding pi auth.json: %w", err)
+			}
+			if code != 0 {
+				return fmt.Errorf("re-seeding pi auth.json: exit %d: %s", code, strings.TrimSpace(stderr))
+			}
+			if h.authFile == "" {
+				return nil
+			}
+			_, _, code, err = sandbox.ExecContext(ctx, h.sandbox, "command -p grep -qF "+shellQuote(current)+" "+shellQuote(h.authFile), openAIPlaceholderExecTimeout)
+			if err == nil && code == 0 {
+				return nil
+			}
 		}
-		if code != 0 {
-			return "", fmt.Errorf("re-seeding pi auth.json: exit %d: %s", code, strings.TrimSpace(stderr))
-		}
-		if h.authFile == "" {
-			break
-		}
-		_, _, code, err = sandbox.ExecContext(ctx, h.sandbox, "command -p grep -qF "+shellQuote(current)+" "+shellQuote(h.authFile), openAIPlaceholderExecTimeout)
-		if err == nil && code == 0 {
-			break
-		}
+		return nil
+	}
+	if err := seed(); err != nil {
+		return "", err
 	}
 	printer.StepInfo("pi auth.json re-seeded with the refreshed OpenAI placeholder")
 	return current, nil

--- a/internal/cli/run_openai_test.go
+++ b/internal/cli/run_openai_test.go
@@ -1139,9 +1139,9 @@ func TestResolveOpenAICredential_ConfigFallback(t *testing.T) {
 }
 
 // The re-seed's sandbox execs must wait for a between-iteration sweep in
-// progress (sandboxQuiesceMu): none reaches the fake openshell while the
+// progress (sandboxMu): none reaches the fake openshell while the
 // lock is held, and the seed lands once it is released.
-func TestReseedOpenAIAuth_WaitsForSandboxQuiesce(t *testing.T) {
+func TestReseedOpenAIAuth_WaitsForSandboxLock(t *testing.T) {
 	binDir := t.TempDir()
 	log := filepath.Join(binDir, "log")
 	script := "#!/bin/sh\ncase \"$*\" in *'printf %s'*) echo polled >> " + shellQuoteForTest(log) + "; printf '" + ph("v222_OPENAI_API_KEY") + "'; exit 0 ;; *auth.json*) echo seeded >> " + shellQuoteForTest(log) + "; exit 0 ;; esac; exit 1\n"
@@ -1149,7 +1149,7 @@ func TestReseedOpenAIAuth_WaitsForSandboxQuiesce(t *testing.T) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	h := openAIProviderHandle{sandbox: "fs-x", authSeed: `printf '{"openai":...}' > /sandbox/pi-config/auth.json`}
 
-	sandboxQuiesceMu.Lock()
+	sandboxMu.Lock()
 	done := make(chan error, 1)
 	go func() {
 		_, err := reseedOpenAIAuth(context.Background(), h, ph("v111_OPENAI_API_KEY"), ui.New(io.Discard))
@@ -1157,13 +1157,13 @@ func TestReseedOpenAIAuth_WaitsForSandboxQuiesce(t *testing.T) {
 	}()
 	select {
 	case err := <-done:
-		sandboxQuiesceMu.Unlock()
+		sandboxMu.Unlock()
 		t.Fatalf("re-seed ran while the sweep held the lock (err=%v)", err)
 	case <-time.After(300 * time.Millisecond):
 	}
 	_, statErr := os.Stat(log)
 	assert.True(t, os.IsNotExist(statErr), "no exec reached the sandbox while the sweep held the lock")
-	sandboxQuiesceMu.Unlock()
+	sandboxMu.Unlock()
 	select {
 	case err := <-done:
 		require.NoError(t, err)

--- a/internal/cli/run_openai_test.go
+++ b/internal/cli/run_openai_test.go
@@ -1137,3 +1137,40 @@ func TestResolveOpenAICredential_ConfigFallback(t *testing.T) {
 		assert.Contains(t, err.Error(), "inference.openai in config.yaml")
 	})
 }
+
+// The re-seed's sandbox execs must wait for a between-iteration sweep in
+// progress (sandboxQuiesceMu): none reaches the fake openshell while the
+// lock is held, and the seed lands once it is released.
+func TestReseedOpenAIAuth_WaitsForSandboxQuiesce(t *testing.T) {
+	binDir := t.TempDir()
+	log := filepath.Join(binDir, "log")
+	script := "#!/bin/sh\ncase \"$*\" in *'printf %s'*) echo polled >> " + shellQuoteForTest(log) + "; printf '" + ph("v222_OPENAI_API_KEY") + "'; exit 0 ;; *auth.json*) echo seeded >> " + shellQuoteForTest(log) + "; exit 0 ;; esac; exit 1\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "openshell"), []byte(script), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	h := openAIProviderHandle{sandbox: "fs-x", authSeed: `printf '{"openai":...}' > /sandbox/pi-config/auth.json`}
+
+	sandboxQuiesceMu.Lock()
+	done := make(chan error, 1)
+	go func() {
+		_, err := reseedOpenAIAuth(context.Background(), h, ph("v111_OPENAI_API_KEY"), ui.New(io.Discard))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		sandboxQuiesceMu.Unlock()
+		t.Fatalf("re-seed ran while the sweep held the lock (err=%v)", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	_, statErr := os.Stat(log)
+	assert.True(t, os.IsNotExist(statErr), "no exec reached the sandbox while the sweep held the lock")
+	sandboxQuiesceMu.Unlock()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("re-seed did not proceed once the lock was released")
+	}
+	data, err := os.ReadFile(log)
+	require.NoError(t, err)
+	assert.Equal(t, "polled\nseeded\n", string(data))
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -6186,3 +6186,98 @@ agents:
 	assert.Equal(t, filepath.Join(dir, "harness", "lint.yaml"), path)
 	assert.Nil(t, deps)
 }
+
+// The token upload must wait for a between-iteration sweep in progress: the
+// in-sandbox tar truncates .gcp-oidc-token on open, so a kill mid-write
+// would leave an empty token until the next 4-minute tick. The iteration
+// loop side has no seam short of running the whole command, so it is
+// covered by the lock's documented contract rather than a test.
+func TestRefreshOIDCToken_WaitsForSandboxQuiesce(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"value":"fresh-oidc-token-content"}`)
+	}))
+	defer srv.Close()
+	stubOpenshell(t, "exit 0")
+
+	sandboxQuiesceMu.Lock()
+	done := make(chan error, 1)
+	go func() {
+		done <- refreshOIDCToken(context.Background(), "sb", srv.URL, "bearer test-auth")
+	}()
+	select {
+	case err := <-done:
+		sandboxQuiesceMu.Unlock()
+		t.Fatalf("upload ran while the sweep held the lock (err=%v)", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	sandboxQuiesceMu.Unlock()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("upload did not proceed once the lock was released")
+	}
+}
+
+// The lock must be released even when the critical section panics: the run's
+// deferred oidcWg/refreshWg waits would otherwise block on a refresher that
+// can never acquire it, hanging the process instead of surfacing the panic.
+func TestWithSandboxQuiesce_ReleasesTheLockOnPanic(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = withSandboxQuiesce(nil, func() error { panic("boom") })
+	})
+	require.True(t, sandboxQuiesceMu.TryLock(), "the quiesce lock is still held after a panic")
+	sandboxQuiesceMu.Unlock()
+}
+
+// A sweep waiting on a credential refresher must say so: nothing else prints
+// between iterations, so an unreported wait looks like a stalled run.
+func TestWithSandboxQuiesce_ReportsALongWait(t *testing.T) {
+	original := sandboxQuiesceWarnAfter
+	sandboxQuiesceWarnAfter = 50 * time.Millisecond
+	t.Cleanup(func() { sandboxQuiesceWarnAfter = original })
+
+	waited := make(chan time.Duration, 4)
+	ran := make(chan struct{})
+	done := make(chan error, 1)
+
+	sandboxQuiesceMu.Lock()
+	go func() {
+		done <- withSandboxQuiesce(
+			func(d time.Duration) { waited <- d },
+			func() error { close(ran); return nil },
+		)
+	}()
+	select {
+	case <-waited:
+	case <-time.After(10 * time.Second):
+		sandboxQuiesceMu.Unlock()
+		t.Fatal("no report while the lock was held")
+	}
+	select {
+	case <-ran:
+		sandboxQuiesceMu.Unlock()
+		t.Fatal("the critical section ran while the lock was held")
+	default:
+	}
+
+	sandboxQuiesceMu.Unlock()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the critical section did not run once the lock was released")
+	}
+	<-ran
+	assert.Empty(t, waited, "the wait is reported once, not once per poll")
+}
+
+// The common case says nothing: a refresher waiting on a sweep is routine,
+// and every refresher passes a nil notify.
+func TestWithSandboxQuiesce_UncontendedRunsWithoutReporting(t *testing.T) {
+	notified := 0
+	require.NoError(t, withSandboxQuiesce(func(time.Duration) { notified++ }, func() error { return nil }))
+	assert.Equal(t, 0, notified)
+	require.True(t, sandboxQuiesceMu.TryLock(), "the quiesce lock is still held after the call returned")
+	sandboxQuiesceMu.Unlock()
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -6192,25 +6192,25 @@ agents:
 // would leave an empty token until the next 4-minute tick. The iteration
 // loop side has no seam short of running the whole command, so it is
 // covered by the lock's documented contract rather than a test.
-func TestRefreshOIDCToken_WaitsForSandboxQuiesce(t *testing.T) {
+func TestRefreshOIDCToken_WaitsForSandboxLock(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"value":"fresh-oidc-token-content"}`)
 	}))
 	defer srv.Close()
 	stubOpenshell(t, "exit 0")
 
-	sandboxQuiesceMu.Lock()
+	sandboxMu.Lock()
 	done := make(chan error, 1)
 	go func() {
 		done <- refreshOIDCToken(context.Background(), "sb", srv.URL, "bearer test-auth")
 	}()
 	select {
 	case err := <-done:
-		sandboxQuiesceMu.Unlock()
+		sandboxMu.Unlock()
 		t.Fatalf("upload ran while the sweep held the lock (err=%v)", err)
 	case <-time.After(300 * time.Millisecond):
 	}
-	sandboxQuiesceMu.Unlock()
+	sandboxMu.Unlock()
 	select {
 	case err := <-done:
 		require.NoError(t, err)
@@ -6222,28 +6222,29 @@ func TestRefreshOIDCToken_WaitsForSandboxQuiesce(t *testing.T) {
 // The lock must be released even when the critical section panics: the run's
 // deferred oidcWg/refreshWg waits would otherwise block on a refresher that
 // can never acquire it, hanging the process instead of surfacing the panic.
-func TestWithSandboxQuiesce_ReleasesTheLockOnPanic(t *testing.T) {
+func TestWithSandboxLock_ReleasesTheLockOnPanic(t *testing.T) {
 	assert.Panics(t, func() {
-		_ = withSandboxQuiesce(nil, func() error { panic("boom") })
+		_ = withSandboxLock(context.Background(), nil, func() error { panic("boom") })
 	})
-	require.True(t, sandboxQuiesceMu.TryLock(), "the quiesce lock is still held after a panic")
-	sandboxQuiesceMu.Unlock()
+	require.True(t, sandboxMu.TryLock(), "the sandbox lock is still held after a panic")
+	sandboxMu.Unlock()
 }
 
 // A sweep waiting on a credential refresher must say so: nothing else prints
 // between iterations, so an unreported wait looks like a stalled run.
-func TestWithSandboxQuiesce_ReportsALongWait(t *testing.T) {
-	original := sandboxQuiesceWarnAfter
-	sandboxQuiesceWarnAfter = 50 * time.Millisecond
-	t.Cleanup(func() { sandboxQuiesceWarnAfter = original })
+func TestWithSandboxLock_ReportsALongWait(t *testing.T) {
+	original := sandboxLockWarnAfter
+	sandboxLockWarnAfter = 50 * time.Millisecond
+	t.Cleanup(func() { sandboxLockWarnAfter = original })
 
 	waited := make(chan time.Duration, 4)
 	ran := make(chan struct{})
 	done := make(chan error, 1)
 
-	sandboxQuiesceMu.Lock()
+	sandboxMu.Lock()
 	go func() {
-		done <- withSandboxQuiesce(
+		done <- withSandboxLock(
+			context.Background(),
 			func(d time.Duration) { waited <- d },
 			func() error { close(ran); return nil },
 		)
@@ -6251,17 +6252,17 @@ func TestWithSandboxQuiesce_ReportsALongWait(t *testing.T) {
 	select {
 	case <-waited:
 	case <-time.After(10 * time.Second):
-		sandboxQuiesceMu.Unlock()
+		sandboxMu.Unlock()
 		t.Fatal("no report while the lock was held")
 	}
 	select {
 	case <-ran:
-		sandboxQuiesceMu.Unlock()
+		sandboxMu.Unlock()
 		t.Fatal("the critical section ran while the lock was held")
 	default:
 	}
 
-	sandboxQuiesceMu.Unlock()
+	sandboxMu.Unlock()
 	select {
 	case err := <-done:
 		require.NoError(t, err)
@@ -6274,10 +6275,38 @@ func TestWithSandboxQuiesce_ReportsALongWait(t *testing.T) {
 
 // The common case says nothing: a refresher waiting on a sweep is routine,
 // and every refresher passes a nil notify.
-func TestWithSandboxQuiesce_UncontendedRunsWithoutReporting(t *testing.T) {
+func TestWithSandboxLock_UncontendedRunsWithoutReporting(t *testing.T) {
 	notified := 0
-	require.NoError(t, withSandboxQuiesce(func(time.Duration) { notified++ }, func() error { return nil }))
+	require.NoError(t, withSandboxLock(context.Background(), func(time.Duration) { notified++ }, func() error { return nil }))
 	assert.Equal(t, 0, notified)
-	require.True(t, sandboxQuiesceMu.TryLock(), "the quiesce lock is still held after the call returned")
-	sandboxQuiesceMu.Unlock()
+	require.True(t, sandboxMu.TryLock(), "the sandbox lock is still held after the call returned")
+	sandboxMu.Unlock()
+}
+
+// A waiter whose run is shutting down must not sit behind the holder's
+// in-flight sandbox exec (up to the documented ~45s hold): a cancelled
+// context abandons the wait, and the critical section never runs.
+func TestWithSandboxLock_AbandonsTheWaitWhenCancelled(t *testing.T) {
+	sandboxMu.Lock()
+	defer sandboxMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ran := false
+	done := make(chan error, 1)
+	go func() {
+		done <- withSandboxLock(ctx, nil, func() error { ran = true; return nil })
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("returned while the lock was held (err=%v)", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the wait did not stop on cancellation")
+	}
+	assert.False(t, ran, "the critical section ran without the lock")
 }

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -178,7 +178,11 @@ func (ClaudeRuntime) Run(ctx context.Context, params RunParams, printer *ui.Prin
 	return exitCode, nil
 }
 
+// ClearIterationArtifacts terminates processes the previous iteration left
+// running (see killStrayProcesses), then removes its outputs and transcripts
+// so artifacts are per-iteration.
 func (r ClaudeRuntime) ClearIterationArtifacts(sandboxName string) error {
+	clearStrayProcesses(sandbox.Exec, sandboxName, os.Stderr)
 	clearCmd := fmt.Sprintf("rm -rf %s/output/* %s/*.jsonl", r.WorkspaceDir(), r.ConfigDir())
 	_, _, _, err := sandbox.Exec(sandboxName, clearCmd, 10*time.Second)
 	return err

--- a/internal/runtime/claude_test.go
+++ b/internal/runtime/claude_test.go
@@ -597,6 +597,44 @@ func TestClaudeRuntime_ClearIterationArtifacts_OpenshellNotInPath(t *testing.T) 
 	assert.Error(t, err)
 }
 
+// ClearIterationArtifacts sweeps stray processes left by the previous
+// iteration before removing its files (see killStrayProcesses).
+func TestClaudeRuntime_ClearIterationArtifacts_SweepsStraysBeforeFiles(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "openshell.log")
+	fakeOpenshellBootstrap(t, logPath, filepath.Join(t.TempDir(), "unused"))
+
+	require.NoError(t, ClaudeRuntime{}.ClearIterationArtifacts("test-sandbox"))
+
+	logBytes, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	log := string(logBytes)
+	sweep := strings.Index(log, "ps -o pid= -o ppid=")
+	rm := strings.Index(log, "rm -rf /sandbox/workspace/output/*")
+	require.NotEqual(t, -1, sweep, "expected the stray-process sweep to run")
+	require.NotEqual(t, -1, rm, "expected the file cleanup to run")
+	assert.Less(t, sweep, rm, "sweep must precede the file cleanup")
+}
+
+// A sweep that fails (exit 124 is the only exec failure sandbox.Exec
+// reports) is warning-only: the rm -rf still runs and the result is nil.
+func TestClaudeRuntime_ClearIterationArtifacts_SweepFailureIsNotAnError(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "openshell.log")
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"echo \"$@\" >> '" + logPath + "'\n" +
+		"for last; do :; done\n" +
+		"case \"$last\" in *\"stray processes killed\"*) echo boom >&2; exit 124 ;; esac\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "openshell"), []byte(script), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	require.NoError(t, ClaudeRuntime{}.ClearIterationArtifacts("test-sandbox"))
+
+	log, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(log), "rm -rf /sandbox/workspace/output/*", "file cleanup still runs after a failed sweep")
+}
+
 func TestClaudeRuntime_ExtractTranscripts_OpenshellNotInPath(t *testing.T) {
 	t.Setenv("PATH", "")
 

--- a/internal/runtime/dummy.go
+++ b/internal/runtime/dummy.go
@@ -138,7 +138,11 @@ func (r DummyRuntime) Run(ctx context.Context, params RunParams, printer *ui.Pri
 	return exitCode, nil
 }
 
+// ClearIterationArtifacts sweeps stray processes (the dummy runtime's ops run
+// in the real sandbox, so it gets the same between-iteration hygiene as the
+// agent runtimes), then removes the previous iteration's output.
 func (r DummyRuntime) ClearIterationArtifacts(sandboxName string) error {
+	clearStrayProcesses(r.execFn(), sandboxName, os.Stderr)
 	clearCmd := fmt.Sprintf("rm -rf %s/output/*", r.WorkspaceDir())
 	_, _, _, err := r.execFn()(sandboxName, clearCmd, 10*time.Second)
 	return err

--- a/internal/runtime/dummy_playback.go
+++ b/internal/runtime/dummy_playback.go
@@ -288,7 +288,11 @@ func (r DummyPlaybackRuntime) commitToCurrentBranch(sandboxName, repoDir, entryN
 	return nil
 }
 
+// ClearIterationArtifacts sweeps stray processes (dummy-playback execs run in
+// the real sandbox, so it gets the same between-iteration hygiene as the
+// agent runtimes), then removes the previous iteration's output.
 func (r DummyPlaybackRuntime) ClearIterationArtifacts(sandboxName string) error {
+	clearStrayProcesses(r.execFn(), sandboxName, os.Stderr)
 	clearCmd := fmt.Sprintf("rm -rf %s/output/*", r.WorkspaceDir())
 	_, _, _, err := r.execFn()(sandboxName, clearCmd, 10*time.Second)
 	return err

--- a/internal/runtime/dummy_playback_test.go
+++ b/internal/runtime/dummy_playback_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -59,6 +60,41 @@ func TestDummyPlaybackRuntime_ClearIterationArtifacts(t *testing.T) {
 	rt := DummyPlaybackRuntime{}
 	err := rt.ClearIterationArtifacts("nonexistent-sandbox")
 	require.Error(t, err)
+}
+
+// ClearIterationArtifacts sweeps stray processes before removing files —
+// dummy-playback execs run in the real sandbox, so it gets the same
+// between-iteration hygiene as the agent runtimes.
+func TestDummyPlaybackRuntime_ClearIterationArtifacts_SweepsStraysBeforeFiles(t *testing.T) {
+	t.Parallel()
+
+	var cmds []string
+	rt := DummyPlaybackRuntime{ExecFn: func(_ string, cmd string, _ time.Duration) (string, string, int, error) {
+		cmds = append(cmds, cmd)
+		return "stray processes killed: 0\n", "", 0, nil
+	}}
+	require.NoError(t, rt.ClearIterationArtifacts("sb"))
+	require.Len(t, cmds, 2)
+	assert.Equal(t, killStrayProcessesScript(), cmds[0])
+	assert.Contains(t, cmds[1], "rm -rf")
+}
+
+// A failed sweep (exit 124 is the only exec failure sandbox.Exec reports)
+// is warning-only: the file cleanup still runs and the result is nil.
+func TestDummyPlaybackRuntime_ClearIterationArtifacts_SweepFailureIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	var cmds []string
+	rt := DummyPlaybackRuntime{ExecFn: func(_ string, cmd string, _ time.Duration) (string, string, int, error) {
+		cmds = append(cmds, cmd)
+		if len(cmds) == 1 {
+			return "", "boom", 124, errors.New("command timed out after 15s")
+		}
+		return "", "", 0, nil
+	}}
+	require.NoError(t, rt.ClearIterationArtifacts("sb"))
+	require.Len(t, cmds, 2)
+	assert.Contains(t, cmds[1], "rm -rf")
 }
 
 func TestLoadPlaylist(t *testing.T) {

--- a/internal/runtime/dummy_test.go
+++ b/internal/runtime/dummy_test.go
@@ -748,3 +748,37 @@ func TestExecuteBehaviourOp_CheckoutBranchExecError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "checkout_branch exec")
 }
+
+// ClearIterationArtifacts sweeps stray processes before removing files, so
+// nothing from iteration N keeps writing into what iteration N+1 reads.
+func TestDummyRuntime_ClearIterationArtifacts_SweepsStraysBeforeFiles(t *testing.T) {
+	t.Parallel()
+
+	var cmds []string
+	rt := DummyRuntime{ExecFn: func(_ string, cmd string, _ time.Duration) (string, string, int, error) {
+		cmds = append(cmds, cmd)
+		return "stray processes killed: 0\n", "", 0, nil
+	}}
+	require.NoError(t, rt.ClearIterationArtifacts("sb"))
+	require.Len(t, cmds, 2)
+	assert.Equal(t, killStrayProcessesScript(), cmds[0])
+	assert.Contains(t, cmds[1], "rm -rf")
+}
+
+// A failed sweep (exit 124 is the only exec failure sandbox.Exec reports)
+// is warning-only: the file cleanup still runs and the result is nil.
+func TestDummyRuntime_ClearIterationArtifacts_SweepFailureIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	var cmds []string
+	rt := DummyRuntime{ExecFn: func(_ string, cmd string, _ time.Duration) (string, string, int, error) {
+		cmds = append(cmds, cmd)
+		if len(cmds) == 1 {
+			return "", "boom", 124, errors.New("command timed out after 15s")
+		}
+		return "", "", 0, nil
+	}}
+	require.NoError(t, rt.ClearIterationArtifacts("sb"))
+	require.Len(t, cmds, 2)
+	assert.Contains(t, cmds[1], "rm -rf")
+}

--- a/internal/runtime/kill_stray_processes_test.sh
+++ b/internal/runtime/kill_stray_processes_test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# kill_stray_processes_test.sh — real-shell test for the stray-process sweep
+# that runtime.ClearIterationArtifacts runs inside the sandbox between
+# iterations (internal/runtime/stray_processes.go). It executes the golden
+# file testdata/kill_stray_processes.sh, which TestKillStrayProcessesScript_Golden
+# pins to the production bytes.
+#
+# The snippet kills every process of the current user it can see, so it is
+# never run against the real process table here: a fake `ps` on PATH
+# delegates to the real one and keeps only this test's own subtree, and the
+# test refuses to run the snippet unless that fake is what `ps` resolves to.
+# kill/sleep/awk/id are the real tools.
+#
+# Run from repo root: bash internal/runtime/kill_stray_processes_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNIPPET="${SCRIPT_DIR}/testdata/kill_stray_processes.sh"
+REAL_PS="$(command -v ps)"
+FAILURES=0
+
+TMP="$(mktemp -d)"
+STRAY_PIDS=()
+cleanup() {
+  local p
+  for p in "${STRAY_PIDS[@]:-}"; do
+    if [ -n "$p" ]; then
+      kill -9 "$p" 2>/dev/null || true
+    fi
+  done
+  rm -rf "${TMP}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "PASS: $*"
+}
+
+# Fake ps. The snippet's enumeration (`-u <uid>`) is delegated to the real
+# ps and then narrowed to STRAY_TEST_ROOT and its descendants (pid is column
+# 1, ppid column 2). What its liveness probes (`-p <pid,...>`) do is the
+# caller's choice: pass through untouched (they are already scoped to
+# signalled targets) or fail, for the broken-probe case below. The
+# enumeration stays scoped either way — an unscoped fake would let the sweep
+# kill this whole session.
+make_fake_ps() {
+  local dir="$1" probe="$2"
+  mkdir -p "${dir}"
+  cat > "${dir}/ps" <<EOF
+#!/bin/sh
+case " \$* " in
+  *" -p "*) ${probe} ;;
+esac
+'${REAL_PS}' "\$@" | awk -v root="\${STRAY_TEST_ROOT}" '
+  { line[NR] = \$0; pid[NR] = \$1; parent[\$1] = \$2 }
+  END {
+    keep[root] = 1
+    do {
+      changed = 0
+      for (i = 1; i <= NR; i++) {
+        p = pid[i]
+        if (!(p in keep) && (parent[p] in keep)) { keep[p] = 1; changed = 1 }
+      }
+    } while (changed)
+    for (i = 1; i <= NR; i++) if (pid[i] in keep) print line[i]
+  }'
+EOF
+  chmod +x "${dir}/ps"
+}
+
+make_fake_ps "${TMP}/bin" "exec '${REAL_PS}' \"\$@\""
+# A ps whose liveness probe fails the way a broken procps does: exit 1 with
+# nothing on stdout, indistinguishable from "none of those pids exist".
+make_fake_ps "${TMP}/probebin" 'exit 1'
+
+# A ps that always fails, for the exit-3 path.
+mkdir -p "${TMP}/badbin"
+printf '#!/bin/sh\nexit 1\n' > "${TMP}/badbin/ps"
+chmod +x "${TMP}/badbin/ps"
+
+# Safety gate: the golden is a live kill script. Refuse to run it unless
+# `ps` under the test PATH is one of the scoped fakes.
+FAKE_PATH="${TMP}/bin:${PATH}"
+PROBE_PATH="${TMP}/probebin:${PATH}"
+for dir in bin probebin; do
+  resolved="$(PATH="${TMP}/${dir}:${PATH}" command -v ps)"
+  if [ "${resolved}" != "${TMP}/${dir}/ps" ]; then
+    echo "ABORT: ps resolves to '${resolved}', not the scoped fake; refusing to run the sweep" >&2
+    exit 1
+  fi
+done
+
+# --- Fixture: strays owned by this test shell -------------------------------
+
+# Plain stray: exits on TERM.
+sleep 300 &
+STRAY_TERM=$!
+STRAY_PIDS+=("${STRAY_TERM}")
+
+# Stubborn stray: SIG_IGN survives exec, so this sleep ignores TERM and only
+# the KILL pass can remove it.
+sh -c 'trap "" TERM; exec sleep 300' &
+STRAY_IGN=$!
+STRAY_PIDS+=("${STRAY_IGN}")
+
+# Keep-alive stand-ins for the sandbox main process (sandbox.KeepAliveCommand):
+# the bare argv and a path-qualified one. BSD sleep rejects "infinity", so
+# only exercised on Linux (CI).
+KEEP=""
+KEEP_PATH=""
+if [ "$(uname)" = "Linux" ]; then
+  sleep infinity &
+  KEEP=$!
+  STRAY_PIDS+=("${KEEP}")
+  "$(command -v sleep)" infinity &
+  KEEP_PATH=$!
+  STRAY_PIDS+=("${KEEP_PATH}")
+fi
+
+sleep 0.2
+kill -0 "${STRAY_TERM}" || fail "fixture: TERM stray did not start"
+kill -0 "${STRAY_IGN}" || fail "fixture: TERM-ignoring stray did not start"
+
+# --- Run the snippet in a subshell, scoped to this test's subtree ----------
+
+expected_killed=2
+set +e
+OUT="$(STRAY_TEST_ROOT=$$ PATH="${FAKE_PATH}" sh "${SNIPPET}" 2>"${TMP}/stderr")"
+RC=$?
+set -e
+
+# --- Assertions --------------------------------------------------------------
+
+if [ "${RC}" -eq 0 ]; then
+  pass "snippet exits 0"
+else
+  fail "snippet exited ${RC}"
+fi
+
+if [ "${OUT}" = "stray processes killed: ${expected_killed}" ]; then
+  pass "stdout reports ${expected_killed} killed"
+else
+  fail "unexpected stdout: '${OUT}' (stderr: $(cat "${TMP}/stderr"))"
+fi
+
+# wait reaps the child and returns its termination status: 128+signal.
+set +e
+wait "${STRAY_TERM}"
+rc_term=$?
+wait "${STRAY_IGN}"
+rc_ign=$?
+set -e
+if [ "${rc_term}" -eq 143 ]; then
+  pass "TERM stray terminated by SIGTERM"
+else
+  fail "TERM stray status ${rc_term}, expected 143"
+fi
+if [ "${rc_ign}" -eq 137 ]; then
+  pass "TERM-ignoring stray killed by SIGKILL after the grace period"
+else
+  fail "TERM-ignoring stray status ${rc_ign}, expected 137"
+fi
+
+if [ -n "${KEEP}" ]; then
+  if kill -0 "${KEEP}" 2>/dev/null; then
+    pass "keep-alive main process survives"
+  else
+    fail "keep-alive main process was killed"
+  fi
+  if kill -0 "${KEEP_PATH}" 2>/dev/null; then
+    pass "path-qualified keep-alive survives"
+  else
+    fail "path-qualified keep-alive was killed"
+  fi
+fi
+
+# The exec shell's own ancestry (this test shell) is untouched — trivially
+# true if we are still running, but make it explicit.
+kill -0 $$ && pass "test shell survives the sweep"
+
+# Idempotent: a second sweep finds nothing.
+OUT2="$(STRAY_TEST_ROOT=$$ PATH="${FAKE_PATH}" sh "${SNIPPET}" 2>/dev/null)"
+if [ "${OUT2}" = "stray processes killed: 0" ]; then
+  pass "second sweep kills nothing"
+else
+  fail "second sweep stdout: '${OUT2}'"
+fi
+
+# A failed listing is distinct from "nothing to kill": exit 3, message on
+# stderr, nothing on stdout.
+set +e
+OUT3="$(PATH="${TMP}/badbin:${PATH}" sh "${SNIPPET}" 2>"${TMP}/stderr3")"
+RC3=$?
+set -e
+if [ "${RC3}" -eq 3 ] && [ -z "${OUT3}" ] && grep -q 'stray processes: ps failed' "${TMP}/stderr3"; then
+  pass "ps failure exits 3 with a stderr message and no count"
+else
+  fail "ps failure: rc=${RC3} stdout='${OUT3}' stderr='$(cat "${TMP}/stderr3")'"
+fi
+
+# --- A failed liveness probe must not read as "everything is dead" ----------
+# `ps -p` failing prints nothing and exits 1, exactly like "none of these
+# pids exist". Trusting that would skip the KILL pass while the snippet
+# still reported a clean sweep, so it cross-checks with kill -0: a broken
+# probe KILLs everything that took the TERM and exits 3.
+
+sh -c 'trap "" TERM; exec sleep 300' &
+PROBE_IGN=$!
+STRAY_PIDS+=("${PROBE_IGN}")
+sleep 0.2
+kill -0 "${PROBE_IGN}" || fail "fixture: probe-case stray did not start"
+
+set +e
+OUT4="$(STRAY_TEST_ROOT=$$ PATH="${PROBE_PATH}" sh "${SNIPPET}" 2>"${TMP}/stderr4")"
+RC4=$?
+set -e
+if [ "${RC4}" -eq 3 ] && [ -z "${OUT4}" ] && grep -q 'stray processes: ps -p failed' "${TMP}/stderr4"; then
+  pass "a failed liveness probe exits 3 instead of reporting a clean sweep"
+else
+  fail "probe failure: rc=${RC4} stdout='${OUT4}' stderr='$(cat "${TMP}/stderr4")'"
+fi
+
+# Bounded: if the KILL pass was skipped the stray is still running and a
+# bare wait would hang the suite instead of failing it. A killed child that
+# this shell has not reaped yet is a zombie, which wait returns for
+# immediately, so only a live (non-Z) state is worth waiting out.
+probe_state() {
+  "${REAL_PS}" -o stat= -p "${PROBE_IGN}" 2>/dev/null | awk 'NR == 1 { print substr($1, 1, 1) }'
+}
+i=0
+while [ "${i}" -lt 30 ] && [ -n "$(probe_state)" ] && [ "$(probe_state)" != "Z" ]; do
+  sleep 0.1
+  i=$((i + 1))
+done
+if [ -n "$(probe_state)" ] && [ "$(probe_state)" != "Z" ]; then
+  fail "probe-case stray survived the sweep"
+  kill -9 "${PROBE_IGN}" 2>/dev/null || true
+fi
+
+set +e
+wait "${PROBE_IGN}"
+rc_probe=$?
+set -e
+if [ "${rc_probe}" -eq 137 ]; then
+  pass "the TERM-ignoring stray is KILLed even though the probe failed"
+else
+  fail "probe-case stray status ${rc_probe}, expected 137"
+fi
+
+if [ "${FAILURES}" -ne 0 ]; then
+  echo "${FAILURES} failure(s)" >&2
+  exit 1
+fi
+echo "All kill_stray_processes tests passed"

--- a/internal/runtime/opencode.go
+++ b/internal/runtime/opencode.go
@@ -44,6 +44,11 @@ func (OpenCodeRuntime) Run(_ context.Context, _ RunParams, _ *ui.Printer, _ time
 	return -1, fmt.Errorf("opencode runtime is not yet implemented")
 }
 
+// ClearIterationArtifacts is a no-op while Run is a stub: nothing has run in
+// the sandbox, so there is nothing to clear. When Run is implemented this
+// must sweep stray sandbox processes (clearStrayProcesses, see
+// killStrayProcesses) before removing the iteration's files, like the other
+// runtimes — the Runtime interface documents that as part of the contract.
 func (OpenCodeRuntime) ClearIterationArtifacts(_ string) error { return nil }
 
 // TranscriptHandler stub methods — return not-implemented errors for extract

--- a/internal/runtime/pi_bootstrap_test.go
+++ b/internal/runtime/pi_bootstrap_test.go
@@ -424,6 +424,31 @@ func TestPiRuntimeClearIterationArtifacts(t *testing.T) {
 	log, err := os.ReadFile(logPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(log), "rm -rf '/sandbox/workspace'/output/* '/sandbox/pi-config/sessions'/* '/sandbox/workspace/pi-debug.log'")
+	// Stray processes from the previous iteration are swept before the
+	// files go, so nothing keeps writing into the cleared directories.
+	sweep := strings.Index(string(log), "ps -o pid= -o ppid=")
+	rm := strings.Index(string(log), "rm -rf '/sandbox/workspace'/output/*")
+	require.NotEqual(t, -1, sweep, "expected the stray-process sweep to run")
+	assert.Less(t, sweep, rm, "sweep must precede the file cleanup")
+}
+
+// A sweep that fails (exit 124 is the only exec failure sandbox.Exec
+// reports) is warning-only: the rm -rf still runs and the result is nil.
+func TestPiRuntimeClearIterationArtifacts_SweepFailureIsNotAnError(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "openshell.log")
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"echo \"$@\" >> '" + logPath + "'\n" +
+		"for last; do :; done\n" +
+		"case \"$last\" in *\"stray processes killed\"*) echo boom >&2; exit 124 ;; esac\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "openshell"), []byte(script), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	require.NoError(t, PiRuntime{}.ClearIterationArtifacts("sb"))
+	log, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(log), "rm -rf '/sandbox/workspace'/output/*", "file cleanup still runs after a failed sweep")
 }
 
 // TestPiDefaultTools_CoversToolMap keeps the settings.json default set and

--- a/internal/runtime/pi_run.go
+++ b/internal/runtime/pi_run.go
@@ -569,9 +569,11 @@ func (r PiRuntime) Run(ctx context.Context, params RunParams, printer *ui.Printe
 	return exitCode, nil
 }
 
-// ClearIterationArtifacts removes the previous iteration's outputs and
-// sessions so transcripts and output files are per-iteration.
+// ClearIterationArtifacts terminates processes the previous iteration left
+// running (see killStrayProcesses), then removes its outputs and sessions
+// so transcripts and output files are per-iteration.
 func (r PiRuntime) ClearIterationArtifacts(sandboxName string) error {
+	clearStrayProcesses(sandbox.Exec, sandboxName, os.Stderr)
 	clearCmd := fmt.Sprintf("rm -rf %s/output/* %s/* %s",
 		shellQuote(r.WorkspaceDir()), shellQuote(r.piSessionsDir()), shellQuote(r.WorkspaceDir()+"/"+piDebugLogFile))
 	_, _, _, err := sandbox.Exec(sandboxName, clearCmd, 10*time.Second)

--- a/internal/runtime/stray_processes.go
+++ b/internal/runtime/stray_processes.go
@@ -1,0 +1,244 @@
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/sandbox"
+)
+
+// killStrayProcessesTimeout bounds the sweep exec. The snippet itself waits
+// at most 2s between TERM and KILL, so anything beyond a few seconds is the
+// gateway, not the sandbox.
+const killStrayProcessesTimeout = 15 * time.Second
+
+// killStrayProcessesTemplate is the POSIX sh snippet ClearIterationArtifacts
+// runs through `sandbox exec` before it removes the previous iteration's
+// files. __KEEPALIVE__ is replaced with the shell-quoted
+// sandbox.KeepAliveCommand by killStrayProcessesScript; the rendered result
+// is pinned in testdata/kill_stray_processes.sh, which
+// kill_stray_processes_test.sh runs under a real shell.
+//
+// Why: pi's built-in bash tool spawns commands detached and kills that
+// process tree only on abort/timeout (pi 0.84.4, core/tools/bash.ts), so a
+// backgrounded command such as `nohup python3 -c 'import time;
+// time.sleep(300)' &` survives the agent process's normal exit. Claude
+// Code's Bash tool is closed source, but the same symptom was observed:
+// after the agent exits, the survivors sit reparented to PID 1 in the
+// sandbox. fullsend reuses the sandbox for a validation-retry iteration,
+// where such a survivor keeps files open, burns CPU/memory and writes into
+// the workspace the next iteration reads.
+//
+// Process-view assumptions, verified against OpenShell 0.0.116 and its
+// source: `sandbox exec` runs `sh -c <command>` as the sandbox user after
+// the supervisor drops privileges
+// (crates/openshell-supervisor-process/src/process.rs). With the podman
+// driver the supervisor is PID 1 owned by root
+// (crates/openshell-driver-podman/src/container.rs sets `user: "0:0"` and
+// the supervisor entrypoint), so it never appears in `ps -u <sandbox user>`;
+// on any driver it is an ancestor of this shell, which is what the
+// ancestry walk below spares — the root/PID 1 detail is not load-bearing.
+// The keep-alive main process (sandbox.KeepAliveCommand) does run as the
+// sandbox user with ppid 1, indistinguishable from a reparented stray by
+// tree shape, so it is excluded by argv: the command word is compared
+// with any leading directory stripped (`/usr/bin/sleep infinity` also
+// counts), which means an agent-started literal `sleep infinity` is spared
+// as a consequence. Killing the keep-alive would make the sandbox terminal
+// on OpenShell 0.0.111+.
+//
+// Serialization: the runner's background credential refreshers write into
+// the sandbox from the host. refreshOIDCToken's `openshell sandbox upload`
+// runs a sandbox-user `/bin/bash -c 'mkdir -p … && cat | tar xf - -C …'`
+// chain (ppid 1, indistinguishable from a stray) and tar truncates the
+// target on open, so a kill mid-write would leave an empty .gcp-oidc-token
+// until the next 4-minute tick; reseedOpenAIAuth's execs are the other
+// writer. internal/cli/run.go therefore serializes the sweep against both
+// through sandboxQuiesceMu: the iteration loop holds it across
+// ClearIterationArtifacts and the refreshers hold it across each upload or
+// writing exec. The residual is the OpenAI seed itself, which writes
+// atomically (`printf > tmp && mv -f`) and is retried on
+// openAIRefreshBackoff.
+//
+// Only tools the sandbox image ships are used (procps ps, mawk, dash
+// builtins, coreutils sleep/id) — no pkill/pgrep. A failed process listing
+// exits 3 (distinct from the always-0 sweep result) so the Go side warns
+// instead of trusting a silent zero; a failing `ps -p` liveness probe takes
+// the same exit, after KILLing everything that was TERMed, because its
+// empty answer is otherwise indistinguishable from "they are all gone".
+const killStrayProcessesTemplate = `# shellcheck shell=sh
+# Sweep processes left behind by the previous iteration. pi's bash tool
+# spawns commands detached and kills that tree only on abort/timeout
+# (pi 0.84.4, core/tools/bash.ts), so a backgrounded command (nohup ... &)
+# outlives the agent; reparented survivors were observed after agent exit
+# regardless of runtime, and because fullsend reuses the sandbox for the
+# next iteration they keep running: holding files open, eating CPU,
+# writing into the workspace the next iteration reads.
+#
+# Kills every process of the sandbox user except: this shell and its
+# ancestors (the exec channel back to the runner), its own helpers,
+# zombies, and the sandbox keep-alive main process. The keep-alive is
+# matched on argv with any directory stripped from the command word
+# (/usr/bin/sleep infinity counts), so an agent-started literal
+# "sleep infinity" is spared as well. TERM first, then KILL whatever is
+# still alive after 2s. The count goes to stdout; a process listing or a
+# liveness probe that fails exits 3 so the runner warns instead of
+# trusting a zero. The user is selected by numeric uid: the sandbox user
+# need not be resolvable through NSS.
+me=$$
+listing=$(ps -o pid= -o ppid= -o stat= -o args= -u "$(id -u)" 2>/dev/null) || {
+  echo 'stray processes: ps failed' >&2
+  exit 3
+}
+targets=$(printf '%s\n' "$listing" | awk -v me="$me" -v keep=__KEEPALIVE__ '
+  NF >= 4 {
+    pid = $1
+    parent[pid] = $2
+    stat[pid] = $3
+    line = $0
+    sub(/^[ \t]*[0-9]+[ \t]+[0-9]+[ \t]+[^ \t]+[ \t]+/, "", line)
+    sub(/^[^ \t]*\//, "", line)
+    cmd[pid] = line
+    order[++n] = pid
+  }
+  END {
+    # This shell and everything above it: the exec channel to the runner.
+    for (p = me; p in parent; p = parent[p]) {
+      if (p in own) break
+      own[p] = 1
+    }
+    own[me] = 1
+    # Everything below this shell: the ps/awk helpers of this very snippet.
+    do {
+      changed = 0
+      for (i = 1; i <= n; i++) {
+        p = order[i]
+        if (p in own || p in below) continue
+        if (parent[p] == me || parent[p] in below) {
+          below[p] = 1
+          changed = 1
+        }
+      }
+    } while (changed)
+    for (i = 1; i <= n; i++) {
+      p = order[i]
+      if (p in own || p in below) continue
+      if (substr(stat[p], 1, 1) == "Z") continue
+      if (cmd[p] == keep) continue
+      print p
+    }
+  }')
+count=0
+pids=""
+signalled=""
+for p in $targets; do
+  if kill -s TERM "$p" 2>/dev/null; then
+    count=$((count + 1))
+    pids="$pids,$p"
+    signalled="$signalled $p"
+  fi
+done
+if [ "$count" -gt 0 ]; then
+  pids=${pids#,}
+  # alive: does any signalled target still exist at all (live or zombie)?
+  # Only used to tell a broken probe from "they are all gone".
+  alive() {
+    for a in $signalled; do
+      if kill -0 "$a" 2>/dev/null; then
+        return 0
+      fi
+    done
+    return 1
+  }
+  # survivors: signalled targets still present and not zombies (a killed
+  # stray stays a zombie until its new parent reaps it); one ps per tick.
+  # An empty answer is trusted only when nothing is left: a ps -p that
+  # fails also prints nothing and exits 1, and reading that as "all dead"
+  # would skip the KILL pass while still reporting a clean sweep. A probe
+  # that fails prints "?" instead.
+  survivors() {
+    out=$(ps -o pid= -o stat= -p "$pids" 2>/dev/null)
+    rc=$?
+    if [ "$rc" -gt 1 ] || { [ -z "$out" ] && alive; }; then
+      echo '?'
+      return
+    fi
+    printf '%s\n' "$out" | awk 'NF && $2 !~ /^Z/ { print $1 }'
+  }
+  left=$(survivors)
+  i=0
+  while [ "$i" -lt 20 ] && [ -n "$left" ] && [ "$left" != '?' ]; do
+    sleep 0.1
+    i=$((i + 1))
+    left=$(survivors)
+  done
+  if [ "$left" = '?' ]; then
+    # The probe is broken, so which targets are still alive is unknown:
+    # KILL every one that took the TERM rather than skip the pass, and
+    # report it so the runner does not read the count as a clean sweep.
+    for p in $signalled; do
+      kill -s KILL "$p" 2>/dev/null
+    done
+    echo 'stray processes: ps -p failed' >&2
+    exit 3
+  fi
+  for p in $left; do
+    kill -s KILL "$p" 2>/dev/null
+  done
+fi
+echo "stray processes killed: $count"
+exit 0
+`
+
+// killStrayProcessesScript renders the sweep snippet with the sandbox
+// keep-alive argv it must spare.
+func killStrayProcessesScript() string {
+	return strings.ReplaceAll(killStrayProcessesTemplate, "__KEEPALIVE__", shellQuote(sandbox.KeepAliveCommand))
+}
+
+var strayProcessesKilledRe = regexp.MustCompile(`(?m)^stray processes killed: ([0-9]+)$`)
+
+// killStrayProcesses runs the sweep snippet in the sandbox through execFn
+// (sandbox.Exec in production) and returns the number of processes it
+// signalled. Any failure — a gateway error, a timeout, a non-zero exit
+// (exit 3 is the snippet's own "ps failed"), or output the snippet never
+// produces — is returned as an error for the caller to downgrade.
+func killStrayProcesses(execFn sandboxExecFunc, sandboxName string) (int, error) {
+	stdout, stderr, exitCode, err := execFn(sandboxName, killStrayProcessesScript(), killStrayProcessesTimeout)
+	if err != nil {
+		return 0, err
+	}
+	if exitCode != 0 {
+		return 0, fmt.Errorf("exit %d: %s", exitCode, strings.TrimSpace(stderr))
+	}
+	m := strayProcessesKilledRe.FindStringSubmatch(stdout)
+	if m == nil {
+		return 0, fmt.Errorf("unexpected output: %q", strings.TrimSpace(stdout))
+	}
+	n, convErr := strconv.Atoi(m[1])
+	if convErr != nil {
+		return 0, fmt.Errorf("unexpected count in output %q: %w", strings.TrimSpace(stdout), convErr)
+	}
+	return n, nil
+}
+
+// clearStrayProcesses is the warning-only front of killStrayProcesses used
+// by ClearIterationArtifacts: a failed sweep must never fail the iteration,
+// and the file cleanup that follows must still run. Progress (with the
+// sweep's duration, which is the TERM grace period when something ignored
+// TERM) and warnings go to w (stderr in production).
+func clearStrayProcesses(execFn sandboxExecFunc, sandboxName string, w io.Writer) {
+	start := time.Now()
+	n, err := killStrayProcesses(execFn, sandboxName)
+	elapsed := time.Since(start).Round(100 * time.Millisecond)
+	if err != nil {
+		fmt.Fprintf(w, "  Warning: could not terminate stray sandbox processes from the previous iteration (after %s): %v\n", elapsed, sanitizeOutput(err.Error()))
+		return
+	}
+	if n > 0 {
+		fmt.Fprintf(w, "  Terminated %d stray process(es) left running by the previous iteration (%s)\n", n, elapsed)
+	}
+}

--- a/internal/runtime/stray_processes.go
+++ b/internal/runtime/stray_processes.go
@@ -57,7 +57,7 @@ const killStrayProcessesTimeout = 15 * time.Second
 // target on open, so a kill mid-write would leave an empty .gcp-oidc-token
 // until the next 4-minute tick; reseedOpenAIAuth's execs are the other
 // writer. internal/cli/run.go therefore serializes the sweep against both
-// through sandboxQuiesceMu: the iteration loop holds it across
+// through sandboxMu: the iteration loop holds it across
 // ClearIterationArtifacts and the refreshers hold it across each upload or
 // writing exec. The residual is the OpenAI seed itself, which writes
 // atomically (`printf > tmp && mv -f`) and is retried on

--- a/internal/runtime/stray_processes_test.go
+++ b/internal/runtime/stray_processes_test.go
@@ -1,0 +1,180 @@
+package runtime
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/sandbox"
+)
+
+// TestKillStrayProcessesScript_Golden pins the snippet byte-for-byte to
+// testdata/kill_stray_processes.sh — the file kill_stray_processes_test.sh
+// executes under a real shell, so the golden is what guarantees the shell
+// test exercises the production bytes.
+func TestKillStrayProcessesScript_Golden(t *testing.T) {
+	t.Parallel()
+
+	want, err := os.ReadFile("testdata/kill_stray_processes.sh")
+	require.NoError(t, err)
+	assert.Equal(t, string(want), killStrayProcessesScript())
+}
+
+// TestKillStrayProcessesScript_Invariants checks the properties the sandbox
+// image and the runner depend on, independent of the exact golden bytes.
+func TestKillStrayProcessesScript_Invariants(t *testing.T) {
+	t.Parallel()
+
+	script := killStrayProcessesScript()
+	// Only tools the sandbox image ships (procps ps, mawk, dash builtins);
+	// no shebang because sandbox.Exec hands the text to `sh -c`.
+	for _, forbidden := range []string{"pkill", "pgrep", "killall", "bash -c", "#!/"} {
+		assert.NotContains(t, script, forbidden, "snippet must stay POSIX sh + ps/awk/kill/sleep/id")
+	}
+	// Numeric uid: the sandbox user need not be resolvable through NSS.
+	assert.Contains(t, script, "ps -o pid= -o ppid= -o stat= -o args= -u \"$(id -u)\"")
+	// The sandbox keep-alive main process runs as the sandbox user and must
+	// survive, or OpenShell marks the sandbox terminal.
+	assert.Contains(t, script, "-v keep="+shellQuote(sandbox.KeepAliveCommand))
+	assert.Contains(t, script, "kill -s TERM")
+	assert.Contains(t, script, "kill -s KILL")
+	// A failed listing must be distinguishable from "nothing to kill".
+	assert.Contains(t, script, "echo 'stray processes: ps failed' >&2\n  exit 3\n")
+	// So must a failed liveness probe, which prints nothing and exits 1
+	// exactly like "none of those pids exist"; the KILL pass still runs
+	// over everything that was TERMed before the snippet gives up.
+	assert.Contains(t, script, "echo 'stray processes: ps -p failed' >&2\n    exit 3\n")
+	assert.Contains(t, script, "kill -0 ")
+	assert.True(t, strings.HasSuffix(script, "exit 0\n"), "a completed sweep never fails the exec")
+}
+
+// The awk exclusion strips a leading directory from the command word and
+// then compares the argv verbatim, so the constant must be exactly the two
+// bare words — a path or an extra token would silently stop matching and
+// the sweep would kill the keep-alive.
+func TestKeepAliveCommandMatchesSweepExclusion(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"sleep", "infinity"}, strings.Fields(sandbox.KeepAliveCommand))
+}
+
+// recordingExec returns a sandboxExecFunc that appends every command to
+// *calls and answers with the given result.
+func recordingExec(calls *[]string, stdout, stderr string, exitCode int, err error) sandboxExecFunc {
+	return func(_ string, cmd string, _ time.Duration) (string, string, int, error) {
+		*calls = append(*calls, cmd)
+		return stdout, stderr, exitCode, err
+	}
+}
+
+func TestKillStrayProcesses_ReportsCount(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	var sbName string
+	var timeout time.Duration
+	execFn := func(name string, cmd string, d time.Duration) (string, string, int, error) {
+		sbName, timeout = name, d
+		calls = append(calls, cmd)
+		return "stray processes killed: 3\n", "", 0, nil
+	}
+
+	n, err := killStrayProcesses(execFn, "sb")
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "sb", sbName)
+	require.Len(t, calls, 1)
+	assert.Equal(t, killStrayProcessesScript(), calls[0])
+	assert.Greater(t, timeout, 2*time.Second, "exec timeout must cover the snippet's own 2s grace period")
+}
+
+func TestKillStrayProcesses_ExecError(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	boom := errors.New("command timed out after 15s")
+	_, err := killStrayProcesses(recordingExec(&calls, "", "", 124, boom), "sb")
+	require.ErrorIs(t, err, boom)
+}
+
+func TestKillStrayProcesses_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	_, err := killStrayProcesses(recordingExec(&calls, "", "sh: awk: not found", 127, nil), "sb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exit 127")
+	assert.Contains(t, err.Error(), "awk: not found")
+}
+
+// The snippet's own "ps failed" exit (3) must surface as an error, not as a
+// silent zero-kill success.
+func TestKillStrayProcesses_PsFailure(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	n, err := killStrayProcesses(recordingExec(&calls, "", "stray processes: ps failed\n", 3, nil), "sb")
+	require.Error(t, err)
+	assert.Equal(t, 0, n)
+	assert.Contains(t, err.Error(), "exit 3")
+	assert.Contains(t, err.Error(), "ps failed")
+}
+
+func TestKillStrayProcesses_UnexpectedOutput(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	_, err := killStrayProcesses(recordingExec(&calls, "something else\n", "", 0, nil), "sb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "something else")
+}
+
+func TestClearStrayProcesses_ReportsKilledWithDuration(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	var out bytes.Buffer
+	clearStrayProcesses(recordingExec(&calls, "stray processes killed: 2\n", "", 0, nil), "sb", &out)
+	assert.Contains(t, out.String(), "2 stray process")
+	assert.Regexp(t, `\([0-9.]+(m|µ|n)?s\)`, out.String(), "the sweep duration is logged")
+}
+
+func TestClearStrayProcesses_SilentWhenNothingKilled(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	var out bytes.Buffer
+	clearStrayProcesses(recordingExec(&calls, "stray processes killed: 0\n", "", 0, nil), "sb", &out)
+	assert.Empty(t, out.String())
+}
+
+// A failed sweep is a warning, never an error: the file cleanup that
+// follows in ClearIterationArtifacts must still run and the iteration
+// must proceed.
+func TestClearStrayProcesses_WarnsOnFailure(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	var out bytes.Buffer
+	clearStrayProcesses(recordingExec(&calls, "", "boom", 124, errors.New("command timed out after 15s")), "sb", &out)
+	assert.Contains(t, out.String(), "Warning")
+	assert.Contains(t, out.String(), "stray")
+	assert.Contains(t, out.String(), "timed out")
+}
+
+// The ps-failure exit takes the same warning path as a gateway error.
+func TestClearStrayProcesses_WarnsOnPsFailure(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	var out bytes.Buffer
+	clearStrayProcesses(recordingExec(&calls, "", "stray processes: ps failed\n", 3, nil), "sb", &out)
+	assert.Contains(t, out.String(), "Warning")
+	assert.Contains(t, out.String(), "ps failed")
+}

--- a/internal/runtime/testdata/kill_stray_processes.sh
+++ b/internal/runtime/testdata/kill_stray_processes.sh
@@ -1,0 +1,122 @@
+# shellcheck shell=sh
+# Sweep processes left behind by the previous iteration. pi's bash tool
+# spawns commands detached and kills that tree only on abort/timeout
+# (pi 0.84.4, core/tools/bash.ts), so a backgrounded command (nohup ... &)
+# outlives the agent; reparented survivors were observed after agent exit
+# regardless of runtime, and because fullsend reuses the sandbox for the
+# next iteration they keep running: holding files open, eating CPU,
+# writing into the workspace the next iteration reads.
+#
+# Kills every process of the sandbox user except: this shell and its
+# ancestors (the exec channel back to the runner), its own helpers,
+# zombies, and the sandbox keep-alive main process. The keep-alive is
+# matched on argv with any directory stripped from the command word
+# (/usr/bin/sleep infinity counts), so an agent-started literal
+# "sleep infinity" is spared as well. TERM first, then KILL whatever is
+# still alive after 2s. The count goes to stdout; a process listing or a
+# liveness probe that fails exits 3 so the runner warns instead of
+# trusting a zero. The user is selected by numeric uid: the sandbox user
+# need not be resolvable through NSS.
+me=$$
+listing=$(ps -o pid= -o ppid= -o stat= -o args= -u "$(id -u)" 2>/dev/null) || {
+  echo 'stray processes: ps failed' >&2
+  exit 3
+}
+targets=$(printf '%s\n' "$listing" | awk -v me="$me" -v keep='sleep infinity' '
+  NF >= 4 {
+    pid = $1
+    parent[pid] = $2
+    stat[pid] = $3
+    line = $0
+    sub(/^[ \t]*[0-9]+[ \t]+[0-9]+[ \t]+[^ \t]+[ \t]+/, "", line)
+    sub(/^[^ \t]*\//, "", line)
+    cmd[pid] = line
+    order[++n] = pid
+  }
+  END {
+    # This shell and everything above it: the exec channel to the runner.
+    for (p = me; p in parent; p = parent[p]) {
+      if (p in own) break
+      own[p] = 1
+    }
+    own[me] = 1
+    # Everything below this shell: the ps/awk helpers of this very snippet.
+    do {
+      changed = 0
+      for (i = 1; i <= n; i++) {
+        p = order[i]
+        if (p in own || p in below) continue
+        if (parent[p] == me || parent[p] in below) {
+          below[p] = 1
+          changed = 1
+        }
+      }
+    } while (changed)
+    for (i = 1; i <= n; i++) {
+      p = order[i]
+      if (p in own || p in below) continue
+      if (substr(stat[p], 1, 1) == "Z") continue
+      if (cmd[p] == keep) continue
+      print p
+    }
+  }')
+count=0
+pids=""
+signalled=""
+for p in $targets; do
+  if kill -s TERM "$p" 2>/dev/null; then
+    count=$((count + 1))
+    pids="$pids,$p"
+    signalled="$signalled $p"
+  fi
+done
+if [ "$count" -gt 0 ]; then
+  pids=${pids#,}
+  # alive: does any signalled target still exist at all (live or zombie)?
+  # Only used to tell a broken probe from "they are all gone".
+  alive() {
+    for a in $signalled; do
+      if kill -0 "$a" 2>/dev/null; then
+        return 0
+      fi
+    done
+    return 1
+  }
+  # survivors: signalled targets still present and not zombies (a killed
+  # stray stays a zombie until its new parent reaps it); one ps per tick.
+  # An empty answer is trusted only when nothing is left: a ps -p that
+  # fails also prints nothing and exits 1, and reading that as "all dead"
+  # would skip the KILL pass while still reporting a clean sweep. A probe
+  # that fails prints "?" instead.
+  survivors() {
+    out=$(ps -o pid= -o stat= -p "$pids" 2>/dev/null)
+    rc=$?
+    if [ "$rc" -gt 1 ] || { [ -z "$out" ] && alive; }; then
+      echo '?'
+      return
+    fi
+    printf '%s\n' "$out" | awk 'NF && $2 !~ /^Z/ { print $1 }'
+  }
+  left=$(survivors)
+  i=0
+  while [ "$i" -lt 20 ] && [ -n "$left" ] && [ "$left" != '?' ]; do
+    sleep 0.1
+    i=$((i + 1))
+    left=$(survivors)
+  done
+  if [ "$left" = '?' ]; then
+    # The probe is broken, so which targets are still alive is unknown:
+    # KILL every one that took the TERM rather than skip the pass, and
+    # report it so the runner does not read the count as a clean sweep.
+    for p in $signalled; do
+      kill -s KILL "$p" 2>/dev/null
+    done
+    echo 'stray processes: ps -p failed' >&2
+    exit 3
+  fi
+  for p in $left; do
+    kill -s KILL "$p" 2>/dev/null
+  done
+fi
+echo "stray processes killed: $count"
+exit 0

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -942,6 +942,14 @@ func effectiveReadyTimeout(override time.Duration) time.Duration {
 	return t
 }
 
+// KeepAliveCommand is the sandbox's canonical main process, started by
+// createOnce so the sandbox stays Ready between `sandbox exec` calls
+// (OpenShell 0.0.111+ makes a sandbox terminal once its main process
+// exits). It runs as the sandbox user, so anything that sweeps the sandbox
+// user's processes (runtime.killStrayProcesses) must spare exactly this
+// argv — keep the two in sync through this constant.
+const KeepAliveCommand = "sleep infinity"
+
 // Create creates a persistent OpenShell sandbox and waits for it to be ready.
 // It retries up to DefaultMaxCreateAttempts times with exponential backoff,
 // deleting the failed sandbox between attempts.
@@ -1057,9 +1065,10 @@ func createOnce(name string, providers []string, image, policy string, timeout t
 	// for subsequent sandbox exec calls. Prior to OpenShell 0.0.111 the
 	// `true` command worked because an exited main process left the
 	// sandbox Ready; starting with 0.0.111 an exited process makes the
-	// sandbox terminal. --detach returns immediately while sleep infinity
-	// continues running in the background.
-	args = append(args, "--detach", "--", "sleep", "infinity")
+	// sandbox terminal. --detach returns immediately while the keep-alive
+	// command continues running in the background.
+	args = append(args, "--detach", "--")
+	args = append(args, strings.Fields(KeepAliveCommand)...)
 
 	cmd := exec.CommandContext(ctx, "openshell", args...)
 	cmd.Stdin = nil

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -43,6 +43,14 @@ const (
 	// each one explicitly with -e.
 	SandboxPiExtensionsDir = "/usr/local/share/pi-extensions"
 
+	// KeepAliveCommand is the sandbox's canonical main process, started by
+	// createOnce so the sandbox stays Ready between `sandbox exec` calls
+	// (OpenShell 0.0.111+ makes a sandbox terminal once its main process
+	// exits). It runs as the sandbox user, so anything that sweeps the
+	// sandbox user's processes (runtime.killStrayProcesses) must spare
+	// exactly this argv — keep the two in sync through this constant.
+	KeepAliveCommand = "sleep infinity"
+
 	readyTimeout    = 120 * time.Second
 	readyPoll       = 2 * time.Second
 	readyCtxBuffer  = 10 * time.Second
@@ -941,14 +949,6 @@ func effectiveReadyTimeout(override time.Duration) time.Duration {
 	}
 	return t
 }
-
-// KeepAliveCommand is the sandbox's canonical main process, started by
-// createOnce so the sandbox stays Ready between `sandbox exec` calls
-// (OpenShell 0.0.111+ makes a sandbox terminal once its main process
-// exits). It runs as the sandbox user, so anything that sweeps the sandbox
-// user's processes (runtime.killStrayProcesses) must spare exactly this
-// argv — keep the two in sync through this constant.
-const KeepAliveCommand = "sleep infinity"
 
 // Create creates a persistent OpenShell sandbox and waits for it to be ready.
 // It retries up to DefaultMaxCreateAttempts times with exponential backoff,


### PR DESCRIPTION
## Summary

A tool command such as `nohup python3 -c 'time.sleep(300)' &` started by the agent's bash tool survives the agent's normal exit inside the sandbox: pi's built-in `bash` kills its process group only on abort/timeout, and Claude Code's Bash behaves the same. fullsend reuses the sandbox for the next validation-retry iteration, and `ClearIterationArtifacts` only `rm -rf`'d files — so strays from iteration 1 kept running into iteration 2 (holding files open, eating CPU/memory, writing into the workspace the next iteration reads). Verified empirically on 2026-08-29 while evaluating pi sub-agents: three backgrounded commands were still alive, reparented to PID 1, after the agent process exited.

Change: a runtime-neutral sweep (`internal/runtime/stray_processes.go`) that every `ClearIterationArtifacts` (Claude Code, pi, dummy) runs before the file cleanup. The POSIX-sh snippet (golden-pinned in `testdata/kill_stray_processes.sh`) kills every process of the sandbox user except the exec shell and its ancestors (the channel back to the runner), its own helpers, zombies, and the sandbox keep-alive main process (`sleep infinity`, now a shared constant `sandbox.KeepAliveCommand` used by `createOnce`); TERM first, KILL survivors after 2 s; warn-only, never fails the iteration. Uses only `ps`/`awk`/`kill`/`sleep`/`id` (all in the sandbox image; no `pkill`/`pgrep`). With the podman driver the OpenShell supervisor is PID 1 as root (`crates/openshell-driver-podman/src/container.rs` `user: "0:0"`), outside the sandbox user's process view, and the ancestry walk covers other drivers; the keep-alive (observed `ps -o args=` = `sleep infinity`, ppid 1) is spared by its argv (path-qualified first token tolerated) because killing it makes the sandbox terminal on OpenShell 0.0.111+ — a consequence is that an agent-started literal `sleep infinity` is spared too. The sweep is serialized against the credential refreshers through the runner's sandbox lock (`sandboxMu`, held across `ClearIterationArtifacts`, the OIDC token upload and the OpenAI auth seed), so a refresh can no longer be killed mid-upload; a `ps` failure inside the sweep exits 3 and surfaces as a warning instead of a silent "0 killed".

## Test plan

- [x] `go test ./internal/runtime/... ./internal/sandbox/...` — only the two known `TestDummyRuntime_*` failures that occur whenever a local OpenShell gateway is running; patch coverage: script builder 100%, `killStrayProcesses` 91.7%, `clearStrayProcesses` 100%, all three `ClearIterationArtifacts` 100%
- [x] `internal/runtime/kill_stray_processes_test.sh` (registered in `make script-test`): plain stray exits 143, TERM-ignoring stray exits 137, the test shell survives, a second sweep kills 0
- [x] `make lint` clean (shellcheck on the golden)
- [x] Live sandbox (`localhost/fullsend-sandbox`, OpenShell 0.0.116, same create flags as `createOnce`): `nohup sleep 300 &`, a TERM-ignoring `sleep 300` and `python3 -c 'time.sleep(300)'` survived the exec; the sweep reported `stray processes killed: 3` in 2 s, only `sleep infinity` remained, the sandbox stayed `Ready`, a follow-up exec worked, a second sweep reported 0
- [x] `docs/runtimes.md` gets one step in the "How a run uses the runtime" diagram; `docs/contributing/runtime-implementation.md` states the `ClearIterationArtifacts` contract (sweep first, then files; failed sweep = warning) under the interface table
- [x] Review round (Claude + Grok): `ps` failure → exit 3 + warning; batched liveness probe (one `ps -p` per tick); keep-alive match tolerant of a path-qualified `sleep`; `TestKeepAliveCommandMatchesSweepExclusion`; shell test asserts the fake `ps` is first on PATH; pi fail-open test; sweep duration logged; refresher/sweep serialization with tests (`TestRefreshOIDCToken_WaitsForSandboxLock`, `TestReseedOpenAIAuth_WaitsForSandboxLock`); the changed snippet re-verified live (3 strays killed, keep-alive spared, zombie skipped, sandbox stayed Ready)

Refs #6464 (found during the pi runtime extension evaluation).
- [x] Review round 2 (Claude + Grok, clean of HIGH/MEDIUM after fixes): the sandbox lock now taken through a panic-safe `withSandboxLock` helper at all four sites; the OpenAI seed holds it only around the atomic `authSeed` exec; the iteration loop reports when it has waited >5 s for the lock; the hold budget (≈45 s worst case vs the 4-minute OIDC tick) is documented next to the mutex; the liveness probe's `ps -p` failure is now detected (KILL the full TERM'd list, then `ps -p failed` + exit 3) with a shell-test case; comments corrected (`/bin/bash -c` upload chain, full 4-minute token window, `id -u`); OpenCode stub annotated; Claude-runtime fail-open test; Makefile help. `go test -race` on the lock/refresh tests, 11/11 shell cases, `make lint` clean.
- [x] Review round 3 (`9b2fccd3`, rebased on main after #6752): reviewer asks — `docs/runtimes.md` paragraph replaced by a diagram step, interface table row shortened with the contract moved to a paragraph under the table, "quiesce" renamed to the sandbox lock (`sandboxMu` / `withSandboxLock`); bot lows — `withSandboxLock` takes a context and abandons the wait when the run is cancelled (`TestWithSandboxLock_AbandonsTheWaitWhenCancelled`), `sandbox.KeepAliveCommand` moved into the const block. `go test ./internal/cli/...` green, `-race` on the lock tests, `make lint` clean.

- [x] Review round 4 (`0af942bfd`, rebased on main after #6772): bot lows — `DummyPlaybackRuntime.ClearIterationArtifacts` now runs the `clearStrayProcesses` sweep before the file cleanup, matching `ClaudeRuntime`/`PiRuntime`/`DummyRuntime` (new tests: `TestDummyPlaybackRuntime_ClearIterationArtifacts_SweepsStraysBeforeFiles`, `_SweepFailureIsNotAnError`); `docs/guides/dev/cli-internals.md`'s validation-loop pseudocode now shows the sweep as a step between iterations. `go build`/targeted tests/`make lint-all` clean.
