### PR TITLE
fix(#6702): use conditional requests for behaviour-suite polling GETs

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -41,7 +41,29 @@ type LiveClient struct {
 	rateMu   sync.Mutex
 	rate     forge.RateLimit
 	rateSeen bool
+
+	// etagCache holds the last ETag and decoded body seen for GET paths
+	// that opt into conditional requests via getCached (#6702). A 304
+	// response reusing a cached ETag does not count against the primary
+	// rate-limit budget, which is what makes this worth doing for the
+	// behaviour-test harness-wait poll loop: the same workflow-runs URL
+	// is requested every few seconds by up to a dozen concurrent
+	// scenarios sharing one installation token.
+	etagMu    sync.Mutex
+	etagCache map[string]etagEntry
 }
+
+// etagEntry is one cached (ETag, body) pair for a GET path.
+type etagEntry struct {
+	etag string
+	body []byte
+}
+
+// etagCacheLimit bounds etagCache so a long-lived client (the behaviour
+// suite runs many scenarios against many distinct run/job/artifact URLs)
+// cannot grow the map without bound. Crude but sufficient: clear it and
+// let it refill rather than evicting individual entries.
+const etagCacheLimit = 256
 
 // Compile-time interface checks.
 var _ forge.Client = (*LiveClient)(nil)
@@ -213,8 +235,20 @@ func IsPATForbiddenError(err error) bool {
 
 const maxRetries = 5
 
+// requestHeader is one extra header to set on a do() request. Only
+// getCached uses this today (If-None-Match); it exists as a variadic
+// option rather than a new do() overload so the other 28 call sites
+// stay untouched.
+type requestHeader struct {
+	key, value string
+}
+
+func withHeader(key, value string) requestHeader {
+	return requestHeader{key: key, value: value}
+}
+
 // do performs an HTTP request against the GitHub API with retry on rate limits.
-func (c *LiveClient) do(ctx context.Context, method, path string, body any) (*http.Response, error) {
+func (c *LiveClient) do(ctx context.Context, method, path string, body any, headers ...requestHeader) (*http.Response, error) {
 	url := c.baseURL + path
 
 	var bodyData []byte
@@ -244,6 +278,9 @@ func (c *LiveClient) do(ctx context.Context, method, path string, body any) (*ht
 		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 		if body != nil {
 			req.Header.Set("Content-Type", "application/json")
+		}
+		for _, h := range headers {
+			req.Header.Set(h.key, h.value)
 		}
 
 		resp, err := c.http.Do(req)
@@ -463,6 +500,72 @@ func (c *LiveClient) get(ctx context.Context, path string) (*http.Response, erro
 		return nil, err
 	}
 	return resp, nil
+}
+
+// getConditional performs a GET request, sending If-None-Match with etag
+// when non-empty. notModified is true when the server confirmed the
+// cached etag is still current (304); resp is nil in that case and the
+// caller must reuse its previously cached body. GitHub does not count a
+// 304 against the primary rate-limit budget (verified 2026-08-31: three
+// consecutive conditional requests left X-RateLimit-Remaining unchanged).
+func (c *LiveClient) getConditional(ctx context.Context, path, etag string) (resp *http.Response, notModified bool, err error) {
+	var headers []requestHeader
+	if etag != "" {
+		headers = append(headers, withHeader("If-None-Match", etag))
+	}
+	resp, err = c.do(ctx, http.MethodGet, path, nil, headers...)
+	if err != nil {
+		return nil, false, err
+	}
+	if resp.StatusCode == http.StatusNotModified {
+		resp.Body.Close()
+		return nil, true, nil
+	}
+	if err := checkStatus(resp, http.StatusOK); err != nil {
+		return nil, false, err
+	}
+	return resp, false, nil
+}
+
+// getCached performs a conditional GET against path, transparently
+// reusing the cached body on a 304. Only worth it for GET paths a
+// caller polls repeatedly with an unchanged result most of the time —
+// see etagCache's doc comment. A response without an ETag header is
+// returned but not cached (nothing to send next time).
+func (c *LiveClient) getCached(ctx context.Context, path string) ([]byte, error) {
+	c.etagMu.Lock()
+	prev, ok := c.etagCache[path]
+	c.etagMu.Unlock()
+
+	etag := ""
+	if ok {
+		etag = prev.etag
+	}
+
+	resp, notModified, err := c.getConditional(ctx, path, etag)
+	if err != nil {
+		return nil, err
+	}
+	if notModified {
+		return prev.body, nil
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if newETag := resp.Header.Get("ETag"); newETag != "" {
+		c.etagMu.Lock()
+		if len(c.etagCache) >= etagCacheLimit {
+			clear(c.etagCache)
+		}
+		if c.etagCache == nil {
+			c.etagCache = make(map[string]etagEntry)
+		}
+		c.etagCache[path] = etagEntry{etag: newETag, body: data}
+		c.etagMu.Unlock()
+	}
+	return data, nil
 }
 
 // post performs a POST request and checks for success.
@@ -3279,7 +3382,7 @@ func (c *LiveClient) awaitBranchUpdate(ctx context.Context, owner, repo string, 
 
 // ListWorkflowRuns returns recent workflow runs for a workflow file.
 func (c *LiveClient) ListWorkflowRuns(ctx context.Context, owner, repo, workflowFile string) ([]forge.WorkflowRun, error) {
-	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/workflows/%s/runs?per_page=10", owner, repo, workflowFile))
+	data, err := c.getCached(ctx, fmt.Sprintf("/repos/%s/%s/actions/workflows/%s/runs?per_page=10", owner, repo, workflowFile))
 	if err != nil {
 		return nil, fmt.Errorf("list workflow runs: %w", err)
 	}
@@ -3294,7 +3397,7 @@ func (c *LiveClient) ListWorkflowRuns(ctx context.Context, owner, repo, workflow
 			CreatedAt  string `json:"created_at"`
 		} `json:"workflow_runs"`
 	}
-	if err := decodeJSON(resp, &result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, fmt.Errorf("decode workflow runs: %w", err)
 	}
 	runs := make([]forge.WorkflowRun, len(result.WorkflowRuns))
@@ -3320,7 +3423,7 @@ func (c *LiveClient) ListRecentWorkflowRuns(ctx context.Context, owner, repo str
 	if perPage > 100 {
 		perPage = 100
 	}
-	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs?per_page=%d", owner, repo, perPage))
+	data, err := c.getCached(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs?per_page=%d", owner, repo, perPage))
 	if err != nil {
 		return nil, fmt.Errorf("list recent workflow runs: %w", err)
 	}
@@ -3335,7 +3438,7 @@ func (c *LiveClient) ListRecentWorkflowRuns(ctx context.Context, owner, repo str
 			CreatedAt  string `json:"created_at"`
 		} `json:"workflow_runs"`
 	}
-	if err := decodeJSON(resp, &result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, fmt.Errorf("decode recent workflow runs: %w", err)
 	}
 	runs := make([]forge.WorkflowRun, len(result.WorkflowRuns))
@@ -3355,7 +3458,7 @@ func (c *LiveClient) ListRecentWorkflowRuns(ctx context.Context, owner, repo str
 
 // ListWorkflowRunJobs returns the jobs within a workflow run.
 func (c *LiveClient) ListWorkflowRunJobs(ctx context.Context, owner, repo string, runID int) ([]forge.WorkflowJob, error) {
-	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs?per_page=100", owner, repo, runID))
+	data, err := c.getCached(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs?per_page=100", owner, repo, runID))
 	if err != nil {
 		return nil, fmt.Errorf("list workflow run jobs: %w", err)
 	}
@@ -3367,7 +3470,7 @@ func (c *LiveClient) ListWorkflowRunJobs(ctx context.Context, owner, repo string
 			Conclusion string `json:"conclusion"`
 		} `json:"jobs"`
 	}
-	if err := decodeJSON(resp, &result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, fmt.Errorf("decode workflow run jobs: %w", err)
 	}
 	jobs := make([]forge.WorkflowJob, len(result.Jobs))
@@ -3384,7 +3487,7 @@ func (c *LiveClient) ListWorkflowRunJobs(ctx context.Context, owner, repo string
 
 // ListWorkflowRunArtifacts returns artifacts uploaded by a workflow run.
 func (c *LiveClient) ListWorkflowRunArtifacts(ctx context.Context, owner, repo string, runID int) ([]forge.WorkflowArtifact, error) {
-	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs/%d/artifacts", owner, repo, runID))
+	data, err := c.getCached(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs/%d/artifacts", owner, repo, runID))
 	if err != nil {
 		return nil, fmt.Errorf("list workflow run artifacts: %w", err)
 	}
@@ -3394,7 +3497,7 @@ func (c *LiveClient) ListWorkflowRunArtifacts(ctx context.Context, owner, repo s
 			Name string `json:"name"`
 		} `json:"artifacts"`
 	}
-	if err := decodeJSON(resp, &result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, fmt.Errorf("decode workflow run artifacts: %w", err)
 	}
 	artifacts := make([]forge.WorkflowArtifact, len(result.Artifacts))
@@ -3440,7 +3543,7 @@ func (c *LiveClient) ListRepositoryArtifacts(ctx context.Context, owner, repo st
 	if perPage > 100 {
 		perPage = 100
 	}
-	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/artifacts?per_page=%d", owner, repo, perPage))
+	data, err := c.getCached(ctx, fmt.Sprintf("/repos/%s/%s/actions/artifacts?per_page=%d", owner, repo, perPage))
 	if err != nil {
 		return nil, fmt.Errorf("list repository artifacts: %w", err)
 	}
@@ -3455,7 +3558,7 @@ func (c *LiveClient) ListRepositoryArtifacts(ctx context.Context, owner, repo st
 			} `json:"workflow_run"`
 		} `json:"artifacts"`
 	}
-	if err := decodeJSON(resp, &result); err != nil {
+	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, fmt.Errorf("decode repository artifacts: %w", err)
 	}
 	artifacts := make([]forge.RepositoryArtifact, 0, len(result.Artifacts))

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -3637,6 +3637,126 @@ func TestListWorkflowRuns_IncludesEvent(t *testing.T) {
 	assert.Equal(t, "issues", runs[0].Event)
 }
 
+// TestGetCached_ConditionalRequestReuses304 exercises the #6702 fix
+// through ListWorkflowRuns: the first request has no If-None-Match, the
+// server returns 200 with an ETag; the second request must send that
+// exact ETag back, and on 304 the client must decode the cached body
+// rather than an empty one.
+func TestGetCached_ConditionalRequestReuses304(t *testing.T) {
+	const etag = `W/"abc123"`
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		switch calls {
+		case 1:
+			assert.Empty(t, r.Header.Get("If-None-Match"), "first request must not send If-None-Match")
+			w.Header().Set("ETag", etag)
+			json.NewEncoder(w).Encode(map[string]any{
+				"workflow_runs": []map[string]any{
+					{"id": 1, "status": "in_progress", "created_at": "2024-01-01T00:00:00Z"},
+				},
+			})
+		case 2:
+			assert.Equal(t, etag, r.Header.Get("If-None-Match"), "second request must echo the weak ETag verbatim")
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusNotModified)
+		default:
+			t.Fatalf("unexpected call %d", calls)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	first, err := client.ListWorkflowRuns(context.Background(), "org", "repo", "fullsend.yaml")
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	second, err := client.ListWorkflowRuns(context.Background(), "org", "repo", "fullsend.yaml")
+	require.NoError(t, err)
+	require.Len(t, second, 1, "304 must decode to the cached body, not an empty one")
+	assert.Equal(t, first[0].ID, second[0].ID)
+	assert.Equal(t, "in_progress", second[0].Status)
+	assert.Equal(t, 2, calls)
+}
+
+// TestGetCached_ChangedETagRefetchesBody guards against the flake class
+// this fix could reintroduce if done wrong: a status change must always
+// come with a new ETag from the (real) server, and the client must not
+// keep serving a stale cached body once the ETag changes.
+func TestGetCached_ChangedETagRefetchesBody(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		status := "in_progress"
+		etag := `"v1"`
+		if calls > 1 {
+			status = "completed"
+			etag = `"v2"`
+		}
+		w.Header().Set("ETag", etag)
+		json.NewEncoder(w).Encode(map[string]any{
+			"workflow_runs": []map[string]any{
+				{"id": 1, "status": status, "created_at": "2024-01-01T00:00:00Z"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	first, err := client.ListWorkflowRuns(context.Background(), "org", "repo", "fullsend.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "in_progress", first[0].Status)
+
+	second, err := client.ListWorkflowRuns(context.Background(), "org", "repo", "fullsend.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "completed", second[0].Status)
+}
+
+// TestGetCached_NoETagNotCached ensures a response without an ETag
+// header is decoded normally and never triggers a conditional request
+// on the next call — there is nothing to send.
+func TestGetCached_NoETagNotCached(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		assert.Empty(t, r.Header.Get("If-None-Match"))
+		json.NewEncoder(w).Encode(map[string]any{
+			"workflow_runs": []map[string]any{
+				{"id": 1, "status": "in_progress", "created_at": "2024-01-01T00:00:00Z"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.ListWorkflowRuns(context.Background(), "org", "repo", "fullsend.yaml")
+	require.NoError(t, err)
+	_, err = client.ListWorkflowRuns(context.Background(), "org", "repo", "fullsend.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+// TestEtagCache_Bounded ensures a long-lived client polling many
+// distinct URLs (one per workflow run, in the behaviour suite) does not
+// grow etagCache without bound.
+func TestEtagCache_Bounded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"`+r.URL.Path+`"`)
+		json.NewEncoder(w).Encode(map[string]any{"jobs": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	for i := range etagCacheLimit * 2 {
+		_, err := client.ListWorkflowRunJobs(context.Background(), "org", "repo", i)
+		require.NoError(t, err)
+	}
+	client.etagMu.Lock()
+	size := len(client.etagCache)
+	client.etagMu.Unlock()
+	assert.LessOrEqual(t, size, etagCacheLimit)
+}
+
 func TestListWorkflowRunJobs(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/repos/org/repo/actions/runs/42/jobs", r.URL.Path)


### PR DESCRIPTION
## What

Follow-up to #6705's instrumentation. That PR measured the harness-wait poll loop draining the shared installation token's primary quota at ~235 req/min, exhausting it ~20 minutes into a suite run (#6702). This is candidate 1 of the two the issue proposed, in order of leverage: conditional requests.

## Why this works

GitHub does not count a `304 Not Modified` against the primary rate-limit budget. Verified against the live API before writing any code:

```
$ curl -si -H "If-None-Match: <etag>" .../actions/runs?per_page=5
HTTP/2 304
x-ratelimit-remaining: 4685
$ curl -si -H "If-None-Match: <etag>" .../actions/runs?per_page=5   # again
HTTP/2 304
x-ratelimit-remaining: 4685   # unchanged across repeated 304s
```

Only the original uncached `200` consumed a unit. The harness-wait poll loop re-requests the same workflow-runs/jobs/artifacts URLs every few seconds, from up to a dozen concurrent scenarios — most of those polls see an unchanged result while a run is still queued or in progress, so this is the highest-leverage fix for exactly the traffic pattern that exhausts the budget.

## What changed

- `LiveClient` gains a small conditional-GET cache (`etagCache`, capped at `etagCacheLimit`) and a `getCached(ctx, path)` helper: sends `If-None-Match` when a cached ETag exists, returns the cached body on `304`, otherwise decodes and caches the new body + ETag.
- `do()` grows a variadic `requestHeader` option so `getConditional` can set `If-None-Match` without touching any of its other 28 call sites.
- Wired into the five GET endpoints the harness-wait poll loop and its diagnostics actually use: `ListWorkflowRuns`, `ListRecentWorkflowRuns`, `ListWorkflowRunJobs`, `ListWorkflowRunArtifacts`, `ListRepositoryArtifacts`. Nothing else opts in — `get()` (used by writes, one-shot reads) is untouched.

## What's deliberately not in this PR

- **The circuit breaker** (issue's candidate 2: back off when remaining drops below a threshold). Landing both at once doubles review surface, and the breaker needs a threshold I don't have data for yet. If behaviour runs after this merges still show #6698's `403 retryable` diagnostics, that's the next PR, sized from real post-fix numbers.
- **Cause 2 (permission-propagation race, #6701/#6703)** — separate, gated on a decision about touching the dispatch-side authorization path (ADR 0054).

## Correctness risk worth naming

If GitHub's ETag on a listing ever failed to change when a run's `status` changed, the poller would silently see stale data — the exact flake class this fixes, reintroduced worse. Not unit-testable; the behaviour job on this PR is the real check (a stuck poll would time out, and #6698's diagnostics now name errors instead of swallowing them).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test -race ./internal/forge/... ./pkg/behaviourtest/...` — all pass
- New tests in `internal/forge/github/github_test.go`: conditional request reuses a `304` and decodes the cached body; a changed ETag forces a real re-fetch (not stale data); a response without an ETag is never cached; `etagCache` stays bounded across many distinct URLs
- Behaviour job on this PR is the live verification (12 concurrent scenarios against a pool org, same conditions #6702 measured)