### PR TITLE
test(hack): add mint-access-patterns harness for workflow-host policy

### DIFF
--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -60,9 +60,18 @@ COUNT_FAIL=0
 COUNT_ERROR=0
 GH_API_TOKEN=""
 GH_CRED_HELPER=""
+TMPROOT=""
+REUSABLE_BRANCH=""
+ACTIVE_BRANCH_REPOS=()
+ACTIVE_BRANCH_NAMES=()
 
 usage() {
-  sed -n '2,40p' "$0" | sed 's/^# \?//'
+  sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 2
 }
 
 while [[ $# -gt 0 ]]; do
@@ -123,6 +132,21 @@ case "$MODE" in
     ;;
 esac
 
+case "$TIMEOUT" in
+  '' | *[!0-9]*) die "--timeout must be a positive integer (got: ${TIMEOUT})" ;;
+esac
+((TIMEOUT > 0)) || die "--timeout must be greater than zero"
+
+case "$POLL_INTERVAL" in
+  '' | *[!0-9]*) die "--poll-interval must be a positive integer (got: ${POLL_INTERVAL})" ;;
+esac
+((POLL_INTERVAL > 0)) || die "--poll-interval must be greater than zero"
+
+case "$ROLE_FILTER" in
+  '' | triage | coder | review | retro | prioritize | fullsend | e2e) ;;
+  *) die "--role must be one of triage, coder, review, retro, prioritize, fullsend, or e2e (got: ${ROLE_FILTER})" ;;
+esac
+
 if [[ -z "$MINT_URL" ]]; then
   echo "ERROR: --mint-url or FULLSEND_MINT_URL is required" >&2
   exit 2
@@ -147,6 +171,37 @@ fi
 # Credential helper for HTTPS remotes (same pattern as eval/scripts/setup-fixture.sh).
 GH_CRED_HELPER="!f(){ echo \"password=${GH_API_TOKEN}\"; };f"
 
+TMPROOT=$(mktemp -d)
+REUSABLE_BRANCH="mint-ap-reusable-$(od -An -N4 -tx1 /dev/urandom | tr -d ' \n')"
+
+register_branch() {
+  ACTIVE_BRANCH_REPOS+=("$1")
+  ACTIVE_BRANCH_NAMES+=("$2")
+}
+
+unregister_branch() {
+  local repo="$1" branch="$2" i
+  for i in "${!ACTIVE_BRANCH_NAMES[@]}"; do
+    if [[ "${ACTIVE_BRANCH_REPOS[$i]}" == "$repo" && "${ACTIVE_BRANCH_NAMES[$i]}" == "$branch" ]]; then
+      unset 'ACTIVE_BRANCH_REPOS[i]' 'ACTIVE_BRANCH_NAMES[i]'
+    fi
+  done
+}
+
+# Invoked indirectly by the EXIT trap.
+# shellcheck disable=SC2317
+cleanup() {
+  local i
+  for i in "${!ACTIVE_BRANCH_NAMES[@]}"; do
+    gh api -X DELETE "/repos/${ACTIVE_BRANCH_REPOS[$i]}/git/refs/heads/${ACTIVE_BRANCH_NAMES[$i]}" \
+      --silent >/dev/null 2>&1 || true
+  done
+  rm -rf "$TMPROOT"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # --- colors (status token only) ---
 C_PASS=""
 C_FAIL=""
@@ -170,7 +225,7 @@ ensure_repo() {
   if gh api "/repos/${full}" --silent &>/dev/null; then
     return 0
   fi
-  echo "creating repo ${full}"
+  echo "creating repo ${full}" >&2
   if gh repo create "${full}" --public --add-readme --description "mint access-pattern test fixture" &>/dev/null; then
     return 0
   fi
@@ -213,65 +268,39 @@ fullsend_mint() {
 
 workflow_host_add() {
   local repo="$1"
-  echo "enrollment: workflow-host add ${repo}"
-  if fullsend_mint workflow-host add "${repo}" --project="${GCP_PROJECT}" --region="${GCP_REGION}" 2>/dev/null; then
-    return 0
-  fi
-  # Fallback when CLI lacks workflow-host (pre-#5916): merge into WORKFLOW_HOST_REPOS.
-  echo "enrollment: workflow-host CLI unavailable; merging WORKFLOW_HOST_REPOS via gcloud"
-  if ! command -v gcloud &>/dev/null; then
-    echo "ERROR: gcloud required for WORKFLOW_HOST_REPOS fallback" >&2
-    return 1
-  fi
-  local traffic_rev current merged
-  traffic_rev=$(gcloud run services describe fullsend-mint \
-    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
-    --format='value(status.traffic[0].revisionName)')
-  current=$(gcloud run revisions describe "${traffic_rev}" \
-    --project="${GCP_PROJECT}" --region="${GCP_REGION}" --format=json \
-    | jq -r '.spec.containers[0].env[]? | select(.name=="WORKFLOW_HOST_REPOS") | .value // empty')
-  merged=$(
-    {
-      [[ -n "$current" ]] && tr ',' '\n' <<<"$current"
-      printf '%s\n' "${repo}"
-    } | awk 'NF && !seen[$0]++' | paste -sd, -
-  )
-  echo "enrollment: setting WORKFLOW_HOST_REPOS=${merged}"
-  gcloud run services update fullsend-mint \
-    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
-    --update-env-vars="WORKFLOW_HOST_REPOS=${merged}" \
-    --quiet
+  echo "enrollment: workflow-host add ${repo}" >&2
+  fullsend_mint workflow-host add "${repo}" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
 }
 
 configure_mint_enrollment() {
-  echo "enrollment: configuring mint for mode=${MODE} project=${GCP_PROJECT} region=${GCP_REGION}"
+  echo "enrollment: configuring mint for mode=${MODE} project=${GCP_PROJECT} region=${GCP_REGION}" >&2
   case "$MODE" in
     per-repo)
-      echo "enrollment: unenroll org ${ORG}"
-      fullsend_mint unenroll "${ORG}" --project="${GCP_PROJECT}" --region="${GCP_REGION}" --yolo || true
-      echo "enrollment: enroll repo ${ORG}/mint-test"
+      echo "enrollment: unenroll org ${ORG}" >&2
+      fullsend_mint unenroll "${ORG}" --project="${GCP_PROJECT}" --region="${GCP_REGION}" --yolo
+      echo "enrollment: enroll repo ${ORG}/mint-test" >&2
       fullsend_mint enroll "${ORG}/mint-test" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
       workflow_host_add "${UPSTREAM_WORKFLOW_HOST}"
       workflow_host_add "${ORG}/${WORKFLOW_REPO}"
       ;;
     per-org)
-      echo "enrollment: unenroll repo ${ORG}/mint-test"
-      fullsend_mint unenroll "${ORG}/mint-test" --project="${GCP_PROJECT}" --region="${GCP_REGION}" --yolo || true
-      echo "enrollment: enroll org ${ORG}"
+      echo "enrollment: unenroll repo ${ORG}/mint-test" >&2
+      fullsend_mint unenroll "${ORG}/mint-test" --project="${GCP_PROJECT}" --region="${GCP_REGION}" --yolo
+      echo "enrollment: enroll org ${ORG}" >&2
       fullsend_mint enroll "${ORG}" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
       workflow_host_add "${UPSTREAM_WORKFLOW_HOST}"
       workflow_host_add "${ORG}/${WORKFLOW_REPO}"
       ;;
     both)
-      echo "enrollment: enroll org ${ORG}"
+      echo "enrollment: enroll org ${ORG}" >&2
       fullsend_mint enroll "${ORG}" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
-      echo "enrollment: enroll repo ${ORG}/mint-test"
+      echo "enrollment: enroll repo ${ORG}/mint-test" >&2
       fullsend_mint enroll "${ORG}/mint-test" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
       workflow_host_add "${UPSTREAM_WORKFLOW_HOST}"
       workflow_host_add "${ORG}/${WORKFLOW_REPO}"
       ;;
   esac
-  echo "enrollment: done"
+  echo "enrollment: done" >&2
 }
 
 # Mint curl body used by reusable + in-repo / .fullsend direct workflows.
@@ -284,12 +313,18 @@ mint_curl_run_script() {
           finish() { exit 0; }
           trap finish EXIT
 
-          OIDC_TOKEN=$(curl -sSf --retry 3 --retry-delay 2 --retry-all-errors \
+          if ! OIDC_RESPONSE=$(curl -sSf --retry 3 --retry-delay 2 --retry-all-errors \
             -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=fullsend-mint" | jq -r '.value' || true)
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=fullsend-mint"); then
+            jq -n '{outcome:"error",error:"oidc_transport"}' > mint-ap-result.json
+            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            exit 0
+          fi
+          OIDC_TOKEN=$(jq -r '.value // empty' <<<"$OIDC_RESPONSE" 2>/dev/null || true)
           if [[ -z "$OIDC_TOKEN" || "$OIDC_TOKEN" == "null" ]]; then
             echo "Failed to obtain OIDC token" >&2
-            jq -n '{outcome:"denied",error:"oidc"}' > mint-ap-result.json
+            jq -n '{outcome:"error",error:"oidc_response"}' > mint-ap-result.json
+            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
             exit 0
           fi
           echo "::add-mask::$OIDC_TOKEN"
@@ -311,31 +346,50 @@ mint_curl_run_script() {
             fi
           fi
 
-          HTTP_CODE=$(curl -sS --retry 2 --retry-delay 2 \
+          if ! HTTP_CODE=$(curl -sS --retry 2 --retry-delay 2 --retry-all-errors \
             -o mint-ap-response.json -w '%{http_code}' \
             -H "Authorization: Bearer $OIDC_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$BODY" \
-            "${MINT_URL}/v1/token" || true)
-
-          if [[ ! "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
-            echo "Mint denied/failed HTTP $HTTP_CODE"
-            jq -n --arg code "$HTTP_CODE" '{outcome:"denied",http_status:($code|tonumber)}' \
-              > mint-ap-result.json
+            "${MINT_URL}/v1/token"); then
+            jq -n '{outcome:"error",error:"mint_transport"}' > mint-ap-result.json
+            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
             exit 0
           fi
 
-          TOKEN=$(jq -r '.token // empty' mint-ap-response.json)
+          if [[ "$HTTP_CODE" == "403" ]]; then
+            echo "Mint denied HTTP $HTTP_CODE"
+            jq -n --arg code "$HTTP_CODE" '{outcome:"denied",http_status:($code|tonumber)}' \
+              > mint-ap-result.json
+            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            exit 0
+          fi
+          if [[ ! "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Mint failed HTTP $HTTP_CODE" >&2
+            jq -n --arg code "$HTTP_CODE" '{outcome:"error",error:"mint_http",http_status:($code|tonumber)}' \
+              > mint-ap-result.json
+            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            exit 0
+          fi
+
+          if ! TOKEN=$(jq -er '.token | select(type == "string" and length > 0)' mint-ap-response.json); then
+            TOKEN=""
+          fi
           if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
             echo "Mint response missing token" >&2
-            jq -n '{outcome:"denied",error:"no_token"}' > mint-ap-result.json
+            jq -n '{outcome:"error",error:"mint_response"}' > mint-ap-result.json
+            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
             exit 0
           fi
           echo "::add-mask::$TOKEN"
 
-          SELECTION=$(jq -r '.repository_selection // empty' mint-ap-response.json)
-          REPOS=$(jq -c '.granted_repos // []' mint-ap-response.json)
-          PERMS=$(jq -c '.granted_permissions // {}' mint-ap-response.json)
+          if ! SELECTION=$(jq -er '.repository_selection | select(type == "string")' mint-ap-response.json) ||
+            ! REPOS=$(jq -ec '.granted_repos // [] | select(type == "array") | sort' mint-ap-response.json) ||
+            ! PERMS=$(jq -ec '.granted_permissions // {} | select(type == "object")' mint-ap-response.json); then
+            jq -n '{outcome:"error",error:"mint_scope_response"}' > mint-ap-result.json
+            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            exit 0
+          fi
 
           jq -n \
             --arg outcome minted \
@@ -345,41 +399,56 @@ mint_curl_run_script() {
             '{outcome:$outcome, repository_selection:$selection, granted_repos:$repos, granted_permissions:$perms}' \
             > mint-ap-result.json
 
-          echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+          case "$ROLE" in
+            triage) EXPECTED_PERMS='{"contents":"read","issues":"write","metadata":"read"}' ;;
+            coder) EXPECTED_PERMS='{"checks":"read","contents":"write","issues":"write","metadata":"read","pull_requests":"write"}' ;;
+            review) EXPECTED_PERMS='{"checks":"read","contents":"read","issues":"write","metadata":"read","pull_requests":"write"}' ;;
+            retro) EXPECTED_PERMS='{"actions":"read","contents":"read","issues":"write","metadata":"read","pull_requests":"write"}' ;;
+            prioritize) EXPECTED_PERMS='{"contents":"read","issues":"write","metadata":"read","organization_projects":"write"}' ;;
+            fullsend) EXPECTED_PERMS='{"actions":"write","actions_variables":"read","contents":"write","metadata":"read","pull_requests":"write","workflows":"write"}' ;;
+            e2e) EXPECTED_PERMS='{"actions":"write","actions_variables":"write","administration":"write","contents":"write","issues":"write","members":"write","metadata":"read","organization_actions_variables":"write","organization_administration":"write","pull_requests":"write","secrets":"write","workflows":"write"}' ;;
+          esac
 
+          SCOPE_VALID=true
           if [[ -n "$EXPECTED_SCOPE_REPO" ]]; then
             if [[ "$SELECTION" != "selected" ]]; then
               echo "Expected repository_selection=selected, got '${SELECTION}'" >&2
-              jq -n \
-                --arg selection "$SELECTION" \
-                --argjson repos "$REPOS" \
-                --argjson perms "$PERMS" \
-                '{outcome:"denied",error:"scope",repository_selection:$selection,granted_repos:$repos,granted_permissions:$perms}' \
-                > mint-ap-result.json
-              exit 0
+              SCOPE_VALID=false
+            elif ! jq -e --arg want "$EXPECTED_SCOPE_REPO" \
+              '.granted_repos == [$want]' mint-ap-result.json >/dev/null; then
+              echo "Expected granted_repos to equal [$EXPECTED_SCOPE_REPO], got $REPOS" >&2
+              SCOPE_VALID=false
             fi
-            if ! jq -e --arg want "$EXPECTED_SCOPE_REPO" \
-              '.granted_repos | index($want) != null' mint-ap-result.json >/dev/null; then
-              echo "Expected granted_repos to contain $EXPECTED_SCOPE_REPO, got $REPOS" >&2
-              jq -n \
-                --arg selection "$SELECTION" \
-                --argjson repos "$REPOS" \
-                --argjson perms "$PERMS" \
-                '{outcome:"denied",error:"scope",repository_selection:$selection,granted_repos:$repos,granted_permissions:$perms}' \
-                > mint-ap-result.json
-              exit 0
-            fi
+          elif jq -e 'length == 1 and .[0] == "*"' <<<"${REPOS_JSON:-[]}" >/dev/null 2>&1 &&
+            { [[ "$SELECTION" != "all" ]] || [[ "$REPOS" != "[]" ]]; }; then
+            echo "Expected installation-wide scope with no explicit repositories, got selection=$SELECTION repos=$REPOS" >&2
+            SCOPE_VALID=false
           fi
+          if ! jq -e --argjson expected "$EXPECTED_PERMS" '.granted_permissions == $expected' \
+            mint-ap-result.json >/dev/null; then
+            echo "Granted permissions do not exactly match role $ROLE" >&2
+            SCOPE_VALID=false
+          fi
+          if [[ "$SCOPE_VALID" != true ]]; then
+            jq -n \
+              --arg selection "$SELECTION" \
+              --argjson repos "$REPOS" \
+              --argjson perms "$PERMS" \
+              '{outcome:"error",error:"scope",repository_selection:$selection,granted_repos:$repos,granted_permissions:$perms}' \
+              > mint-ap-result.json
+          fi
+          echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
 RUNSCRIPT
 }
 
-# Write reusable workflow onto {org}/fullsend main (idempotent content push).
+# Write the reusable workflow to a disposable branch removed by cleanup().
 ensure_fullsend_reusable() {
   local full_repo="${ORG}/${WORKFLOW_REPO}"
   local work tmp
-  echo "setup: ensuring reusable workflow on ${full_repo}"
-  work=$(mktemp -d)
-  tmp=$(mktemp)
+  echo "setup: ensuring reusable workflow on ${full_repo}" >&2
+  work=$(mktemp -d "${TMPROOT}/reusable.XXXXXX")
+  tmp=$(mktemp "${TMPROOT}/reusable-error.XXXXXX")
+  register_branch "$full_repo" "$REUSABLE_BRANCH"
   (
     set -euo pipefail
     git -c "credential.helper=${GH_CRED_HELPER}" \
@@ -445,13 +514,9 @@ HDR
 FTR
     } >.github/workflows/mint-ap-reusable.yml
     git add .github/workflows/mint-ap-reusable.yml
-    if git diff --cached --quiet; then
-      echo "setup: reusable workflow already up to date"
-    else
-      git commit -m "mint-ap: sync reusable workflow" --quiet
-      git push origin HEAD:main --quiet
-      echo "setup: pushed reusable workflow to ${full_repo}@main"
-    fi
+    git commit --allow-empty -m "mint-ap: disposable reusable workflow" --quiet
+    git push origin "HEAD:${REUSABLE_BRANCH}" --quiet
+    echo "setup: pushed reusable workflow to ${full_repo}@${REUSABLE_BRANCH}" >&2
   ) 2>"${tmp}" || {
     echo "ERROR: failed to ensure reusable on ${full_repo}: $(tr '\n' ' ' <"${tmp}" | head -c 300)" >&2
     rm -rf "${work}" "${tmp}"
@@ -461,6 +526,7 @@ FTR
 }
 
 # Direct mint workflow (on: push) for .fullsend or in-repo-host negative.
+# Args: destination directory, role, repos JSON, expected scope repo, optional target org.
 write_direct_mint_workflow() {
   local dest_dir="$1"
   local role="$2"
@@ -513,6 +579,7 @@ FTR
 }
 
 # Thin shim on mint-test that calls {org}/fullsend reusable.
+# Args: destination directory, role, repos JSON, expected scope repo, optional target org.
 write_shim_workflow() {
   local dest_dir="$1"
   local role="$2"
@@ -535,7 +602,7 @@ permissions:
   actions: write
 jobs:
   mint:
-    uses: ${ORG}/${WORKFLOW_REPO}/.github/workflows/mint-ap-reusable.yml@main
+    uses: ${ORG}/${WORKFLOW_REPO}/.github/workflows/mint-ap-reusable.yml@${REUSABLE_BRANCH}
     with:
       mint_url: '${MINT_URL//\'/\'\'}'
       role: '${role//\'/\'\'}'
@@ -549,9 +616,10 @@ EOF
 fetch_result_json() {
   local full_repo="$1" run_id="$2"
   local tmp attempt
-  tmp=$(mktemp -d)
+  tmp=$(mktemp -d "${TMPROOT}/result.XXXXXX")
 
   for attempt in 1 2 3 4 5; do
+    rm -rf "${tmp:?}"/*
     if gh run download "${run_id}" --repo "${full_repo}" -n mint-ap-result -D "${tmp}" &>/dev/null; then
       if [[ -f "${tmp}/mint-ap-result.json" ]]; then
         cat "${tmp}/mint-ap-result.json"
@@ -559,6 +627,7 @@ fetch_result_json() {
         return 0
       fi
     fi
+    echo "result artifact unavailable (attempt ${attempt}/5); retrying" >&2
     sleep 2
   done
 
@@ -576,14 +645,14 @@ fetch_result_json() {
 }
 
 wait_for_run() {
-  local full_repo="$1" branch="$2"
+  local full_repo="$1" branch="$2" head_sha="$3"
   local deadline=$((SECONDS + TIMEOUT))
   local run_json run_id status
 
   while ((SECONDS < deadline)); do
-    run_json=$(gh run list --repo "${full_repo}" --branch "${branch}" --limit 1 \
-      --json databaseId,status,conclusion,url 2>/dev/null || echo '[]')
-    run_id=$(jq -r '.[0].databaseId // empty' <<<"$run_json")
+    run_json=$(gh run list --repo "${full_repo}" --branch "${branch}" --limit 20 \
+      --json databaseId,status,conclusion,url,headSha 2>/dev/null || echo '[]')
+    run_id=$(jq -r --arg sha "$head_sha" '[.[] | select(.headSha == $sha)][0].databaseId // empty' <<<"$run_json")
     if [[ -n "$run_id" ]]; then
       break
     fi
@@ -596,8 +665,16 @@ wait_for_run() {
   fi
 
   while ((SECONDS < deadline)); do
-    run_json=$(gh run view "${run_id}" --repo "${full_repo}" \
-      --json databaseId,status,conclusion,url)
+    if ! run_json=$(gh run view "${run_id}" --repo "${full_repo}" \
+      --json databaseId,status,conclusion,url,headSha 2>/dev/null); then
+      echo "transient error reading workflow run ${run_id}; retrying" >&2
+      sleep "${POLL_INTERVAL}"
+      continue
+    fi
+    if [[ "$(jq -r '.headSha // empty' <<<"$run_json")" != "$head_sha" ]]; then
+      echo "workflow run ${run_id} has unexpected head SHA" >&2
+      return 1
+    fi
     status=$(jq -r '.status' <<<"$run_json")
     if [[ "$status" == "completed" ]]; then
       printf '%s\n' "$run_json"
@@ -624,7 +701,7 @@ mtest() {
   local host_style="${8:-shim}"
   local label="${id}/${role}"
   local full_repo="${ORG}/${caller_repo}"
-  local branch work tmp_err run_json run_id run_url conclusion actual result_json scope_rest
+  local branch work tmp_err head_sha run_json run_id run_url conclusion actual result_json scope_rest
   local expected_scope_full=""
   local target_org_arg=""
 
@@ -649,8 +726,8 @@ mtest() {
   branch="mint-ap-${id}-${role}-$(rand_hex)"
   branch=$(tr -c 'a-zA-Z0-9._-' '-' <<<"$branch" | sed 's/-\+/-/g; s/^-//; s/-$//')
 
-  work=$(mktemp -d)
-  tmp_err=$(mktemp)
+  work=$(mktemp -d "${TMPROOT}/case.XXXXXX")
+  tmp_err=$(mktemp "${TMPROOT}/case-error.XXXXXX")
 
   if ! (
     set -euo pipefail
@@ -684,11 +761,14 @@ mtest() {
     return 0
   fi
   rm -f "${tmp_err}"
+  head_sha=$(git -C "${work}/repo" rev-parse HEAD)
+  register_branch "$full_repo" "$branch"
 
-  if ! run_json=$(wait_for_run "${full_repo}" "${branch}" 2>"${work}/wait.err"); then
+  if ! run_json=$(wait_for_run "${full_repo}" "${branch}" "$head_sha" 2>"${work}/wait.err"); then
     print_case_line ERROR "$label" "$(tr '\n' ' ' <"${work}/wait.err" | head -c 200)"
     COUNT_ERROR=$((COUNT_ERROR + 1))
     git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    unregister_branch "$full_repo" "$branch"
     rm -rf "${work}"
     return 0
   fi
@@ -701,16 +781,26 @@ mtest() {
     print_case_line ERROR "$label" "workflow conclusion=${conclusion:-unknown}  ${run_url}"
     COUNT_ERROR=$((COUNT_ERROR + 1))
     git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    unregister_branch "$full_repo" "$branch"
     rm -rf "${work}"
     return 0
   fi
 
   result_json=$(fetch_result_json "${full_repo}" "${run_id}" 2>/dev/null || true)
   actual=$(jq -r '.outcome // empty' <<<"${result_json:-{}}" 2>/dev/null || true)
+  if [[ "$actual" == "error" ]]; then
+    print_case_line ERROR "$label" "mint workflow error=$(jq -r '.error // "unknown"' <<<"$result_json")  ${run_url}"
+    COUNT_ERROR=$((COUNT_ERROR + 1))
+    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    unregister_branch "$full_repo" "$branch"
+    rm -rf "${work}"
+    return 0
+  fi
   if [[ "$actual" != "minted" && "$actual" != "denied" ]]; then
     print_case_line ERROR "$label" "missing or invalid mint-ap-result artifact  ${run_url}"
     COUNT_ERROR=$((COUNT_ERROR + 1))
     git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    unregister_branch "$full_repo" "$branch"
     rm -rf "${work}"
     return 0
   fi
@@ -723,6 +813,7 @@ mtest() {
   fi
 
   git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+  unregister_branch "$full_repo" "$branch"
   rm -rf "${work}"
 
   if [[ "$actual" == "$expect" ]]; then
@@ -787,6 +878,12 @@ esac
 # Negative: mint job hosted in mint-test (must deny). host_style=in-repo-host
 # id                 role         caller      repos_json              expect  scope   target  host_style
 mtest in-repo-host   triage       mint-test   '["mint-test"]'         denied  -       -       in-repo-host
+mtest in-repo-host   coder        mint-test   '["mint-test"]'         denied  -       -       in-repo-host
+mtest in-repo-host   review       mint-test   '["mint-test"]'         denied  -       -       in-repo-host
+mtest in-repo-host   retro        mint-test   '["mint-test"]'         denied  -       -       in-repo-host
+mtest in-repo-host   prioritize   mint-test   '["mint-test"]'         denied  -       -       in-repo-host
+mtest in-repo-host   fullsend     mint-test   '["mint-test"]'         denied  -       -       in-repo-host
+mtest in-repo-host   e2e          mint-test   '["mint-test"]'         denied  -       -       in-repo-host
 
 # Same-org via mint-test shim → {org}/fullsend reusable
 # id                 role         caller      repos_json              expect                  scope      target  host_style

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -1,0 +1,846 @@
+#!/usr/bin/env bash
+# mint-access-patterns — exercise mint repos-field + workflow-host access patterns
+# via GHA OIDC (ADR 0082 / PR #5916).
+#
+# Pushes ephemeral on-push workflows that call the mint with curl (not the
+# fullsend binary), then asserts minted/denied outcomes and token scope.
+#
+# Most mint-test cases use a shim that calls a reusable workflow in {org}/fullsend
+# (listed on WORKFLOW_HOST_REPOS). .fullsend hosts its own mint job for org-mode
+# cases. One negative case hosts the mint job in mint-test itself (must deny).
+#
+# Usage:
+#   hack/mint-access-patterns.sh --mint-url URL [options]
+#
+# Options:
+#   --org ORG             GitHub org (default: fullsand-ai)
+#   --mint-url URL        Mint base URL (or set FULLSEND_MINT_URL)
+#   --foreign-org ORG     Target org for e2e foreign-mint cases (default: halfsend)
+#   --role ROLE           Run only cases for this role (default: all roles in matrix)
+#   --mode MODE           per-repo (default) | per-org | both
+#   --project GCP_PROJECT Optional: surgically enroll/unenroll for MODE
+#   --region REGION       GCP region for mint CLI (default: us-central1)
+#   --timeout SECONDS     Per-case workflow wait timeout (default: 600)
+#   --poll-interval SEC   Poll interval while waiting for runs (default: 5)
+#   -h, --help            Show this help
+#
+# Requires: gh, jq, git, curl; gh authenticated (or GH_TOKEN) with repo create +
+# contents/actions. Git clone/push use HTTPS with a token credential helper.
+# With --project: gcloud + mise/go for fullsend mint CLI.
+#
+# Output: one line per case with colored PASS/FAIL/ERROR (TTY, respects NO_COLOR),
+# mint outcome (minted|denied), and scope when minted. Exit 0 only if all PASS.
+# Generated workflows always succeed (no GitHub failure emails); case results are
+# reported only by this script from the mint-ap-result artifact.
+#
+# Foreign e2e: blank repos expect denied; repos=["*"] expect minted in
+# per-repo/both (shim via {org}/fullsend). In per-org the same shim is
+# denied — per-org hosts are hard-wired to {org}/.fullsend and upstream.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ORG="fullsand-ai"
+MINT_URL="${FULLSEND_MINT_URL:-}"
+FOREIGN_ORG="halfsend"
+ROLE_FILTER=""
+MODE="per-repo"
+GCP_PROJECT=""
+GCP_REGION="us-central1"
+TIMEOUT=600
+POLL_INTERVAL=5
+
+UPSTREAM_WORKFLOW_HOST="fullsend-ai/fullsend"
+WORKFLOW_REPO="fullsend"
+
+COUNT_OK=0
+COUNT_FAIL=0
+COUNT_ERROR=0
+GH_API_TOKEN=""
+GH_CRED_HELPER=""
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \?//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org)
+      ORG="${2:?--org requires a value}"
+      shift 2
+      ;;
+    --mint-url)
+      MINT_URL="${2:?--mint-url requires a value}"
+      shift 2
+      ;;
+    --foreign-org)
+      FOREIGN_ORG="${2:?--foreign-org requires a value}"
+      shift 2
+      ;;
+    --role)
+      ROLE_FILTER="${2:?--role requires a value}"
+      shift 2
+      ;;
+    --mode)
+      MODE="${2:?--mode requires a value}"
+      shift 2
+      ;;
+    --project)
+      GCP_PROJECT="${2:?--project requires a value}"
+      shift 2
+      ;;
+    --region)
+      GCP_REGION="${2:?--region requires a value}"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT="${2:?--timeout requires a value}"
+      shift 2
+      ;;
+    --poll-interval)
+      POLL_INTERVAL="${2:?--poll-interval requires a value}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$MODE" in
+  per-repo | per-org | both) ;;
+  *)
+    echo "ERROR: --mode must be per-repo, per-org, or both (got: ${MODE})" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "$MINT_URL" ]]; then
+  echo "ERROR: --mint-url or FULLSEND_MINT_URL is required" >&2
+  exit 2
+fi
+MINT_URL="${MINT_URL%/}"
+
+for cmd in gh jq git curl; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: $cmd is required but not found in PATH" >&2
+    exit 2
+  fi
+done
+
+GH_API_TOKEN="${GH_TOKEN:-}"
+if [[ -z "$GH_API_TOKEN" ]]; then
+  GH_API_TOKEN="$(gh auth token 2>/dev/null || true)"
+fi
+if [[ -z "$GH_API_TOKEN" ]]; then
+  echo "ERROR: set GH_TOKEN or run gh auth login (needed for HTTPS git)" >&2
+  exit 2
+fi
+# Credential helper for HTTPS remotes (same pattern as eval/scripts/setup-fixture.sh).
+GH_CRED_HELPER="!f(){ echo \"password=${GH_API_TOKEN}\"; };f"
+
+# --- colors (status token only) ---
+C_PASS=""
+C_FAIL=""
+C_ERROR=""
+C_RESET=""
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  C_PASS=$'\033[32m'
+  C_FAIL=$'\033[31m'
+  C_ERROR=$'\033[33m'
+  C_RESET=$'\033[0m'
+fi
+
+rand_hex() {
+  od -An -N4 -tx1 /dev/urandom | tr -d ' \n'
+}
+
+# --- repo ensure ---
+ensure_repo() {
+  local name="$1"
+  local full="${ORG}/${name}"
+  if gh api "/repos/${full}" --silent &>/dev/null; then
+    return 0
+  fi
+  echo "creating repo ${full}"
+  if gh repo create "${full}" --public --add-readme --description "mint access-pattern test fixture" &>/dev/null; then
+    return 0
+  fi
+  gh api -X POST "/orgs/${ORG}/repos" \
+    -f name="${name}" \
+    -f visibility=public \
+    -F auto_init=true \
+    -f description="mint access-pattern test fixture" \
+    --silent >/dev/null
+}
+
+# --- formatting ---
+format_scope() {
+  local json="$1"
+  local selection repos perms
+  selection=$(jq -r '.repository_selection // empty' <<<"$json")
+  repos=$(jq -r '.granted_repos // [] | join(",")' <<<"$json")
+  perms=$(jq -r '.granted_permissions // {} | to_entries | map("\(.key)=\(.value)") | join(",")' <<<"$json")
+  local out="scope=${selection}"
+  [[ -n "$repos" ]] && out+=" repos=${repos}"
+  [[ -n "$perms" ]] && out+=" perms=${perms}"
+  printf '%s' "$out"
+}
+
+print_case_line() {
+  local status="$1" label="$2" rest="$3"
+  local color=""
+  case "$status" in
+    PASS) color="$C_PASS" ;;
+    FAIL) color="$C_FAIL" ;;
+    ERROR) color="$C_ERROR" ;;
+  esac
+  printf '%s%-5s%s %-28s %s\n' "$color" "$status" "$C_RESET" "$label" "$rest"
+}
+
+# --- mint CLI helpers (optional --project) ---
+fullsend_mint() {
+  (cd "${REPO_ROOT}" && mise exec -- go run ./cmd/fullsend mint "$@")
+}
+
+workflow_host_add() {
+  local repo="$1"
+  echo "enrollment: workflow-host add ${repo}"
+  if fullsend_mint workflow-host add "${repo}" --project="${GCP_PROJECT}" --region="${GCP_REGION}" 2>/dev/null; then
+    return 0
+  fi
+  # Fallback when CLI lacks workflow-host (pre-#5916): merge into WORKFLOW_HOST_REPOS.
+  echo "enrollment: workflow-host CLI unavailable; merging WORKFLOW_HOST_REPOS via gcloud"
+  if ! command -v gcloud &>/dev/null; then
+    echo "ERROR: gcloud required for WORKFLOW_HOST_REPOS fallback" >&2
+    return 1
+  fi
+  local traffic_rev current merged
+  traffic_rev=$(gcloud run services describe fullsend-mint \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
+    --format='value(status.traffic[0].revisionName)')
+  current=$(gcloud run revisions describe "${traffic_rev}" \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" --format=json \
+    | jq -r '.spec.containers[0].env[]? | select(.name=="WORKFLOW_HOST_REPOS") | .value // empty')
+  merged=$(
+    {
+      [[ -n "$current" ]] && tr ',' '\n' <<<"$current"
+      printf '%s\n' "${repo}"
+    } | awk 'NF && !seen[$0]++' | paste -sd, -
+  )
+  echo "enrollment: setting WORKFLOW_HOST_REPOS=${merged}"
+  gcloud run services update fullsend-mint \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
+    --update-env-vars="WORKFLOW_HOST_REPOS=${merged}" \
+    --quiet
+}
+
+configure_mint_enrollment() {
+  echo "enrollment: configuring mint for mode=${MODE} project=${GCP_PROJECT} region=${GCP_REGION}"
+  case "$MODE" in
+    per-repo)
+      echo "enrollment: unenroll org ${ORG}"
+      fullsend_mint unenroll "${ORG}" --project="${GCP_PROJECT}" --region="${GCP_REGION}" --yolo || true
+      echo "enrollment: enroll repo ${ORG}/mint-test"
+      fullsend_mint enroll "${ORG}/mint-test" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
+      workflow_host_add "${UPSTREAM_WORKFLOW_HOST}"
+      workflow_host_add "${ORG}/${WORKFLOW_REPO}"
+      ;;
+    per-org)
+      echo "enrollment: unenroll repo ${ORG}/mint-test"
+      fullsend_mint unenroll "${ORG}/mint-test" --project="${GCP_PROJECT}" --region="${GCP_REGION}" --yolo || true
+      echo "enrollment: enroll org ${ORG}"
+      fullsend_mint enroll "${ORG}" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
+      workflow_host_add "${UPSTREAM_WORKFLOW_HOST}"
+      workflow_host_add "${ORG}/${WORKFLOW_REPO}"
+      ;;
+    both)
+      echo "enrollment: enroll org ${ORG}"
+      fullsend_mint enroll "${ORG}" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
+      echo "enrollment: enroll repo ${ORG}/mint-test"
+      fullsend_mint enroll "${ORG}/mint-test" --project="${GCP_PROJECT}" --region="${GCP_REGION}"
+      workflow_host_add "${UPSTREAM_WORKFLOW_HOST}"
+      workflow_host_add "${ORG}/${WORKFLOW_REPO}"
+      ;;
+  esac
+  echo "enrollment: done"
+}
+
+# Mint curl body used by reusable + in-repo / .fullsend direct workflows.
+# Args expand at generation time into the workflow file.
+mint_curl_run_script() {
+  cat <<'RUNSCRIPT'
+          set -euo pipefail
+          # Always exit 0 so GitHub does not email on "failed" runs; outcome lives
+          # in mint-ap-result.json for the driver.
+          finish() { exit 0; }
+          trap finish EXIT
+
+          OIDC_TOKEN=$(curl -sSf --retry 3 --retry-delay 2 --retry-all-errors \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=fullsend-mint" | jq -r '.value' || true)
+          if [[ -z "$OIDC_TOKEN" || "$OIDC_TOKEN" == "null" ]]; then
+            echo "Failed to obtain OIDC token" >&2
+            jq -n '{outcome:"denied",error:"oidc"}' > mint-ap-result.json
+            exit 0
+          fi
+          echo "::add-mask::$OIDC_TOKEN"
+
+          if [[ -z "${REPOS_JSON}" ]]; then
+            if [[ -n "${TARGET_ORG}" ]]; then
+              BODY=$(jq -nc --arg role "$ROLE" --arg target_org "$TARGET_ORG" \
+                '{role: $role, target_org: $target_org}')
+            else
+              BODY=$(jq -nc --arg role "$ROLE" '{role: $role}')
+            fi
+          else
+            if [[ -n "${TARGET_ORG}" ]]; then
+              BODY=$(jq -nc --arg role "$ROLE" --argjson repos "$REPOS_JSON" --arg target_org "$TARGET_ORG" \
+                '{role: $role, repos: $repos, target_org: $target_org}')
+            else
+              BODY=$(jq -nc --arg role "$ROLE" --argjson repos "$REPOS_JSON" \
+                '{role: $role, repos: $repos}')
+            fi
+          fi
+
+          HTTP_CODE=$(curl -sS --retry 2 --retry-delay 2 \
+            -o mint-ap-response.json -w '%{http_code}' \
+            -H "Authorization: Bearer $OIDC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "${MINT_URL}/v1/token" || true)
+
+          if [[ ! "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Mint denied/failed HTTP $HTTP_CODE"
+            jq -n --arg code "$HTTP_CODE" '{outcome:"denied",http_status:($code|tonumber)}' \
+              > mint-ap-result.json
+            exit 0
+          fi
+
+          TOKEN=$(jq -r '.token // empty' mint-ap-response.json)
+          if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+            echo "Mint response missing token" >&2
+            jq -n '{outcome:"denied",error:"no_token"}' > mint-ap-result.json
+            exit 0
+          fi
+          echo "::add-mask::$TOKEN"
+
+          SELECTION=$(jq -r '.repository_selection // empty' mint-ap-response.json)
+          REPOS=$(jq -c '.granted_repos // []' mint-ap-response.json)
+          PERMS=$(jq -c '.granted_permissions // {}' mint-ap-response.json)
+
+          jq -n \
+            --arg outcome minted \
+            --arg selection "$SELECTION" \
+            --argjson repos "$REPOS" \
+            --argjson perms "$PERMS" \
+            '{outcome:$outcome, repository_selection:$selection, granted_repos:$repos, granted_permissions:$perms}' \
+            > mint-ap-result.json
+
+          echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+
+          if [[ -n "$EXPECTED_SCOPE_REPO" ]]; then
+            if [[ "$SELECTION" != "selected" ]]; then
+              echo "Expected repository_selection=selected, got '${SELECTION}'" >&2
+              jq -n \
+                --arg selection "$SELECTION" \
+                --argjson repos "$REPOS" \
+                --argjson perms "$PERMS" \
+                '{outcome:"denied",error:"scope",repository_selection:$selection,granted_repos:$repos,granted_permissions:$perms}' \
+                > mint-ap-result.json
+              exit 0
+            fi
+            if ! jq -e --arg want "$EXPECTED_SCOPE_REPO" \
+              '.granted_repos | index($want) != null' mint-ap-result.json >/dev/null; then
+              echo "Expected granted_repos to contain $EXPECTED_SCOPE_REPO, got $REPOS" >&2
+              jq -n \
+                --arg selection "$SELECTION" \
+                --argjson repos "$REPOS" \
+                --argjson perms "$PERMS" \
+                '{outcome:"denied",error:"scope",repository_selection:$selection,granted_repos:$repos,granted_permissions:$perms}' \
+                > mint-ap-result.json
+              exit 0
+            fi
+          fi
+RUNSCRIPT
+}
+
+# Write reusable workflow onto {org}/fullsend main (idempotent content push).
+ensure_fullsend_reusable() {
+  local full_repo="${ORG}/${WORKFLOW_REPO}"
+  local work tmp
+  echo "setup: ensuring reusable workflow on ${full_repo}"
+  work=$(mktemp -d)
+  tmp=$(mktemp)
+  (
+    set -euo pipefail
+    git -c "credential.helper=${GH_CRED_HELPER}" \
+      clone --depth 1 --quiet "https://x-access-token@github.com/${full_repo}.git" "${work}/repo"
+    cd "${work}/repo"
+    git config credential.helper "${GH_CRED_HELPER}"
+    git config user.email "mint-ap@localhost"
+    git config user.name "mint-access-patterns"
+    git config commit.gpgsign false
+    mkdir -p .github/workflows
+    {
+      cat <<'HDR'
+name: mint-ap-reusable
+on:
+  workflow_call:
+    inputs:
+      mint_url:
+        required: true
+        type: string
+      role:
+        required: true
+        type: string
+      repos_json:
+        required: false
+        type: string
+        default: ""
+      target_org:
+        required: false
+        type: string
+        default: ""
+      expected_scope_repo:
+        required: false
+        type: string
+        default: ""
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint via curl
+        id: mint
+        env:
+          MINT_URL: ${{ inputs.mint_url }}
+          ROLE: ${{ inputs.role }}
+          REPOS_JSON: ${{ inputs.repos_json }}
+          EXPECTED_SCOPE_REPO: ${{ inputs.expected_scope_repo }}
+          TARGET_ORG: ${{ inputs.target_org }}
+        run: |
+HDR
+      mint_curl_run_script
+      cat <<'FTR'
+
+      - name: Upload mint-ap result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mint-ap-result
+          path: mint-ap-result.json
+          if-no-files-found: ignore
+FTR
+    } >.github/workflows/mint-ap-reusable.yml
+    git add .github/workflows/mint-ap-reusable.yml
+    if git diff --cached --quiet; then
+      echo "setup: reusable workflow already up to date"
+    else
+      git commit -m "mint-ap: sync reusable workflow" --quiet
+      git push origin HEAD:main --quiet
+      echo "setup: pushed reusable workflow to ${full_repo}@main"
+    fi
+  ) 2>"${tmp}" || {
+    echo "ERROR: failed to ensure reusable on ${full_repo}: $(tr '\n' ' ' <"${tmp}" | head -c 300)" >&2
+    rm -rf "${work}" "${tmp}"
+    exit 1
+  }
+  rm -rf "${work}" "${tmp}"
+}
+
+# Direct mint workflow (on: push) for .fullsend or in-repo-host negative.
+write_direct_mint_workflow() {
+  local dest_dir="$1"
+  local role="$2"
+  local repos_json="$3"
+  local expected_scope_full="$4"
+  local target_org="${5:-}"
+
+  local repos_yaml
+  if [[ "$repos_json" == "-" ]]; then
+    repos_yaml='""'
+  else
+    repos_yaml="'${repos_json//\'/\'\'}'"
+  fi
+
+  mkdir -p "${dest_dir}/.github/workflows"
+  {
+    cat <<EOF
+name: mint-ap
+on: push
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint via curl
+        id: mint
+        env:
+          MINT_URL: '${MINT_URL//\'/\'\'}'
+          ROLE: '${role//\'/\'\'}'
+          REPOS_JSON: ${repos_yaml}
+          EXPECTED_SCOPE_REPO: '${expected_scope_full//\'/\'\'}'
+          TARGET_ORG: '${target_org//\'/\'\'}'
+        run: |
+EOF
+    mint_curl_run_script
+    cat <<'FTR'
+
+      - name: Upload mint-ap result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mint-ap-result
+          path: mint-ap-result.json
+          if-no-files-found: ignore
+FTR
+  } >"${dest_dir}/.github/workflows/mint-ap.yml"
+}
+
+# Thin shim on mint-test that calls {org}/fullsend reusable.
+write_shim_workflow() {
+  local dest_dir="$1"
+  local role="$2"
+  local repos_json="$3"
+  local expected_scope_full="$4"
+  local target_org="${5:-}"
+
+  local repos_input=""
+  if [[ "$repos_json" != "-" ]]; then
+    repos_input="${repos_json}"
+  fi
+
+  mkdir -p "${dest_dir}/.github/workflows"
+  cat >"${dest_dir}/.github/workflows/mint-ap.yml" <<EOF
+name: mint-ap
+on: push
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+jobs:
+  mint:
+    uses: ${ORG}/${WORKFLOW_REPO}/.github/workflows/mint-ap-reusable.yml@main
+    with:
+      mint_url: '${MINT_URL//\'/\'\'}'
+      role: '${role//\'/\'\'}'
+      repos_json: '${repos_input//\'/\'\'}'
+      target_org: '${target_org//\'/\'\'}'
+      expected_scope_repo: '${expected_scope_full//\'/\'\'}'
+EOF
+}
+
+# Fetch result JSON for a completed run (artifact preferred, log fallback).
+fetch_result_json() {
+  local full_repo="$1" run_id="$2"
+  local tmp attempt
+  tmp=$(mktemp -d)
+
+  for attempt in 1 2 3 4 5; do
+    if gh run download "${run_id}" --repo "${full_repo}" -n mint-ap-result -D "${tmp}" &>/dev/null; then
+      if [[ -f "${tmp}/mint-ap-result.json" ]]; then
+        cat "${tmp}/mint-ap-result.json"
+        rm -rf "${tmp}"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+
+  local log line
+  if log=$(gh run view "${run_id}" --repo "${full_repo}" --log 2>/dev/null); then
+    line=$(grep -o 'MINT_AP_RESULT={.*}' <<<"$log" | tail -1 || true)
+    if [[ -n "$line" ]]; then
+      printf '%s\n' "${line#MINT_AP_RESULT=}"
+      rm -rf "${tmp}"
+      return 0
+    fi
+  fi
+  rm -rf "${tmp}"
+  return 1
+}
+
+wait_for_run() {
+  local full_repo="$1" branch="$2"
+  local deadline=$((SECONDS + TIMEOUT))
+  local run_json run_id status
+
+  while ((SECONDS < deadline)); do
+    run_json=$(gh run list --repo "${full_repo}" --branch "${branch}" --limit 1 \
+      --json databaseId,status,conclusion,url 2>/dev/null || echo '[]')
+    run_id=$(jq -r '.[0].databaseId // empty' <<<"$run_json")
+    if [[ -n "$run_id" ]]; then
+      break
+    fi
+    sleep "${POLL_INTERVAL}"
+  done
+
+  if [[ -z "${run_id:-}" ]]; then
+    echo "timeout waiting for workflow run to appear" >&2
+    return 1
+  fi
+
+  while ((SECONDS < deadline)); do
+    run_json=$(gh run view "${run_id}" --repo "${full_repo}" \
+      --json databaseId,status,conclusion,url)
+    status=$(jq -r '.status' <<<"$run_json")
+    if [[ "$status" == "completed" ]]; then
+      printf '%s\n' "$run_json"
+      return 0
+    fi
+    sleep "${POLL_INTERVAL}"
+  done
+
+  echo "timeout waiting for workflow run ${run_id} to complete" >&2
+  return 1
+}
+
+# --- mtest ---
+# mtest <id> <role> <caller_repo> <repos_json|-> <expect> <scope_repo|-> [target_org|-] [host_style]
+#
+# host_style: shim (default) | direct | in-repo-host
+# repos_json: JSON array, or "-" to omit the repos key (blank)
+# expect:     minted | denied
+# scope_repo: bare repo name required in granted_repos when minted, or "-" when denied
+# target_org: optional cross-org mint target; omit or "-" for same-org
+mtest() {
+  local id="$1" role="$2" caller_repo="$3" repos_json="$4" expect="$5" scope_repo="$6"
+  local target_org="${7:--}"
+  local host_style="${8:-shim}"
+  local label="${id}/${role}"
+  local full_repo="${ORG}/${caller_repo}"
+  local branch work tmp_err run_json run_id run_url conclusion actual result_json scope_rest
+  local expected_scope_full=""
+  local target_org_arg=""
+
+  if [[ -n "$ROLE_FILTER" && "$role" != "$ROLE_FILTER" ]]; then
+    return 0
+  fi
+
+  if [[ "$expect" != "minted" && "$expect" != "denied" ]]; then
+    print_case_line ERROR "$label" "invalid expect=${expect}"
+    COUNT_ERROR=$((COUNT_ERROR + 1))
+    return 0
+  fi
+
+  if [[ "$target_org" != "-" && -n "$target_org" ]]; then
+    target_org_arg="$target_org"
+  fi
+
+  if [[ "$expect" == "minted" && "$scope_repo" != "-" && -n "$scope_repo" ]]; then
+    expected_scope_full="${ORG}/${scope_repo}"
+  fi
+
+  branch="mint-ap-${id}-${role}-$(rand_hex)"
+  branch=$(tr -c 'a-zA-Z0-9._-' '-' <<<"$branch" | sed 's/-\+/-/g; s/^-//; s/-$//')
+
+  work=$(mktemp -d)
+  tmp_err=$(mktemp)
+
+  if ! (
+    set -euo pipefail
+    git -c "credential.helper=${GH_CRED_HELPER}" \
+      clone --depth 1 --quiet "https://x-access-token@github.com/${full_repo}.git" "${work}/repo"
+    cd "${work}/repo"
+    git config credential.helper "${GH_CRED_HELPER}"
+    git checkout -b "${branch}" >/dev/null
+    git config user.email "mint-ap@localhost"
+    git config user.name "mint-access-patterns"
+    git config commit.gpgsign false
+    case "$host_style" in
+      shim)
+        write_shim_workflow "$(pwd)" "${role}" "${repos_json}" "${expected_scope_full}" "${target_org_arg}"
+        ;;
+      direct | in-repo-host)
+        write_direct_mint_workflow "$(pwd)" "${role}" "${repos_json}" "${expected_scope_full}" "${target_org_arg}"
+        ;;
+      *)
+        echo "invalid host_style=${host_style}" >&2
+        exit 1
+        ;;
+    esac
+    git add .github/workflows/mint-ap.yml
+    git commit -m "mint-ap: ${id} ${role} ${host_style}" --quiet
+    git push -u origin "HEAD:${branch}" --quiet
+  ) 2>"${tmp_err}"; then
+    print_case_line ERROR "$label" "push failed: $(tr '\n' ' ' <"${tmp_err}" | head -c 200)"
+    COUNT_ERROR=$((COUNT_ERROR + 1))
+    rm -rf "${work}" "${tmp_err}"
+    return 0
+  fi
+  rm -f "${tmp_err}"
+
+  if ! run_json=$(wait_for_run "${full_repo}" "${branch}" 2>"${work}/wait.err"); then
+    print_case_line ERROR "$label" "$(tr '\n' ' ' <"${work}/wait.err" | head -c 200)"
+    COUNT_ERROR=$((COUNT_ERROR + 1))
+    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    rm -rf "${work}"
+    return 0
+  fi
+
+  run_id=$(jq -r '.databaseId' <<<"$run_json")
+  run_url=$(jq -r '.url' <<<"$run_json")
+  conclusion=$(jq -r '.conclusion // empty' <<<"$run_json")
+
+  if [[ "$conclusion" != "success" ]]; then
+    print_case_line ERROR "$label" "workflow conclusion=${conclusion:-unknown}  ${run_url}"
+    COUNT_ERROR=$((COUNT_ERROR + 1))
+    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    rm -rf "${work}"
+    return 0
+  fi
+
+  result_json=$(fetch_result_json "${full_repo}" "${run_id}" 2>/dev/null || true)
+  actual=$(jq -r '.outcome // empty' <<<"${result_json:-{}}" 2>/dev/null || true)
+  if [[ "$actual" != "minted" && "$actual" != "denied" ]]; then
+    print_case_line ERROR "$label" "missing or invalid mint-ap-result artifact  ${run_url}"
+    COUNT_ERROR=$((COUNT_ERROR + 1))
+    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    rm -rf "${work}"
+    return 0
+  fi
+
+  scope_rest=""
+  if [[ -n "${result_json}" ]] && jq -e 'has("repository_selection") or ((.granted_repos // []) | length) > 0' <<<"$result_json" &>/dev/null; then
+    if [[ "$actual" == "minted" ]] || jq -e '.error == "scope"' <<<"$result_json" &>/dev/null; then
+      scope_rest=$(format_scope "$result_json")
+    fi
+  fi
+
+  git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+  rm -rf "${work}"
+
+  if [[ "$actual" == "$expect" ]]; then
+    if [[ "$actual" == "minted" && -n "$scope_rest" ]]; then
+      print_case_line PASS "$label" "minted  ${scope_rest}"
+    else
+      print_case_line PASS "$label" "$actual"
+    fi
+    COUNT_OK=$((COUNT_OK + 1))
+  else
+    local detail="expect=${expect} actual=${actual}"
+    [[ -n "$scope_rest" ]] && detail+="  ${scope_rest}"
+    detail+="  ${run_url}"
+    print_case_line FAIL "$label" "$detail"
+    COUNT_FAIL=$((COUNT_FAIL + 1))
+  fi
+}
+
+# --- startup banner ---
+echo "mint-access-patterns: mode=${MODE}"
+echo "  org=${ORG} mint-url=${MINT_URL} foreign-org=${FOREIGN_ORG}"
+if [[ -n "$GCP_PROJECT" ]]; then
+  echo "  project=${GCP_PROJECT} region=${GCP_REGION}"
+else
+  echo "  enrollment: assumed preconfigured for mode=${MODE}"
+fi
+[[ -n "$ROLE_FILTER" ]] && echo "  role-filter=${ROLE_FILTER}"
+
+# --- setup ---
+ensure_repo ".fullsend"
+ensure_repo "mint-test"
+ensure_repo "mint-test-other"
+ensure_repo "${WORKFLOW_REPO}"
+ensure_fullsend_reusable
+
+if [[ -n "$GCP_PROJECT" ]]; then
+  configure_mint_enrollment
+fi
+
+# Mode-derived expects
+shim_same_expect=denied
+fullsend_tgt_expect=denied
+foreign_wild_expect=denied
+case "$MODE" in
+  per-repo)
+    shim_same_expect=minted
+    fullsend_tgt_expect=denied
+    foreign_wild_expect=minted
+    ;;
+  per-org)
+    shim_same_expect=denied
+    fullsend_tgt_expect=minted
+    foreign_wild_expect=denied
+    ;;
+  both)
+    shim_same_expect=minted
+    fullsend_tgt_expect=minted
+    foreign_wild_expect=minted
+    ;;
+esac
+
+# Negative: mint job hosted in mint-test (must deny). host_style=in-repo-host
+# id                 role         caller      repos_json              expect  scope   target  host_style
+mtest in-repo-host   triage       mint-test   '["mint-test"]'         denied  -       -       in-repo-host
+
+# Same-org via mint-test shim → {org}/fullsend reusable
+# id                 role         caller      repos_json              expect                  scope      target  host_style
+mtest blank-repos    triage       mint-test   -                      denied                  -          -       shim
+mtest same-repo      triage       mint-test   '["mint-test"]'         "$shim_same_expect"    mint-test  -       shim
+mtest wildcard       triage       mint-test   '["*"]'                 denied                  -          -       shim
+mtest other-repo     triage       mint-test   '["mint-test-other"]'   denied                  -          -       shim
+mtest fullsend-tgt   triage       .fullsend   '["mint-test"]'         "$fullsend_tgt_expect" mint-test  -       direct
+
+mtest blank-repos    coder        mint-test   -                      denied                  -          -       shim
+mtest same-repo      coder        mint-test   '["mint-test"]'         "$shim_same_expect"    mint-test  -       shim
+mtest wildcard       coder        mint-test   '["*"]'                 denied                  -          -       shim
+mtest other-repo     coder        mint-test   '["mint-test-other"]'   denied                  -          -       shim
+mtest fullsend-tgt   coder        .fullsend   '["mint-test"]'         "$fullsend_tgt_expect" mint-test  -       direct
+
+mtest blank-repos    review       mint-test   -                      denied                  -          -       shim
+mtest same-repo      review       mint-test   '["mint-test"]'         "$shim_same_expect"    mint-test  -       shim
+mtest wildcard       review       mint-test   '["*"]'                 denied                  -          -       shim
+mtest other-repo     review       mint-test   '["mint-test-other"]'   denied                  -          -       shim
+mtest fullsend-tgt   review       .fullsend   '["mint-test"]'         "$fullsend_tgt_expect" mint-test  -       direct
+
+mtest blank-repos    retro        mint-test   -                      denied                  -          -       shim
+mtest same-repo      retro        mint-test   '["mint-test"]'         "$shim_same_expect"    mint-test  -       shim
+mtest wildcard       retro        mint-test   '["*"]'                 denied                  -          -       shim
+mtest other-repo     retro        mint-test   '["mint-test-other"]'   denied                  -          -       shim
+mtest fullsend-tgt   retro        .fullsend   '["mint-test"]'         "$fullsend_tgt_expect" mint-test  -       direct
+
+mtest blank-repos    prioritize   mint-test   -                      denied                  -          -       shim
+mtest same-repo      prioritize   mint-test   '["mint-test"]'         "$shim_same_expect"    mint-test  -       shim
+mtest wildcard       prioritize   mint-test   '["*"]'                 denied                  -          -       shim
+mtest other-repo     prioritize   mint-test   '["mint-test-other"]'   denied                  -          -       shim
+mtest fullsend-tgt   prioritize   .fullsend   '["mint-test"]'         "$fullsend_tgt_expect" mint-test  -       direct
+
+mtest blank-repos    fullsend     mint-test   -                      denied                  -          -       shim
+mtest same-repo      fullsend     mint-test   '["mint-test"]'         "$shim_same_expect"    mint-test  -       shim
+mtest wildcard       fullsend     mint-test   '["*"]'                 denied                  -          -       shim
+mtest other-repo     fullsend     mint-test   '["mint-test-other"]'   denied                  -          -       shim
+mtest fullsend-tgt   fullsend     .fullsend   '["mint-test"]'         "$fullsend_tgt_expect" mint-test  -       direct
+
+# e2e foreign via mint-test shim → {org}/fullsend (.fullsend not used).
+# per-org denies the shim host; per-repo/both allow it via WORKFLOW_HOST_REPOS.
+mtest foreign-blank  e2e          mint-test   -                      denied                  -          "$FOREIGN_ORG" shim
+mtest foreign-wild   e2e          mint-test   '["*"]'                 "$foreign_wild_expect"  -          "$FOREIGN_ORG" shim
+
+# --- summary ---
+echo "ok  ${COUNT_OK}"
+if ((COUNT_FAIL > 0)); then
+  echo "FAIL  ${COUNT_FAIL}"
+fi
+if ((COUNT_ERROR > 0)); then
+  echo "ERROR ${COUNT_ERROR}"
+fi
+
+if ((COUNT_FAIL > 0 || COUNT_ERROR > 0)); then
+  exit 1
+fi
+exit 0

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -175,8 +175,14 @@ if [[ -z "$GH_API_TOKEN" ]]; then
   GH_API_TOKEN="$(gh auth token 2>/dev/null || true)"
 fi
 [[ -n "$GH_API_TOKEN" ]] || die "set GH_TOKEN or run gh auth login (needed for HTTPS git)"
-# Credential helper for HTTPS remotes (same pattern as eval/scripts/setup-fixture.sh).
-GH_CRED_HELPER="!f(){ echo \"password=${GH_API_TOKEN}\"; };f"
+export GH_API_TOKEN
+# Expand the token only inside the credential-helper process, keeping it out of
+# Git command arguments and repository configuration.
+GH_CRED_HELPER='!f(){ echo "username=x-access-token"; echo "password=${GH_API_TOKEN}"; };f'
+
+git_auth() {
+  git -c "credential.helper=${GH_CRED_HELPER}" "$@"
+}
 
 TMPROOT=$(mktemp -d)
 REUSABLE_BRANCH="mint-ap-reusable-$(od -An -N4 -tx1 /dev/urandom | tr -d ' \n')"
@@ -458,10 +464,8 @@ ensure_fullsend_reusable() {
   register_branch "$full_repo" "$REUSABLE_BRANCH"
   (
     set -euo pipefail
-    git -c "credential.helper=${GH_CRED_HELPER}" \
-      clone --depth 1 --quiet "https://x-access-token@github.com/${full_repo}.git" "${work}/repo"
+    git_auth clone --depth 1 --quiet "https://github.com/${full_repo}.git" "${work}/repo"
     cd "${work}/repo"
-    git config credential.helper "${GH_CRED_HELPER}"
     git config user.email "mint-ap@localhost"
     git config user.name "mint-access-patterns"
     git config commit.gpgsign false
@@ -522,7 +526,7 @@ FTR
     } >.github/workflows/mint-ap-reusable.yml
     git add .github/workflows/mint-ap-reusable.yml
     git commit --allow-empty -m "mint-ap: disposable reusable workflow" --quiet
-    git push origin "HEAD:${REUSABLE_BRANCH}" --quiet
+    git_auth push origin "HEAD:${REUSABLE_BRANCH}" --quiet
     echo "setup: pushed reusable workflow to ${full_repo}@${REUSABLE_BRANCH}" >&2
   ) 2>"${tmp}" || {
     echo "ERROR: failed to ensure reusable on ${full_repo}: $(tr '\n' ' ' <"${tmp}" | head -c 300)" >&2
@@ -718,7 +722,7 @@ mtest() {
   local host_style="${8:-shim}"
   local label="${id}/${role}"
   local full_repo="${ORG}/${caller_repo}"
-  local branch work tmp_err head_sha run_json run_id run_url conclusion actual result_json scope_rest
+  local branch work tmp_err head_sha run_json run_id run_url conclusion actual result_json scope_rest detail
   local expected_scope_full=""
   local target_org_arg=""
 
@@ -748,10 +752,8 @@ mtest() {
 
   if ! (
     set -euo pipefail
-    git -c "credential.helper=${GH_CRED_HELPER}" \
-      clone --depth 1 --quiet "https://x-access-token@github.com/${full_repo}.git" "${work}/repo"
+    git_auth clone --depth 1 --quiet "https://github.com/${full_repo}.git" "${work}/repo"
     cd "${work}/repo"
-    git config credential.helper "${GH_CRED_HELPER}"
     git checkout -b "${branch}" >/dev/null
     git config user.email "mint-ap@localhost"
     git config user.name "mint-access-patterns"
@@ -770,7 +772,7 @@ mtest() {
     esac
     git add .github/workflows/mint-ap.yml
     git commit -m "mint-ap: ${id} ${role} ${host_style}" --quiet
-    git push -u origin "HEAD:${branch}" --quiet
+    git_auth push -u origin "HEAD:${branch}" --quiet
   ) 2>"${tmp_err}"; then
     print_case_line ERROR "$label" "push failed: $(tr '\n' ' ' <"${tmp_err}" | head -c 200)"
     COUNT_ERROR=$((COUNT_ERROR + 1))
@@ -784,7 +786,7 @@ mtest() {
   if ! run_json=$(wait_for_run "${full_repo}" "${branch}" "$head_sha" 2>"${work}/wait.err"); then
     print_case_line ERROR "$label" "$(tr '\n' ' ' <"${work}/wait.err" | head -c 200)"
     COUNT_ERROR=$((COUNT_ERROR + 1))
-    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    git_auth -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
     unregister_branch "$full_repo" "$branch"
     rm -rf "${work}"
     return 0
@@ -797,7 +799,7 @@ mtest() {
   if [[ "$conclusion" != "success" ]]; then
     print_case_line ERROR "$label" "workflow conclusion=${conclusion:-unknown}  ${run_url}"
     COUNT_ERROR=$((COUNT_ERROR + 1))
-    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    git_auth -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
     unregister_branch "$full_repo" "$branch"
     rm -rf "${work}"
     return 0
@@ -808,7 +810,7 @@ mtest() {
   if [[ "$actual" == "error" ]]; then
     print_case_line ERROR "$label" "mint workflow error=$(jq -r '.error // "unknown"' <<<"$result_json")  ${run_url}"
     COUNT_ERROR=$((COUNT_ERROR + 1))
-    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    git_auth -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
     unregister_branch "$full_repo" "$branch"
     rm -rf "${work}"
     return 0
@@ -816,7 +818,7 @@ mtest() {
   if [[ "$actual" != "minted" && "$actual" != "denied" ]]; then
     print_case_line ERROR "$label" "missing or invalid mint-ap-result artifact  ${run_url}"
     COUNT_ERROR=$((COUNT_ERROR + 1))
-    git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+    git_auth -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
     unregister_branch "$full_repo" "$branch"
     rm -rf "${work}"
     return 0
@@ -829,7 +831,7 @@ mtest() {
     fi
   fi
 
-  git -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
+  git_auth -C "${work}/repo" push origin --delete "${branch}" --quiet 2>/dev/null || true
   unregister_branch "$full_repo" "$branch"
   rm -rf "${work}"
 
@@ -841,7 +843,7 @@ mtest() {
     fi
     COUNT_OK=$((COUNT_OK + 1))
   else
-    local detail="expect=${expect} actual=${actual}"
+    detail="expect=${expect} actual=${actual}"
     [[ -n "$scope_rest" ]] && detail+="  ${scope_rest}"
     detail+="  ${run_url}"
     print_case_line FAIL "$label" "$detail"

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -66,7 +66,25 @@ ACTIVE_BRANCH_REPOS=()
 ACTIVE_BRANCH_NAMES=()
 
 usage() {
-  sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+  cat <<'USAGE'
+mint-access-patterns — exercise mint repos-field + workflow-host access patterns
+via GHA OIDC (ADR 0082 / PR #5916).
+
+Usage:
+  hack/mint-access-patterns.sh --mint-url URL [options]
+
+Options:
+  --org ORG             GitHub org (default: fullsand-ai)
+  --mint-url URL        Mint base URL (or set FULLSEND_MINT_URL)
+  --foreign-org ORG     Target org for e2e foreign-mint cases (default: halfsend)
+  --role ROLE           Run only cases for this role (default: all roles in matrix)
+  --mode MODE           per-repo (default) | per-org | both
+  --project GCP_PROJECT Optional: surgically enroll/unenroll for MODE
+  --region REGION       GCP region for mint CLI (default: us-central1)
+  --timeout SECONDS     Per-case workflow wait timeout (default: 600)
+  --poll-interval SEC   Poll interval while waiting for runs (default: 5)
+  -h, --help            Show this help
+USAGE
 }
 
 die() {
@@ -117,19 +135,17 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
       usage >&2
-      exit 2
+      die "unknown option: $1"
       ;;
   esac
 done
 
+# TODO(ADR-0044): Remove per-org and both modes after existing users complete
+# migration to the sole supported per-repo installation model.
 case "$MODE" in
   per-repo | per-org | both) ;;
-  *)
-    echo "ERROR: --mode must be per-repo, per-org, or both (got: ${MODE})" >&2
-    exit 2
-    ;;
+  *) die "--mode must be per-repo, per-org, or both (got: ${MODE})" ;;
 esac
 
 case "$TIMEOUT" in
@@ -147,27 +163,18 @@ case "$ROLE_FILTER" in
   *) die "--role must be one of triage, coder, review, retro, prioritize, fullsend, or e2e (got: ${ROLE_FILTER})" ;;
 esac
 
-if [[ -z "$MINT_URL" ]]; then
-  echo "ERROR: --mint-url or FULLSEND_MINT_URL is required" >&2
-  exit 2
-fi
+[[ -n "$MINT_URL" ]] || die "--mint-url or FULLSEND_MINT_URL is required"
 MINT_URL="${MINT_URL%/}"
 
 for cmd in gh jq git curl; do
-  if ! command -v "$cmd" &>/dev/null; then
-    echo "ERROR: $cmd is required but not found in PATH" >&2
-    exit 2
-  fi
+  command -v "$cmd" &>/dev/null || die "$cmd is required but not found in PATH"
 done
 
 GH_API_TOKEN="${GH_TOKEN:-}"
 if [[ -z "$GH_API_TOKEN" ]]; then
   GH_API_TOKEN="$(gh auth token 2>/dev/null || true)"
 fi
-if [[ -z "$GH_API_TOKEN" ]]; then
-  echo "ERROR: set GH_TOKEN or run gh auth login (needed for HTTPS git)" >&2
-  exit 2
-fi
+[[ -n "$GH_API_TOKEN" ]] || die "set GH_TOKEN or run gh auth login (needed for HTTPS git)"
 # Credential helper for HTTPS remotes (same pattern as eval/scripts/setup-fixture.sh).
 GH_CRED_HELPER="!f(){ echo \"password=${GH_API_TOKEN}\"; };f"
 
@@ -526,7 +533,12 @@ FTR
 }
 
 # Direct mint workflow (on: push) for .fullsend or in-repo-host negative.
-# Args: destination directory, role, repos JSON, expected scope repo, optional target org.
+# Arguments:
+#   $1 destination directory
+#   $2 mint role
+#   $3 requested repositories as JSON, or "-" to omit repos
+#   $4 expected fully-qualified repository scope, or empty
+#   $5 optional target organization
 write_direct_mint_workflow() {
   local dest_dir="$1"
   local role="$2"
@@ -579,7 +591,12 @@ FTR
 }
 
 # Thin shim on mint-test that calls {org}/fullsend reusable.
-# Args: destination directory, role, repos JSON, expected scope repo, optional target org.
+# Arguments:
+#   $1 destination directory
+#   $2 mint role
+#   $3 requested repositories as JSON, or "-" to omit repos
+#   $4 expected fully-qualified repository scope, or empty
+#   $5 optional target organization
 write_shim_workflow() {
   local dest_dir="$1"
   local role="$2"

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -141,6 +141,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Per-org coverage validates continuity during ADR 0044 Phase 1 migration.
 # TODO(ADR-0044): Remove per-org and both modes after existing users complete
 # migration to the sole supported per-repo installation model.
 case "$MODE" in
@@ -253,11 +254,11 @@ ensure_repo() {
 # --- formatting ---
 format_scope() {
   local json="$1"
-  local selection repos perms
+  local selection repos perms out
   selection=$(jq -r '.repository_selection // empty' <<<"$json")
   repos=$(jq -r '.granted_repos // [] | join(",")' <<<"$json")
   perms=$(jq -r '.granted_permissions // {} | to_entries | map("\(.key)=\(.value)") | join(",")' <<<"$json")
-  local out="scope=${selection}"
+  out="scope=${selection}"
   [[ -n "$repos" ]] && out+=" repos=${repos}"
   [[ -n "$perms" ]] && out+=" perms=${perms}"
   printf '%s' "$out"
@@ -414,12 +415,20 @@ mint_curl_run_script() {
 
           case "$ROLE" in
             triage) EXPECTED_PERMS='{"contents":"read","issues":"write","metadata":"read"}' ;;
+            # packages:read remains transitional in optionalRolePermissions;
+            # add it here when it becomes part of every coder token.
             coder) EXPECTED_PERMS='{"checks":"read","contents":"write","issues":"write","metadata":"read","pull_requests":"write"}' ;;
             review) EXPECTED_PERMS='{"checks":"read","contents":"read","issues":"write","metadata":"read","pull_requests":"write"}' ;;
             retro) EXPECTED_PERMS='{"actions":"read","contents":"read","issues":"write","metadata":"read","pull_requests":"write"}' ;;
             prioritize) EXPECTED_PERMS='{"contents":"read","issues":"write","metadata":"read","organization_projects":"write"}' ;;
             fullsend) EXPECTED_PERMS='{"actions":"write","actions_variables":"read","contents":"write","metadata":"read","pull_requests":"write","workflows":"write"}' ;;
             e2e) EXPECTED_PERMS='{"actions":"write","actions_variables":"write","administration":"write","contents":"write","issues":"write","members":"write","metadata":"read","organization_actions_variables":"write","organization_administration":"write","pull_requests":"write","secrets":"write","workflows":"write"}' ;;
+            *)
+              echo "Unknown role: $ROLE" >&2
+              jq -n '{outcome:"error",error:"unknown_role"}' > mint-ap-result.json
+              echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+              exit 0
+              ;;
           esac
 
           SCOPE_VALID=true

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -42,6 +42,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# fullsand-ai is the primary test org, halfsend is foreign, and
+# fullsend-ai/fullsend is the real upstream reusable-workflow host.
 ORG="fullsand-ai"
 MINT_URL="${FULLSEND_MINT_URL:-}"
 FOREIGN_ORG="halfsend"

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -212,7 +212,7 @@ cleanup() {
   local i
   for i in "${!ACTIVE_BRANCH_NAMES[@]}"; do
     gh api -X DELETE "/repos/${ACTIVE_BRANCH_REPOS[$i]}/git/refs/heads/${ACTIVE_BRANCH_NAMES[$i]}" \
-      --silent >/dev/null 2>&1 || true
+      --silent &>/dev/null || true
   done
   rm -rf "$TMPROOT"
 }

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -185,8 +185,12 @@ git_auth() {
   git -c "credential.helper=${GH_CRED_HELPER}" "$@"
 }
 
+rand_hex() {
+  od -An -N4 -tx1 /dev/urandom | tr -d ' \n'
+}
+
 TMPROOT=$(mktemp -d)
-REUSABLE_BRANCH="mint-ap-reusable-$(od -An -N4 -tx1 /dev/urandom | tr -d ' \n')"
+REUSABLE_BRANCH="mint-ap-reusable-$(rand_hex)"
 
 register_branch() {
   ACTIVE_BRANCH_REPOS+=("$1")
@@ -227,10 +231,6 @@ if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
   C_ERROR=$'\033[33m'
   C_RESET=$'\033[0m'
 fi
-
-rand_hex() {
-  od -An -N4 -tx1 /dev/urandom | tr -d ' \n'
-}
 
 # --- repo ensure ---
 ensure_repo() {
@@ -325,20 +325,27 @@ mint_curl_run_script() {
           # Always exit 0 so GitHub does not email on "failed" runs; outcome lives
           # in mint-ap-result.json for the driver.
           finish() { exit 0; }
+          emit_result() { printf 'MINT_AP_RESULT=%s\n' "$(jq -c . mint-ap-result.json)"; }
           trap finish EXIT
 
           if ! OIDC_RESPONSE=$(curl -sSf --retry 3 --retry-delay 2 --retry-all-errors \
             -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=fullsend-mint"); then
             jq -n '{outcome:"error",error:"oidc_transport"}' > mint-ap-result.json
-            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            emit_result
             exit 0
           fi
           OIDC_TOKEN=$(jq -r '.value // empty' <<<"$OIDC_RESPONSE" 2>/dev/null || true)
           if [[ -z "$OIDC_TOKEN" || "$OIDC_TOKEN" == "null" ]]; then
             echo "Failed to obtain OIDC token" >&2
             jq -n '{outcome:"error",error:"oidc_response"}' > mint-ap-result.json
-            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            emit_result
+            exit 0
+          fi
+          if [[ "$OIDC_TOKEN" == *$'\n'* || "$OIDC_TOKEN" == *$'\r'* || "$OIDC_TOKEN" == *'::'* ]]; then
+            echo "OIDC response contained an unsafe token value" >&2
+            jq -n '{outcome:"error",error:"oidc_response"}' > mint-ap-result.json
+            emit_result
             exit 0
           fi
           echo "::add-mask::$OIDC_TOKEN"
@@ -367,7 +374,7 @@ mint_curl_run_script() {
             -d "$BODY" \
             "${MINT_URL}/v1/token"); then
             jq -n '{outcome:"error",error:"mint_transport"}' > mint-ap-result.json
-            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            emit_result
             exit 0
           fi
 
@@ -375,14 +382,14 @@ mint_curl_run_script() {
             echo "Mint denied HTTP $HTTP_CODE"
             jq -n --arg code "$HTTP_CODE" '{outcome:"denied",http_status:($code|tonumber)}' \
               > mint-ap-result.json
-            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            emit_result
             exit 0
           fi
           if [[ ! "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
             echo "Mint failed HTTP $HTTP_CODE" >&2
             jq -n --arg code "$HTTP_CODE" '{outcome:"error",error:"mint_http",http_status:($code|tonumber)}' \
               > mint-ap-result.json
-            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            emit_result
             exit 0
           fi
 
@@ -392,7 +399,13 @@ mint_curl_run_script() {
           if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
             echo "Mint response missing token" >&2
             jq -n '{outcome:"error",error:"mint_response"}' > mint-ap-result.json
-            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            emit_result
+            exit 0
+          fi
+          if [[ "$TOKEN" == *$'\n'* || "$TOKEN" == *$'\r'* || "$TOKEN" == *'::'* ]]; then
+            echo "Mint response contained an unsafe token value" >&2
+            jq -n '{outcome:"error",error:"mint_response"}' > mint-ap-result.json
+            emit_result
             exit 0
           fi
           echo "::add-mask::$TOKEN"
@@ -401,7 +414,7 @@ mint_curl_run_script() {
             ! REPOS=$(jq -ec '.granted_repos // [] | select(type == "array") | sort' mint-ap-response.json) ||
             ! PERMS=$(jq -ec '.granted_permissions // {} | select(type == "object")' mint-ap-response.json); then
             jq -n '{outcome:"error",error:"mint_scope_response"}' > mint-ap-result.json
-            echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+            emit_result
             exit 0
           fi
 
@@ -428,7 +441,7 @@ mint_curl_run_script() {
             *)
               echo "Unknown role: $ROLE" >&2
               jq -n '{outcome:"error",error:"unknown_role"}' > mint-ap-result.json
-              echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+              emit_result
               exit 0
               ;;
           esac
@@ -464,7 +477,7 @@ mint_curl_run_script() {
               '{outcome:"error",error:"scope",repository_selection:$selection,granted_repos:$repos,granted_permissions:$perms}' \
               > mint-ap-result.json
           fi
-          echo "MINT_AP_RESULT=$(cat mint-ap-result.json)"
+          emit_result
 RUNSCRIPT
 }
 

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -413,11 +413,13 @@ mint_curl_run_script() {
             '{outcome:$outcome, repository_selection:$selection, granted_repos:$repos, granted_permissions:$perms}' \
             > mint-ap-result.json
 
+          EXPECTED_OPTIONAL_PERMS='{}'
           case "$ROLE" in
             triage) EXPECTED_PERMS='{"contents":"read","issues":"write","metadata":"read"}' ;;
-            # packages:read remains transitional in optionalRolePermissions;
-            # add it here when it becomes part of every coder token.
-            coder) EXPECTED_PERMS='{"checks":"read","contents":"write","issues":"write","metadata":"read","pull_requests":"write"}' ;;
+            coder)
+              EXPECTED_PERMS='{"checks":"read","contents":"write","issues":"write","metadata":"read","pull_requests":"write"}'
+              EXPECTED_OPTIONAL_PERMS='{"packages":"read"}'
+              ;;
             review) EXPECTED_PERMS='{"checks":"read","contents":"read","issues":"write","metadata":"read","pull_requests":"write"}' ;;
             retro) EXPECTED_PERMS='{"actions":"read","contents":"read","issues":"write","metadata":"read","pull_requests":"write"}' ;;
             prioritize) EXPECTED_PERMS='{"contents":"read","issues":"write","metadata":"read","organization_projects":"write"}' ;;
@@ -446,9 +448,12 @@ mint_curl_run_script() {
             echo "Expected installation-wide scope with no explicit repositories, got selection=$SELECTION repos=$REPOS" >&2
             SCOPE_VALID=false
           fi
-          if ! jq -e --argjson expected "$EXPECTED_PERMS" '.granted_permissions == $expected' \
+          if ! jq -e \
+            --argjson expected "$EXPECTED_PERMS" \
+            --argjson optional "$EXPECTED_OPTIONAL_PERMS" \
+            '.granted_permissions == $expected or .granted_permissions == ($expected + $optional)' \
             mint-ap-result.json >/dev/null; then
-            echo "Granted permissions do not exactly match role $ROLE" >&2
+            echo "Granted permissions do not match an allowed shape for role $ROLE" >&2
             SCOPE_VALID=false
           fi
           if [[ "$SCOPE_VALID" != true ]]; then

--- a/hack/mint-access-patterns.sh
+++ b/hack/mint-access-patterns.sh
@@ -674,6 +674,7 @@ fetch_result_json() {
   return 1
 }
 
+# Wait for the workflow triggered by head_sha on branch and print its run JSON.
 wait_for_run() {
   local full_repo="$1" branch="$2" head_sha="$3"
   local deadline=$((SECONDS + TIMEOUT))


### PR DESCRIPTION
## Summary
- Add `hack/mint-access-patterns.sh`, a bash harness that exercises mint `repos`-field and workflow-host access patterns via GHA OIDC (ADR 0082).
- Supports `--mode per-repo|per-org|both`, optional `--project` enrollment, `--role` filter, and foreign e2e cases against staging/dev/public/Cloudflare mints.
- Reports PASS/FAIL per case from `mint-ap-result` artifacts; workflows always exit green so failures surface only in harness output.

## Test plan
- [x] Staging mint: per-repo, per-org, both — 33/33 each
- [x] Dev mint: per-repo, per-org, both — 33/33 each
- [x] Cloudflare preview mints (per-org-pv, per-repo-pv, both-pv) — 33/33 parallel
- [x] Public mints (`mint-test.korren.org`, `mint.fullsend.sh`, `mint-status-auth-test.barak-korren.workers.dev`) — per-repo without enrollment


Made with [Cursor](https://cursor.com)