### PR TITLE
chore(#7019): drop the last "interim" and rewrap two comments

### DIFF
--- a/internal/runtime/pi_extension/fullsend-agent.js
+++ b/internal/runtime/pi_extension/fullsend-agent.js
@@ -304,8 +304,8 @@ export function childArgs(agent, { seq, modelSpec, tools }) {
 // *parent*, so it only ever matched the parent's provider; a child on a
 // different provider would otherwise inherit, say, a stray
 // ANTHROPIC_API_KEY (which pi's built-in anthropic provider would use for a
-// direct-to-Anthropic call) or an ambient GOOGLE_CLOUD_PROJECT. The rules below are the same ones
-// pi_run.go applies, per resolved child provider.
+// direct-to-Anthropic call) or an ambient GOOGLE_CLOUD_PROJECT. The rules
+// below are the same ones pi_run.go applies, per resolved child provider.
 //
 // google-vertex and openai have no rules here on purpose, matching
 // buildPiRunCommand: google-vertex reads the ADC the sandbox already

--- a/internal/runtime/pi_run.go
+++ b/internal/runtime/pi_run.go
@@ -453,7 +453,7 @@ func buildPiRunCommand(params RunParams, m *piManifest, exts []piManifestExtensi
 		"--session-dir "+shellQuote(r.piSessionsDir()),
 	)
 	if vertex {
-		// The interim Claude-on-Vertex provider is only needed for the
+		// The vendored Claude-on-Vertex extension is only needed for the
 		// anthropic-vertex model spec; other providers get pi's built-ins.
 		parts = append(parts, "-e "+shellQuote(piVertexExtensionPath))
 	}


### PR DESCRIPTION
## Summary

The two review-agent findings on #7025 that were still open when it reached the merge queue. Both are comments only — no behaviour change, 3 lines.

`internal/runtime/pi_run.go` — the `-e` block still called it "The interim Claude-on-Vertex provider". Dropping "interim" from the extension's characterization is what #7019 was for; that sweep covered `pi.go`, the Containerfile and `runtime-implementation.md` but missed this one. Now "The vendored Claude-on-Vertex extension".

`internal/runtime/pi_extension/fullsend-agent.js` — the `childEnv` comment was left at 98 columns by #7025's rewrite of its stray-credential rationale, in a file that wraps at 79. Rewrapped at the sentence boundary; wording unchanged.

## Why these came separately

They were found by `fullsend-ai-review[bot]` on an earlier head of #7025 and confirmed still open against the final one. By then #7025 was enqueued and its branch was locked (`protected branch hook declined`), and it had `behaviour` + `e2e` green — so pushing a two-comment fix would have thrown away a full CI cycle for cosmetics. The change request was dismissed as "cosmetic, carried in a follow-up" and both threads resolved with that pointer; this is that follow-up.

The same review's other two findings needed no change: `[protected-path]` on `images/` is informational and satisfied by the human approval on #7025, and `[comment-formatting]` on `pi_run.go:25` was superseded when that comment was rewritten for the pi 0.85.0 bump.

## Testing

```console
$ go build ./... && go vet ./...
$ go test -count=1 ./internal/runtime/
ok  github.com/fullsend-ai/fullsend/internal/runtime  27.861s

$ node --test internal/runtime/pi_extension/fullsend-agent.test.mjs
# pass 32, fail 0

$ grep -c interim internal/runtime/pi_run.go
0
$ awk 'length>79 && /^[[:space:]]*\/\//' internal/runtime/pi_extension/fullsend-agent.js
# (no output)
```

Follow-up to #7025.
