### PR TITLE
fix(#6156): block closed issue code dispatch

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -141,6 +141,7 @@ jobs:
           COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
 
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          ISSUE_STATE: ${{ github.event.issue.state }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           ISSUE_IS_PR: ${{ github.event.issue.pull_request && 'true' || 'false' }}
           ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
@@ -274,7 +275,7 @@ jobs:
               elif [[ "${EVENT_ACTION}" == "labeled" ]]; then
                 if [[ "${TRIGGERING_LABEL}" == "ready-for-triage" ]]; then
                   STAGE="triage"
-                elif [[ "${TRIGGERING_LABEL}" == "ready-to-code" ]]; then
+                elif [[ "${TRIGGERING_LABEL}" == "ready-to-code" ]] && [[ "${ISSUE_STATE}" == "open" ]]; then
                   # Mutation stage: write+ labeler, or bots (agent handoff).
                   if [[ "${EVENT_SENDER_LOGIN}" =~ \[bot\]$ ]] || is_event_actor_authorized "${EVENT_SENDER_LOGIN}"; then
                     STAGE="code"

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -40,6 +40,7 @@ jobs:
           COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
 
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          ISSUE_STATE: ${{ github.event.issue.state }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           ISSUE_HAS_PR: ${{ github.event.issue.pull_request && 'true' || 'false' }}
           ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
@@ -176,7 +177,7 @@ jobs:
               elif [[ "${EVENT_ACTION}" == "labeled" ]]; then
                 if [[ "${TRIGGERING_LABEL}" == "ready-for-triage" ]]; then
                   STAGE="triage"
-                elif [[ "${TRIGGERING_LABEL}" == "ready-to-code" ]]; then
+                elif [[ "${TRIGGERING_LABEL}" == "ready-to-code" ]] && [[ "${ISSUE_STATE}" == "open" ]]; then
                   # Mutation stage: write+ labeler, or bots (agent handoff).
                   if [[ "${EVENT_SENDER_LOGIN}" =~ \[bot\]$ ]] || is_event_actor_authorized "${EVENT_SENDER_LOGIN}"; then
                     STAGE="code"

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -664,10 +664,13 @@ func TestClosedIssueReadyToCodeDoesNotDispatch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := string(tc.content(t))
+			condition := `elif [[ "${TRIGGERING_LABEL}" == "ready-to-code" ]] && [[ "${ISSUE_STATE}" == "open" ]]; then`
 			assert.Contains(t, s, `ISSUE_STATE: ${{ github.event.issue.state }}`,
 				"route step must read issue state from the triggering event")
-			assert.Regexp(t, `(?s)TRIGGERING_LABEL\}" == "ready-to-code".*ISSUE_STATE\}" == "open".*STAGE="code"`, s,
-				"ready-to-code must route only when the event reports an open issue")
+			assert.Contains(t, s, condition,
+				"ready-to-code must require an open issue in the same conditional")
+			assert.Regexp(t, regexp.QuoteMeta(condition)+`\n\s+#[^\n]*\n\s+if [^\n]+; then\n\s+STAGE="code"\n\s+fi`, s,
+				"STAGE=code must remain inside the guarded ready-to-code branch")
 		})
 	}
 }

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -649,6 +649,29 @@ func TestDispatchPerStageAuthorization(t *testing.T) {
 	}
 }
 
+// TestClosedIssueReadyToCodeDoesNotDispatch guards the final routing boundary
+// against a close-between-check-and-label race in post-triage. Both dispatch
+// implementations must use the issue state carried by the labeled event.
+func TestClosedIssueReadyToCodeDoesNotDispatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		content func(t *testing.T) []byte
+	}{
+		{"reusable-dispatch.yml", loadRepoFile(".github/workflows/reusable-dispatch.yml")},
+		{"scaffold/dispatch.yml", loadScaffoldFile(".github/workflows/dispatch.yml")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := string(tc.content(t))
+			assert.Contains(t, s, `ISSUE_STATE: ${{ github.event.issue.state }}`,
+				"route step must read issue state from the triggering event")
+			assert.Regexp(t, `(?s)TRIGGERING_LABEL\}" == "ready-to-code".*ISSUE_STATE\}" == "open".*STAGE="code"`, s,
+				"ready-to-code must route only when the event reports an open issue")
+		})
+	}
+}
+
 // TestShimScaffoldBranchFilter validates that both shim templates skip dispatch
 // for PRs from the fullsend/scaffold branch. Without this filter, the shim
 // fires pull_request_target on the scaffold PR, causing dispatch noise (#5470).


### PR DESCRIPTION
## Summary

- read the issue state from the triggering GitHub event
- route `ready-to-code` labels only when that event reports an open issue
- keep the reusable and scaffold dispatch implementations synchronized
- add a regression covering both routing implementations

This is the authoritative dispatch-side guard for the close-between-check-and-label race. The producer-side optimization and post-triage regressions are in fullsend-ai/agents#1120.

## Testing

- `GOCACHE=/private/tmp/fullsend-6156-go-cache go test ./internal/scaffold -count=1`
- `GOCACHE=/private/tmp/fullsend-6156-go-cache make lint`

Fixes #6156
