### PR TITLE
ci(release): validate agents before publishing binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   release:
+    needs: [validate-agents, resolve-agents]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,7 +54,7 @@ jobs:
           fi
 
   validate-agents:
-    needs: release
+    needs: resolve-agents
     # Permission contract of the called workflow. GitHub validates this at
     # parse time, before any job runs or `if:` is evaluated — a called
     # workflow may only downgrade the caller's grants, so every permission
@@ -87,7 +88,6 @@ jobs:
     # output), and tag-agents prefers that; this job's resolution is the
     # fallback if that output is ever empty, and the input for the
     # informational pin-drift check below (#6512).
-    needs: release
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -96,6 +96,25 @@ jobs:
       agents_sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SHA: ${{ github.sha }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_INFO=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}")
+          TAG_TYPE=$(jq -r '.object.type' <<<"${TAG_INFO}")
+          TAG_SHA=$(jq -r '.object.sha' <<<"${TAG_INFO}")
+          if [[ "${TAG_TYPE}" == "tag" ]]; then
+            TAG_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_SHA}" --jq '.object.sha')
+          fi
+          if [[ "${TAG_SHA}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error::Release tag ${TAG} resolves to ${TAG_SHA}, expected ${EXPECTED_SHA}"
+            exit 1
+          fi
+          echo "Release tag ${TAG} resolves to ${EXPECTED_SHA}"
 
       - name: Resolve agents main
         id: resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,11 @@ permissions:
 
 jobs:
   release:
-    needs: [validate-agents, resolve-agents]
+    needs: [validate-agents, resolve-agents, recheck-tag]
     runs-on: ubuntu-24.04
+    # Historically ~2 minutes. Bounded so a hung publish cannot hold the
+    # tag-agents sync (and the default 6h limit) open.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -95,26 +98,35 @@ jobs:
     outputs:
       agents_sha: ${{ steps.resolve.outputs.sha }}
     steps:
+      # Pinned to the commit, not the tag: the guard below must not run a
+      # copy of itself fetched through the mutable ref it is checking.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
 
+      # First half of the tag-move guard — see the recheck-tag job.
       - name: Verify release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXPECTED_SHA: ${{ github.sha }}
-          TAG: ${{ github.ref_name }}
+        run: bash scripts/verify-release-tag.sh
+
+      # validate-agents is only a real gate while the functional tests
+      # actually run. In the called workflow an empty E2E_GCP_WIF_PROVIDER
+      # makes the "Check for secrets" step log a warning, skip GCP auth and
+      # every test step, and still report success — which, now that the
+      # binary is published only after that gate, would ship a release that
+      # validated nothing. Fail the release loudly instead of silently
+      # degrading to no coverage.
+      - name: Verify agents gate secrets
+        env:
+          WIF_PROVIDER: ${{ secrets.E2E_GCP_WIF_PROVIDER }}
         run: |
           set -euo pipefail
-          TAG_INFO=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}")
-          TAG_TYPE=$(jq -r '.object.type' <<<"${TAG_INFO}")
-          TAG_SHA=$(jq -r '.object.sha' <<<"${TAG_INFO}")
-          if [[ "${TAG_TYPE}" == "tag" ]]; then
-            TAG_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_SHA}" --jq '.object.sha')
-          fi
-          if [[ "${TAG_SHA}" != "${EXPECTED_SHA}" ]]; then
-            echo "::error::Release tag ${TAG} resolves to ${TAG_SHA}, expected ${EXPECTED_SHA}"
+          if [[ -z "${WIF_PROVIDER}" ]]; then
+            echo "::error::E2E_GCP_WIF_PROVIDER is not configured — agents functional tests would skip and the release gate would pass without running a single test"
             exit 1
           fi
-          echo "Release tag ${TAG} resolves to ${EXPECTED_SHA}"
+          echo "::notice::E2E_GCP_WIF_PROVIDER is configured; the agents gate will run its tests"
 
       - name: Resolve agents main
         id: resolve
@@ -138,6 +150,35 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/check-agents-gate-pin.sh
+
+  recheck-tag:
+    # Second half of the tag-move guard. validate-agents clones fullsend by
+    # tag name — the called workflow only accepts `main` or a `v*` ref and
+    # uses `git clone --branch`, so it cannot be pinned to a SHA from this
+    # side. A tag moved during the ~45 minutes of functional tests would
+    # otherwise leave the gate validating one commit while GoReleaser
+    # publishes another. resolve-agents checks the tag before validation
+    # starts; this checks it again after, so publication requires the tag
+    # to have been stable across the whole gate.
+    #
+    # Its own job rather than a step inside `release` so that a tag moved
+    # mid-gate stays a *pre-publication* failure: nothing has shipped, and
+    # notify-release-blocked can say so.
+    needs: validate-agents
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      # Pinned to the commit, not the tag — see resolve-agents.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Verify release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/verify-release-tag.sh
 
   tag-agents:
     # Sync the version tag to fullsend-ai/agents. Runs for all tags
@@ -194,14 +235,18 @@ jobs:
             -f sha="${AGENTS_SHA}"
           echo "Created tag ${TAG} on fullsend-ai/agents at ${AGENTS_SHA}"
 
-  notify-agents-sync-failure:
-    needs: [release, validate-agents, resolve-agents, tag-agents]
+  notify-release-blocked:
+    # Pre-publication failure: nothing shipped. Before the gate moved ahead
+    # of GoReleaser this path did not exist — a validation failure still
+    # published the binary and Slack reported only the missing agents tag.
+    # Now the whole release stops here, so it needs its own signal;
+    # otherwise a blocked release is silent on Slack.
+    needs: [validate-agents, resolve-agents, recheck-tag]
     if: >-
       always()
-      && needs.release.result == 'success'
       && (needs.validate-agents.result == 'failure'
           || needs.resolve-agents.result == 'failure'
-          || needs.tag-agents.result == 'failure')
+          || needs.recheck-tag.result == 'failure')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -211,6 +256,37 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "::error::SLACK_WEBHOOK_URL secret is not configured"
+            exit 1
+          fi
+          PAYLOAD=$(jq -n --arg tag "${GITHUB_REF_NAME}" --arg url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{text: ":no_entry: Release `\($tag)` was blocked before publishing — tag verification or agents functional tests failed. No binary was published and no tags were moved. <\($url)|View run>"}')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$SLACK_WEBHOOK"
+
+  notify-agents-sync-failure:
+    # Post-publication failure: the binary shipped but the agents tag did
+    # not follow. validate-agents and resolve-agents are no longer checked
+    # here — `release` depends on both, so its success already implies they
+    # passed, and their failure is reported by notify-release-blocked.
+    needs: [release, tag-agents]
+    if: >-
+      always()
+      && needs.release.result == 'success'
+      && needs.tag-agents.result == 'failure'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "::error::SLACK_WEBHOOK_URL secret is not configured"
+            exit 1
+          fi
           PAYLOAD=$(jq -n --arg tag "${GITHUB_REF_NAME}" --arg url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             '{text: ":warning: Agents tag sync failed for `\($tag)`. The fullsend release shipped but the agents tag was not created. <\($url)|View run>"}')
           curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$SLACK_WEBHOOK"

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ script-test:
 	$(call run-timed,bash scripts/redact-behaviour-artifacts-test.sh)
 	$(call run-timed,bash .github/scripts/check-fix-eligibility-test.sh)
 	$(call run-timed,bash scripts/check-agents-gate-pin-test.sh)
+	$(call run-timed,bash scripts/verify-release-tag-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh)
 	$(call run-timed,bash internal/scaffold/fullsend-repo/.github/scripts/setup-agent-env-test.sh)

--- a/scripts/verify-release-tag-test.sh
+++ b/scripts/verify-release-tag-test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# verify-release-tag-test.sh — Tests for verify-release-tag.sh
+#
+# Run from the repo root:
+#   bash scripts/verify-release-tag-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/verify-release-tag.sh"
+FAILURES=0
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+COMMIT_A="aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+COMMIT_B="5555eeee4444dddd3333cccc2222bbbb1111aaaa"
+TAG_OBJ_1="1111111111111111111111111111111111111111"
+TAG_OBJ_2="2222222222222222222222222222222222222222"
+
+# build_mock creates a mock gh binary.
+#   $1 — JSON body returned for git/ref/tags/<tag>, or "fail" to error
+#   $2 — JSON body returned for git/tags/<TAG_OBJ_1> (optional)
+#   $3 — JSON body returned for git/tags/<TAG_OBJ_2> (optional)
+build_mock() {
+  local ref_body="$1" tag_body_1="${2:-}" tag_body_2="${3:-}"
+  local mock_bin="${TMPDIR}/bin"
+
+  rm -rf "${mock_bin}"
+  mkdir -p "${mock_bin}"
+
+  cat > "${mock_bin}/gh" <<MOCKEOF
+#!/usr/bin/env bash
+if [[ "\$1" != "api" ]]; then
+  echo "mock gh: unexpected command: \$*" >&2
+  exit 1
+fi
+
+case "\$2" in
+  repos/fullsend-ai/fullsend/git/ref/tags/*)
+    if [[ '${ref_body}' == "fail" ]]; then
+      echo "gh: Not Found (HTTP 404)" >&2
+      exit 1
+    fi
+    echo '${ref_body}'
+    ;;
+  repos/fullsend-ai/fullsend/git/tags/${TAG_OBJ_1})
+    if [[ -z '${tag_body_1}' ]]; then
+      echo "mock gh: no body configured for ${TAG_OBJ_1}" >&2
+      exit 1
+    fi
+    echo '${tag_body_1}'
+    ;;
+  repos/fullsend-ai/fullsend/git/tags/${TAG_OBJ_2})
+    if [[ -z '${tag_body_2}' ]]; then
+      echo "mock gh: no body configured for ${TAG_OBJ_2}" >&2
+      exit 1
+    fi
+    echo '${tag_body_2}'
+    ;;
+  *)
+    echo "mock gh: unexpected endpoint: \$2" >&2
+    exit 1
+    ;;
+esac
+exit 0
+MOCKEOF
+
+  chmod +x "${mock_bin}/gh"
+  echo "${mock_bin}"
+}
+
+# run_test runs the script under a mock gh and asserts exit code and output.
+#   $1 — test name
+#   $2 — expected exit code
+#   $3 — expected output substring ("" to skip)
+#   $4 — EXPECTED_SHA to pass in
+#   $5 — git/ref/tags body (or "fail")
+#   $6 — git/tags/<TAG_OBJ_1> body (optional)
+#   $7 — git/tags/<TAG_OBJ_2> body (optional)
+run_test() {
+  local name="$1" expected_exit="$2" expected_output="$3" expected_sha="$4"
+  local ref_body="$5" tag_body_1="${6:-}" tag_body_2="${7:-}"
+
+  local mock_bin
+  mock_bin=$(build_mock "${ref_body}" "${tag_body_1}" "${tag_body_2}")
+
+  local actual_exit=0 output
+  output=$(
+    PATH="${mock_bin}:${PATH}" \
+    TAG="v9.9.9" \
+    EXPECTED_SHA="${expected_sha}" \
+    REPO="fullsend-ai/fullsend" \
+    GH_TOKEN="fake" \
+    bash "${SCRIPT}" 2>&1
+  ) || actual_exit=$?
+
+  if [[ "${actual_exit}" -ne "${expected_exit}" ]]; then
+    echo "FAIL: ${name} — expected exit ${expected_exit}, got ${actual_exit}"
+    echo "  output: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if [[ -n "${expected_output}" ]] && [[ "${output}" != *"${expected_output}"* ]]; then
+    echo "FAIL: ${name} — expected '${expected_output}' not found in output"
+    echo "  output: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${name}"
+}
+
+echo "=== verify-release-tag tests ==="
+
+# Lightweight tag pointing straight at the release commit.
+run_test "lightweight tag matches" 0 "resolves to ${COMMIT_A}" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"commit\",\"sha\":\"${COMMIT_A}\"}}"
+
+# Annotated tag: one peel to reach the commit.
+run_test "annotated tag matches" 0 "resolves to ${COMMIT_A}" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_1}\"}}" \
+  "{\"object\":{\"type\":\"commit\",\"sha\":\"${COMMIT_A}\"}}"
+
+# Nested annotated tag: two peels to reach the commit.
+run_test "nested annotated tag matches" 0 "resolves to ${COMMIT_A}" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_1}\"}}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_2}\"}}" \
+  "{\"object\":{\"type\":\"commit\",\"sha\":\"${COMMIT_A}\"}}"
+
+# Tag moved after the run started — must fail.
+run_test "moved tag fails" 1 "expected ${COMMIT_A}" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"commit\",\"sha\":\"${COMMIT_B}\"}}"
+
+# Annotated tag that was moved — the peel must not hide the mismatch.
+run_test "moved annotated tag fails" 1 "expected ${COMMIT_A}" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_1}\"}}" \
+  "{\"object\":{\"type\":\"commit\",\"sha\":\"${COMMIT_B}\"}}"
+
+# Tag ref cannot be read — must fail, never pass.
+run_test "unreadable tag fails" 1 "Could not read tag" "${COMMIT_A}" "fail"
+
+# Ref names something other than a commit.
+run_test "non-commit tag target fails" 1 "does not name a commit" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"tree\",\"sha\":\"${COMMIT_A}\"}}"
+
+# API returned something that is not a 40-hex SHA.
+run_test "malformed sha fails" 1 "unexpected value" "${COMMIT_A}" \
+  '{"object":{"type":"commit","sha":"not-a-sha"}}'
+
+# EXPECTED_SHA itself is malformed — fail before querying anything.
+run_test "malformed expected sha fails" 1 "not a commit SHA" "HEAD" \
+  "{\"object\":{\"type\":\"commit\",\"sha\":\"${COMMIT_A}\"}}"
+
+# Tag object cycle: peeling never reaches a commit — must fail, not hang.
+run_test "peel depth exceeded fails" 1 "nested more than" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_1}\"}}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_2}\"}}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_1}\"}}"
+
+# A tag object that cannot be dereferenced — must fail, never pass.
+run_test "undereferenceable tag object fails" 1 "Could not dereference" "${COMMIT_A}" \
+  "{\"object\":{\"type\":\"tag\",\"sha\":\"${TAG_OBJ_1}\"}}"
+
+# Missing required inputs.
+missing_input_test() {
+  local mock_bin actual_exit=0 output
+  mock_bin=$(build_mock "{\"object\":{\"type\":\"commit\",\"sha\":\"${COMMIT_A}\"}}")
+  output=$(
+    PATH="${mock_bin}:${PATH}" \
+    TAG="" GITHUB_REF_NAME="" \
+    EXPECTED_SHA="${COMMIT_A}" \
+    REPO="fullsend-ai/fullsend" \
+    bash "${SCRIPT}" 2>&1
+  ) || actual_exit=$?
+
+  if [[ "${actual_exit}" -ne 1 || "${output}" != *"requires TAG"* ]]; then
+    echo "FAIL: missing TAG — expected exit 1 with usage error, got ${actual_exit}: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  echo "PASS: missing TAG"
+
+  actual_exit=0
+  output=$(
+    PATH="${mock_bin}:${PATH}" \
+    TAG="v9.9.9" \
+    EXPECTED_SHA="${COMMIT_A}" \
+    REPO="" GITHUB_REPOSITORY="" \
+    bash "${SCRIPT}" 2>&1
+  ) || actual_exit=$?
+
+  if [[ "${actual_exit}" -ne 1 || "${output}" != *"requires TAG"* ]]; then
+    echo "FAIL: missing REPO — expected exit 1 with usage error, got ${actual_exit}: ${output}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  echo "PASS: missing REPO"
+}
+missing_input_test
+
+echo
+if [[ "${FAILURES}" -gt 0 ]]; then
+  echo "${FAILURES} test(s) failed"
+  exit 1
+fi
+echo "All tests passed"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# verify-release-tag.sh — Verify that a release tag still resolves to the
+# commit this workflow run was started for.
+#
+# The release pipeline gates publication on agents functional tests that
+# clone fullsend by *tag name* (the called workflow only accepts `main` or
+# a `v*` ref). A tag move between the gate and the publish step would mean
+# the binary is built from one commit while the gate validated another, so
+# this check runs on both sides of the gate: once before validation starts
+# and once immediately before GoReleaser publishes.
+#
+# Exits 0 if the tag resolves to EXPECTED_SHA.
+# Exits 1 if it resolves elsewhere, or if the ref cannot be resolved to a
+# commit.
+#
+# Inputs (env vars):
+#   TAG           — tag name to verify (default: $GITHUB_REF_NAME)
+#   EXPECTED_SHA  — commit the tag must point at (default: $GITHUB_SHA)
+#   REPO          — owner/name to query (default: $GITHUB_REPOSITORY)
+#
+# Requires: gh CLI authenticated with read access to REPO.
+
+set -euo pipefail
+
+TAG="${TAG:-${GITHUB_REF_NAME:-}}"
+EXPECTED_SHA="${EXPECTED_SHA:-${GITHUB_SHA:-}}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+
+# Peeling an annotated tag can take more than one hop (a tag object may
+# point at another tag object). Bound the walk so a cycle cannot hang the
+# job.
+MAX_PEEL_DEPTH=5
+
+if [[ -z "${TAG}" || -z "${EXPECTED_SHA}" || -z "${REPO}" ]]; then
+  echo "::error::verify-release-tag.sh requires TAG, EXPECTED_SHA and REPO"
+  exit 1
+fi
+
+if [[ ! "${EXPECTED_SHA}" =~ ^[a-f0-9]{40}$ ]]; then
+  echo "::error::EXPECTED_SHA is not a commit SHA: ${EXPECTED_SHA//::/}"
+  exit 1
+fi
+
+REF_JSON=$(gh api "repos/${REPO}/git/ref/tags/${TAG}") || {
+  echo "::error::Could not read tag ${TAG//::/} from ${REPO//::/}"
+  exit 1
+}
+
+OBJ_TYPE=$(jq -r '.object.type' <<<"${REF_JSON}")
+OBJ_SHA=$(jq -r '.object.sha' <<<"${REF_JSON}")
+
+# Dereference annotated tag objects down to the commit they name. Each SHA
+# is shape-checked before it is fed back into the API path, so a malformed
+# response cannot become part of a request.
+depth=0
+while :; do
+  if [[ ! "${OBJ_SHA}" =~ ^[a-f0-9]{40}$ ]]; then
+    echo "::error::Tag ${TAG//::/} resolved to an unexpected value: ${OBJ_SHA//::/}"
+    exit 1
+  fi
+  [[ "${OBJ_TYPE}" == "tag" ]] || break
+  if (( depth >= MAX_PEEL_DEPTH )); then
+    echo "::error::Tag ${TAG//::/} is nested more than ${MAX_PEEL_DEPTH} levels deep"
+    exit 1
+  fi
+  TAG_JSON=$(gh api "repos/${REPO}/git/tags/${OBJ_SHA}") || {
+    echo "::error::Could not dereference tag object ${OBJ_SHA//::/} in ${REPO//::/}"
+    exit 1
+  }
+  OBJ_TYPE=$(jq -r '.object.type' <<<"${TAG_JSON}")
+  OBJ_SHA=$(jq -r '.object.sha' <<<"${TAG_JSON}")
+  depth=$(( depth + 1 ))
+done
+
+if [[ "${OBJ_TYPE}" != "commit" ]]; then
+  echo "::error::Tag ${TAG//::/} does not name a commit (got '${OBJ_TYPE//::/}')"
+  exit 1
+fi
+
+if [[ "${OBJ_SHA}" != "${EXPECTED_SHA}" ]]; then
+  echo "::error::Release tag ${TAG//::/} resolves to ${OBJ_SHA//::/}, expected ${EXPECTED_SHA//::/}"
+  exit 1
+fi
+
+echo "::notice::Release tag ${TAG//::/} resolves to ${EXPECTED_SHA}"

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -103,11 +103,15 @@ GoReleaser's `name_template` (see `.goreleaser.yml`).
 git push origin <tag>
 ```
 
-GoReleaser takes over from here. Verify the workflow starts:
+The Release workflow takes over from here. Verify it starts:
 
 ```
 gh run list --workflow=release.yml --limit=1
 ```
+
+Expect the run to take a while before any artifact appears: agents'
+functional tests gate the publish step, so GoReleaser does not start
+until they pass (see the notes at the end of this file).
 
 ### 8. Run post-flight verification
 
@@ -179,14 +183,21 @@ installs the binary as `fullsend-<tag>` so multiple versions can coexist.
 - **The `v0` tag** is a moving tag consumed by downstream orgs for reusable
   workflows. It is automatically moved by the release workflow after
   GoReleaser completes (skipped for pre-release tags).
-- **The `fullsend-ai/agents` repo** is tagged with the same version
-  after the release workflow validates agents against the new binary.
-  After GoReleaser completes, the `validate-agents` job runs agents'
-  functional tests (via a cross-repo reusable workflow call) against
-  the release tag. Only if those tests pass does the `tag-agents` job
-  push the tag to agents using an org-owned GitHub App token
-  (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`). If validation or
-  tagging fails, a Slack notification is sent and the fullsend release
-  still ships — only the agents tag is blocked. That tag push triggers
-  agents' own `release.yml`, which creates a GitHub Release and moves
-  its `v0` floating tag.
+- **Agents validation runs before anything is published.** On a `v*` tag
+  push the workflow first runs `resolve-agents` (verifies the tag still
+  points at the commit that triggered the run, checks the gate secrets
+  are configured, and records agents' `main` SHA), then `validate-agents`,
+  which runs agents' functional tests (via a cross-repo reusable workflow
+  call) against the release tag. Only if those pass does the `release` job
+  re-verify the tag and run GoReleaser. A failure at either step means
+  **nothing is published** — no binaries, no GitHub Release, no moved
+  `v0` tag — and a Slack notification reports the release as blocked. The
+  fix is to resolve the cause and re-run the failed jobs; the tag stays
+  as it is.
+- **The `fullsend-ai/agents` repo** is tagged with the same version last,
+  by the `tag-agents` job, using an org-owned GitHub App token
+  (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`). This is the only step
+  that can fail after the binary has shipped; when it does, a Slack
+  notification is sent and only the agents tag is missing. That tag push
+  triggers agents' own `release.yml`, which creates a GitHub Release and
+  moves its `v0` floating tag.

--- a/skills/cutting-releases/post-flight.md
+++ b/skills/cutting-releases/post-flight.md
@@ -32,26 +32,31 @@ Verify the release is not marked as a draft.
 
 ## B2. Verify agents validation and tag
 
-The release workflow gates the agents tag on functional test
-validation. After GoReleaser completes, `validate-agents` runs
-agents' functional tests against the release tag. Only if those
-tests pass does `tag-agents` push the tag to agents. If either
-job fails, a Slack notification is sent automatically.
+The release workflow gates **publication itself** on functional test
+validation. `resolve-agents` verifies the tag and checks the gate
+secrets, `validate-agents` runs agents' functional tests against the
+release tag, and only then does `release` run GoReleaser. `tag-agents`
+pushes the version tag to agents last. Every failure path sends a Slack
+notification.
 
-First, verify the `validate-agents` and `tag-agents` jobs succeeded
-in the release workflow run:
+Verify the four jobs succeeded in the release workflow run:
 
 ```
 gh run view <run-id> --repo fullsend-ai/fullsend --json jobs \
-  --jq '.jobs[] | select(.name | test("validate-agents|tag-agents")) | {name, conclusion}'
+  --jq '.jobs[] | select(.name | test("resolve-agents|validate-agents|release|tag-agents")) | {name, conclusion}'
 ```
 
-If `validate-agents` failed, the agents functional tests did not
-pass against the new binary — investigate before proceeding. The
-fullsend release shipped, but agents was not tagged. A Slack
-notification should have been sent.
+If `resolve-agents` or `validate-agents` failed, the release was
+blocked before publishing: no binaries, no GitHub Release, no moved
+`v0` tag, and no agents tag. Step B above will show nothing to verify.
+Investigate the failure, then use "Re-run failed jobs" on the existing
+run rather than re-tagging — the tag is already correct and must not be
+moved (re-verification would fail the release if it were).
 
-If both jobs succeeded, verify the tag and release exist on agents:
+If only `tag-agents` failed, the fullsend release shipped but agents
+was not tagged; fix that job's cause and re-run it.
+
+If all jobs succeeded, verify the tag and release exist on agents:
 
 ```
 gh release view <tag> --repo fullsend-ai/agents

--- a/skills/cutting-releases/pre-flight.md
+++ b/skills/cutting-releases/pre-flight.md
@@ -51,8 +51,10 @@ Classify each change as:
 
 ## A2. Check agents repo state
 
-The release workflow tags `fullsend-ai/agents` with the same version
-after GoReleaser succeeds. Verify agents is in a healthy state:
+Agents is not just tagged by the release workflow — it gates it. Agents'
+functional tests run against the release tag *before* GoReleaser
+publishes anything, so an unhealthy agents `main` blocks the whole
+release, not only the agents tag. Verify agents is in a healthy state:
 
 ```
 gh run list --repo fullsend-ai/agents --limit=5


### PR DESCRIPTION
Releasing fullsend currently publishes the binary before the agents functional tests finish. That leaves a window where users can receive the new binary while the matching agents tag is still missing.

This changes the release dependency graph so that:

- the release tag is verified against the triggering commit;
- agents functional tests run against that release tag first;
- GoReleaser publishes only after validation passes;
- the matching agents tag is created last.

The functional tests already build fullsend from the `fullsend_ref` input, so they validate the unreleased source tag rather than a previous published binary.

Validation:
- `actionlint .github/workflows/release.yml`
- `make lint`