### PR TITLE
docs: remove internal-only e2e role from the user-facing role matrix

### DIFF
--- a/docs/guides/infrastructure/infrastructure-reference.md
+++ b/docs/guides/infrastructure/infrastructure-reference.md
@@ -104,9 +104,6 @@ Custom roles can be registered via the standalone mint's `CUSTOM_ROLE_PERMISSION
 | **review** | read | write | write | — | read | — | — | — | read |
 | **retro** | read | write | write | read | — | — | — | — | read |
 | **prioritize** | read | — | write | — | — | — | — | write | read |
-| **e2e** | write | write | write | write | — | write | write | — | read |
-
-The **e2e** role also grants: `administration` (write), `members` (write), `secrets` (write), `organization_actions_variables` (write), `organization_administration` (write). These permissions are omitted from the table above because no other role uses them.
 
 ### Mint Security Controls
 


### PR DESCRIPTION
## What

Removes the `e2e` row and its permissions note from the **Role Permissions Matrix** in `docs/guides/infrastructure/infrastructure-reference.md` (the row was added in #6652).

## Why

`e2e` is an internal role used only to drive fullsend's own end-to-end / behaviour test tooling against disposable test orgs. It is **not** a role users select for their agents. Listing it in the user-facing matrix alongside `coder`/`review`/`triage`/etc. implies it is a selectable option, which is exactly the role-selection confusion #6563 is about. The matrix should show only roles intended for user/agent configuration.

This is docs-only — no behaviour change. The role continues to exist and function for internal test tooling.

Relates to #6563 (BYOA role selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)