### PR TITLE
ci(#2618): retry transient issue creation auth failures

### DIFF
--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -495,7 +495,9 @@ Files over 64KB save fine if they contain only ASCII characters.`
 	// Bot-authored issues skip issues.opened dispatch (ADR 0054). Apply
 	// ready-for-triage in a follow-up call so the shim receives issues.labeled
 	// (#2636).
-	issue, err := env.client.CreateIssue(ctx, env.org, e2etest.TestRepo, issueTitle, issueBody)
+	issue, err := createIssueWithRetry(ctx, func() (*forge.Issue, error) {
+		return env.client.CreateIssue(ctx, env.org, e2etest.TestRepo, issueTitle, issueBody)
+	}, time.After)
 	require.NoError(t, err, "creating test issue")
 	t.Logf("Created test issue #%d: %s", issue.Number, issue.URL)
 	require.NoError(t, ensureRepoLabel(ctx, env.token, env.org, e2etest.TestRepo, "ready-for-triage"))
@@ -646,6 +648,33 @@ Files over 64KB save fine if they contain only ASCII characters.`
 	}
 	assert.True(t, hasTriageLabel,
 		"issue should have a triage label (needs-info, ready-to-code, duplicate, or blocked), got: %v", labelNames)
+}
+
+// createIssueWithRetry retries the transient 401 observed after provisioning,
+// while preserving fail-fast behavior for all other GitHub API errors.
+func createIssueWithRetry(
+	ctx context.Context,
+	create func() (*forge.Issue, error),
+	after func(time.Duration) <-chan time.Time,
+) (*forge.Issue, error) {
+	for attempt := range 3 {
+		issue, err := create()
+		if err == nil {
+			return issue, nil
+		}
+		var apiErr *gh.APIError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnauthorized || attempt == 2 {
+			return nil, err
+		}
+
+		delay := time.Duration(attempt+1) * 10 * time.Second
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-after(delay):
+		}
+	}
+	panic("unreachable")
 }
 
 // saveWorkflowRunDebugInfo fetches logs and artifacts for a workflow run and

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -497,7 +497,7 @@ Files over 64KB save fine if they contain only ASCII characters.`
 	// (#2636).
 	issue, err := createIssueWithRetry(ctx, func() (*forge.Issue, error) {
 		return env.client.CreateIssue(ctx, env.org, e2etest.TestRepo, issueTitle, issueBody)
-	}, time.After)
+	}, time.After, t.Logf)
 	require.NoError(t, err, "creating test issue")
 	t.Logf("Created test issue #%d: %s", issue.Number, issue.URL)
 	require.NoError(t, ensureRepoLabel(ctx, env.token, env.org, e2etest.TestRepo, "ready-for-triage"))
@@ -656,6 +656,7 @@ func createIssueWithRetry(
 	ctx context.Context,
 	create func() (*forge.Issue, error),
 	after func(time.Duration) <-chan time.Time,
+	logf func(string, ...any),
 ) (*forge.Issue, error) {
 	for attempt := range 3 {
 		issue, err := create()
@@ -668,6 +669,7 @@ func createIssueWithRetry(
 		}
 
 		delay := time.Duration(attempt+1) * 10 * time.Second
+		logf("Create issue attempt %d failed with status %d, retrying in %s...", attempt+1, apiErr.StatusCode, delay)
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/e2e/admin/create_issue_retry_test.go
+++ b/e2e/admin/create_issue_retry_test.go
@@ -1,0 +1,92 @@
+//go:build e2e
+
+package admin
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+)
+
+func TestCreateIssueWithRetry_RetriesUnauthorizedThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	waits := make([]time.Duration, 0, 2)
+	want := &forge.Issue{Number: 42}
+
+	issue, err := createIssueWithRetry(
+		context.Background(),
+		func() (*forge.Issue, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, &gh.APIError{StatusCode: http.StatusUnauthorized, Message: "Bad credentials"}
+			}
+			return want, nil
+		},
+		func(delay time.Duration) <-chan time.Time {
+			waits = append(waits, delay)
+			ready := make(chan time.Time, 1)
+			ready <- time.Time{}
+			return ready
+		},
+	)
+
+	require.NoError(t, err)
+	require.Same(t, want, issue)
+	require.Equal(t, 3, attempts)
+	require.Equal(t, []time.Duration{10 * time.Second, 20 * time.Second}, waits)
+}
+
+func TestCreateIssueWithRetry_DoesNotRetryOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	wantErr := &gh.APIError{StatusCode: http.StatusForbidden, Message: "Resource not accessible"}
+	attempts := 0
+
+	issue, err := createIssueWithRetry(
+		context.Background(),
+		func() (*forge.Issue, error) {
+			attempts++
+			return nil, wantErr
+		},
+		func(time.Duration) <-chan time.Time {
+			t.Fatal("unexpected retry delay")
+			return nil
+		},
+	)
+
+	require.Nil(t, issue)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 1, attempts)
+}
+
+func TestCreateIssueWithRetry_StopsAfterThreeUnauthorizedErrors(t *testing.T) {
+	t.Parallel()
+
+	wantErr := &gh.APIError{StatusCode: http.StatusUnauthorized, Message: "Bad credentials"}
+	attempts := 0
+
+	issue, err := createIssueWithRetry(
+		context.Background(),
+		func() (*forge.Issue, error) {
+			attempts++
+			return nil, wantErr
+		},
+		func(time.Duration) <-chan time.Time {
+			ready := make(chan time.Time, 1)
+			ready <- time.Time{}
+			return ready
+		},
+	)
+
+	require.Nil(t, issue)
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 3, attempts)
+}

--- a/e2e/admin/create_issue_retry_test.go
+++ b/e2e/admin/create_issue_retry_test.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -36,6 +37,7 @@ func TestCreateIssueWithRetry_RetriesUnauthorizedThenSucceeds(t *testing.T) {
 			ready <- time.Time{}
 			return ready
 		},
+		t.Logf,
 	)
 
 	require.NoError(t, err)
@@ -60,6 +62,7 @@ func TestCreateIssueWithRetry_DoesNotRetryOtherErrors(t *testing.T) {
 			t.Fatal("unexpected retry delay")
 			return nil
 		},
+		t.Logf,
 	)
 
 	require.Nil(t, issue)
@@ -84,9 +87,44 @@ func TestCreateIssueWithRetry_StopsAfterThreeUnauthorizedErrors(t *testing.T) {
 			ready <- time.Time{}
 			return ready
 		},
+		t.Logf,
 	)
 
 	require.Nil(t, issue)
 	require.ErrorIs(t, err, wantErr)
 	require.Equal(t, 3, attempts)
+}
+
+func TestCreateIssueWithRetry_RetriesWrappedUnauthorizedError(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	waits := make([]time.Duration, 0, 1)
+	want := &forge.Issue{Number: 42}
+
+	issue, err := createIssueWithRetry(
+		context.Background(),
+		func() (*forge.Issue, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, fmt.Errorf("create issue: %w", &gh.APIError{
+					StatusCode: http.StatusUnauthorized,
+					Message:    "Bad credentials",
+				})
+			}
+			return want, nil
+		},
+		func(delay time.Duration) <-chan time.Time {
+			waits = append(waits, delay)
+			ready := make(chan time.Time, 1)
+			ready <- time.Time{}
+			return ready
+		},
+		t.Logf,
+	)
+
+	require.NoError(t, err)
+	require.Same(t, want, issue)
+	require.Equal(t, 2, attempts)
+	require.Equal(t, []time.Duration{10 * time.Second}, waits)
 }


### PR DESCRIPTION
## Summary

Retry the e2e triage test's issue-creation request when GitHub temporarily returns HTTP 401. Other errors still fail immediately so genuine authorization and validation failures are not hidden.

## Related Issue

Fixes #2618

## Changes

- retry typed GitHub 401 errors up to three total attempts
- use context-aware 10-second and 20-second backoff delays
- cover recovery, typed non-401 fail-fast behavior, and retry exhaustion

## Testing

- [x] `make lint` passes (stage changes first, then run)
- [x] Tests added/updated for new or modified logic
- [x] `go test -race -tags=e2e ./e2e/admin -run '^TestCreateIssueWithRetry_' -count=1`
- [x] e2e admin package compiles with the `e2e` build tag

The broader `make go-test` command was also run. It reached two unrelated baseline failures in `internal/harnessdispatch` and `internal/sandbox`; neither package compiles these e2e-tagged files.

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it
