### PR TITLE
fix(#6762): resolve harness bot identity

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1724,6 +1724,21 @@ jobs:
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
           fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
+      - name: Resolve bot identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          read -r BOT_LOGIN BOT_USER_ID < <(
+            gh api graphql -f query='{ viewer { login databaseId } }' \
+              | jq -r '.data.viewer | "\(.login) \(.databaseId)"'
+          )
+          GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
+          echo "Resolved bot identity: ${BOT_LOGIN} (${BOT_USER_ID})"
+          echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"
+          git config --global user.email "${GIT_BOT_EMAIL}"
+          git config --global user.name "${BOT_LOGIN}"
+
       - name: Setup agent environment
         shell: bash
         env:

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -1135,6 +1135,30 @@ func TestOpenAIVariableForwarding(t *testing.T) {
 	})
 }
 
+// TestHarnessRunResolvesBotIdentity validates that the common matrix path
+// exports the app-derived commit identity before it configures and runs an
+// agent (#6762). Harnesses intentionally require this identity so commits are
+// associated with the GitHub App, including for DCO checks.
+func TestHarnessRunResolvesBotIdentity(t *testing.T) {
+	content := string(loadRepoFile(".github/workflows/reusable-dispatch.yml")(t))
+	harnessStart := strings.Index(content, "  harness-run:\n")
+	require.NotEqual(t, -1, harnessStart, "reusable-dispatch.yml must define harness-run")
+	harnessJob := content[harnessStart:]
+
+	identity := extractStepSection(t, harnessJob, "Resolve bot identity")
+	assert.Contains(t, identity, "GH_TOKEN: ${{ steps.app-token.outputs.token }}")
+	assert.Contains(t, identity, "viewer { login databaseId }")
+	assert.Contains(t, identity, `GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"`)
+	assert.Contains(t, identity, `echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"`)
+	assert.Contains(t, identity, `git config --global user.email "${GIT_BOT_EMAIL}"`)
+	assert.Contains(t, identity, `git config --global user.name "${BOT_LOGIN}"`)
+
+	identityIndex := strings.Index(harnessJob, "      - name: Resolve bot identity\n")
+	setupIndex := strings.Index(harnessJob, "      - name: Setup agent environment\n")
+	require.NotEqual(t, -1, setupIndex, "harness-run must set up the agent environment")
+	assert.Less(t, identityIndex, setupIndex, "harness-run must resolve identity before agent environment setup")
+}
+
 // TestLayeredDirsMatchWorkspacePreparation pins the LAYERED_DIRS list in
 // every workspace-preparation step to scaffold.layeredDirs. The scaffold
 // skips these directories at install time on the promise that workspace


### PR DESCRIPTION
The common precomputed-matrix path mints an agent token, but it did not resolve that token's app identity before setting up the harness environment. That left harnesses without `GIT_BOT_EMAIL` and prevented app-associated commits.

This carries the existing code/fix identity contract into `harness-run`: query the token viewer's login and database ID, export the derived noreply email, and configure git before agent setup. A regression test pins both the values and their ordering.

Tests:
- `make lint`
- `GOCACHE=/tmp/fullsend-go-cache GOMODCACHE=/tmp/fullsend-go-mod go test ./internal/scaffold`
- Live precomputed-matrix run from a consuming workflow pointed directly at this branch

Closes #6762