### PR TITLE
fix(#6760): expose work item keys to harness agents

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -178,6 +178,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
+          FULLSEND_WORK_ITEM_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
           FULLSEND_WORK_ITEM_KEY: ${{ fromJSON(inputs.event_payload).issue.number }}
           ISSUE_NUMBER: ${{ fromJSON(inputs.event_payload).issue.number }}
           # Reaches the harness pre-script inside fullsend run, which reads it

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -178,6 +178,7 @@ jobs:
         uses: ./.defaults/
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
+          FULLSEND_WORK_ITEM_KEY: ${{ fromJSON(inputs.event_payload).issue.number }}
           ISSUE_NUMBER: ${{ fromJSON(inputs.event_payload).issue.number }}
           # Reaches the harness pre-script inside fullsend run, which reads it
           # for its --force override of the existing-PR check (pre-script

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1767,7 +1767,10 @@ jobs:
             printf '%s' "${URL}"
             echo
             echo "${DELIM}"
-            echo "work_item_key=${WORK_ITEM_KEY}"
+            echo "work_item_key<<${DELIM}"
+            printf '%s' "${WORK_ITEM_KEY}"
+            echo
+            echo "${DELIM}"
             echo "issue_number=${ISSUE_NUMBER}"
           } >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -810,6 +810,7 @@ jobs:
         env:
           GITHUB_ISSUE_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
           FULLSEND_WORK_ITEM_URL: ${{ fromJSON(needs.route.outputs.event_payload).issue.html_url }}
+          FULLSEND_WORK_ITEM_KEY: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
           ISSUE_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
           # Reaches the harness pre-script inside fullsend run, which reads it
           # for its --force override of the existing-PR check (pre-script
@@ -1754,12 +1755,20 @@ jobs:
             echo "::error::event_payload missing issue or pull_request html_url"
             exit 1
           fi
+          WORK_ITEM_KEY=$(printf '%s' "${EVENT_PAYLOAD}" | jq -r '._normalized_event.entity.key // .issue.number // .pull_request.number // empty')
+          if [[ -z "${WORK_ITEM_KEY}" ]]; then
+            echo "::error::event_payload missing normalized entity key, issue number, or pull request number"
+            exit 1
+          fi
+          ISSUE_NUMBER=$(printf '%s' "${EVENT_PAYLOAD}" | jq -r 'if ._normalized_event.source.system == "jira" then empty else (.issue.number // .pull_request.number // empty) end')
           DELIM="ISSUE_URL_$(openssl rand -hex 8)"
           {
             echo "issue_url<<${DELIM}"
             printf '%s' "${URL}"
             echo
             echo "${DELIM}"
+            echo "work_item_key=${WORK_ITEM_KEY}"
+            echo "issue_number=${ISSUE_NUMBER}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Run harness agent
@@ -1767,6 +1776,8 @@ jobs:
         env:
           GITHUB_ISSUE_URL: ${{ steps.dispatch-env.outputs.issue_url }}
           FULLSEND_WORK_ITEM_URL: ${{ steps.dispatch-env.outputs.issue_url }}
+          FULLSEND_WORK_ITEM_KEY: ${{ steps.dispatch-env.outputs.work_item_key }}
+          ISSUE_NUMBER: ${{ steps.dispatch-env.outputs.issue_number }}
           REPO_FULL_NAME: ${{ matrix.source_repo }}
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}

--- a/docs/ADRs/0063-polling-based-work-discovery.md
+++ b/docs/ADRs/0063-polling-based-work-discovery.md
@@ -420,7 +420,8 @@ execution-ref projection from `NormalizedEvent`
 | `FULLSEND_POLL_LOCK_PROPERTY` | Entity-property key for the lock |
 
 `GITHUB_ISSUE_URL` and related forge fields remain populated when
-`entity` maps to a GitHub issue for backward compatibility.
+`entity` maps to a GitHub issue for backward compatibility. `ISSUE_NUMBER`
+remains empty for external trackers whose keys do not identify GitHub issues.
 
 ### Concurrency model
 

--- a/docs/normative/normalized-event/v1/jira-poll-adapter.md
+++ b/docs/normative/normalized-event/v1/jira-poll-adapter.md
@@ -90,14 +90,16 @@ When `source.system` is `jira`, projection supplements the GitHub-shaped
 | `FULLSEND_WORK_ITEM_URL` | `entity.url` |
 | `FULLSEND_WORK_ITEM_SOURCE` | `jira` |
 | `FULLSEND_WORK_ITEM_KEY` | `entity.key` |
+| `ISSUE_NUMBER` | Omit or empty — a Jira key is not a GitHub issue number |
 | `event_payload.comment` | `transition.comment` when present |
 | `GITHUB_ISSUE_URL` | Omit or empty — not a GitHub issue |
 | `status-number` | `entity.id` (numeric Jira id) |
 
 Harnesses and pre-scripts that require forge-agnostic work item URLs SHOULD use
 `FULLSEND_WORK_ITEM_*` rather than forge-specific variables like
-`GITHUB_ISSUE_URL`. The dispatch workflow sets `FULLSEND_WORK_ITEM_URL` to
-`entity.url` for both GitHub and Jira events.
+`GITHUB_ISSUE_URL`. The dispatch workflow sets `FULLSEND_WORK_ITEM_URL` and
+`FULLSEND_WORK_ITEM_KEY` from the normalized entity for Jira events. For
+forge-native events, the generic key and `ISSUE_NUMBER` carry the same value.
 
 ## Example
 

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -818,6 +818,8 @@ func TestWorkItemKeyEnvCompatibility(t *testing.T) {
 		content := string(loadRepoFile(".github/workflows/reusable-code.yml")(t))
 		section := extractStepSection(t, content, "Run code agent")
 		assert.Contains(t, section,
+			"FULLSEND_WORK_ITEM_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}")
+		assert.Contains(t, section,
 			"FULLSEND_WORK_ITEM_KEY: ${{ fromJSON(inputs.event_payload).issue.number }}")
 		assert.Contains(t, section,
 			"ISSUE_NUMBER: ${{ fromJSON(inputs.event_payload).issue.number }}")

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -810,6 +810,44 @@ func TestReusableDispatchPRHeadSHAPassthrough(t *testing.T) {
 	})
 }
 
+// TestWorkItemKeyEnvCompatibility validates that legacy code dispatch and the
+// common harness-dispatch path expose the forge-neutral key alongside the
+// backwards-compatible GitHub issue number (#6760).
+func TestWorkItemKeyEnvCompatibility(t *testing.T) {
+	t.Run("legacy reusable code", func(t *testing.T) {
+		content := string(loadRepoFile(".github/workflows/reusable-code.yml")(t))
+		section := extractStepSection(t, content, "Run code agent")
+		assert.Contains(t, section,
+			"FULLSEND_WORK_ITEM_KEY: ${{ fromJSON(inputs.event_payload).issue.number }}")
+		assert.Contains(t, section,
+			"ISSUE_NUMBER: ${{ fromJSON(inputs.event_payload).issue.number }}")
+	})
+
+	t.Run("route based code", func(t *testing.T) {
+		content := string(loadRepoFile(".github/workflows/reusable-dispatch.yml")(t))
+		section := extractStepSection(t, content, "Run code agent")
+		assert.Contains(t, section,
+			"FULLSEND_WORK_ITEM_KEY: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}")
+		assert.Contains(t, section,
+			"ISSUE_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}")
+	})
+
+	t.Run("harness dispatch", func(t *testing.T) {
+		content := string(loadRepoFile(".github/workflows/reusable-dispatch.yml")(t))
+		exportSection := extractStepSection(t, content, "Export dispatch context env")
+		assert.Contains(t, exportSection,
+			`._normalized_event.entity.key // .issue.number // .pull_request.number // empty`)
+		assert.Contains(t, exportSection,
+			`if ._normalized_event.source.system == "jira" then empty`)
+
+		runSection := extractStepSection(t, content, "Run harness agent")
+		assert.Contains(t, runSection,
+			"FULLSEND_WORK_ITEM_KEY: ${{ steps.dispatch-env.outputs.work_item_key }}")
+		assert.Contains(t, runSection,
+			"ISSUE_NUMBER: ${{ steps.dispatch-env.outputs.issue_number }}")
+	})
+}
+
 // TestReusableDispatchStatusCommentPassthrough validates that all agent jobs in
 // reusable-dispatch.yml pass run-url, status-repo, and status-number to the
 // action, enabling status comments for every stage (#6397).

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -841,6 +841,9 @@ func TestWorkItemKeyEnvCompatibility(t *testing.T) {
 			`._normalized_event.entity.key // .issue.number // .pull_request.number // empty`)
 		assert.Contains(t, exportSection,
 			`if ._normalized_event.source.system == "jira" then empty`)
+		assert.Contains(t, exportSection, `echo "work_item_key<<${DELIM}"`)
+		assert.Contains(t, exportSection, `printf '%s' "${WORK_ITEM_KEY}"`)
+		assert.NotContains(t, exportSection, `echo "work_item_key=${WORK_ITEM_KEY}"`)
 
 		runSection := extractStepSection(t, content, "Run harness agent")
 		assert.Contains(t, runSection,


### PR DESCRIPTION
The common harness-dispatch path currently exports work-item URLs without the matching identifiers, so CEL-triggered code harnesses that require `ISSUE_NUMBER` fail before the agent starts. This adds the forge-neutral `FULLSEND_WORK_ITEM_KEY` while keeping the compatibility variable where it is meaningful.

For GitHub issue and PR payloads, both variables carry the numeric identifier. For Jira payloads, `FULLSEND_WORK_ITEM_KEY` carries `event.entity.key` and `ISSUE_NUMBER` stays empty, so we do not invent a relationship to a GitHub issue. The legacy reusable-code and inline route paths now expose the generic key beside their existing issue number too.

Tests pin all three paths, including the Jira distinction.

Closes #6760

Testing: `make lint`; `GOCACHE=/tmp/fullsend-go-cache go test ./internal/scaffold -count=1`