### PR TITLE
ci(#6116): always upload behaviour artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -294,7 +294,7 @@ jobs:
           TEST_ACTOR_OUTSIDER_PAT: ${{ secrets.TEST_ACTOR_OUTSIDER_PAT }}
 
       - name: Check out redaction script from base branch
-        if: failure() && steps.changes.outputs.relevant != 'false'
+        if: always() && steps.changes.outputs.relevant != 'false'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Base-branch script only — PR head must not control artifact redaction (#5221).
@@ -305,7 +305,7 @@ jobs:
 
       - name: Redact secrets from behaviour debug artifacts
         id: redact
-        if: failure() && steps.changes.outputs.relevant != 'false'
+        if: always() && steps.changes.outputs.relevant != 'false'
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/behaviour-artifacts
           TEST_FULLSEND_PEM: ${{ secrets.TEST_FULLSEND_PEM }}
@@ -345,7 +345,7 @@ jobs:
             /usr/bin/bash "${{ github.workspace }}/base-scripts/scripts/redact-behaviour-artifacts.sh"
 
       - name: Upload behaviour debug artifacts
-        if: failure() && steps.changes.outputs.relevant != 'false' && steps.redact.outcome == 'success'
+        if: always() && steps.changes.outputs.relevant != 'false' && steps.redact.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: behaviour-artifacts-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.run_id }}

--- a/docs/contributing/ci-workflows.md
+++ b/docs/contributing/ci-workflows.md
@@ -184,7 +184,7 @@ When a PR adds or modifies secret references in a `pull_request_target` job, rev
 
 ### Behaviour debug artifact redaction
 
-The behaviour job in `e2e.yml` uploads debug artifacts on failure. Because PR-head code populates that directory under `pull_request_target`, a malicious authorized PR could write job secrets into artifact files (GitHub masks logs but not uploaded artifact contents).
+The behaviour job in `e2e.yml` uploads debug artifacts after every relevant run, whether the tests succeed or fail. Because PR-head code populates that directory under `pull_request_target`, a malicious authorized PR could write job secrets into artifact files (GitHub masks logs but not uploaded artifact contents).
 
 Before upload, the workflow checks out `scripts/redact-behaviour-artifacts.sh` from the **base branch** (`github.sha` on `pull_request_target`; the merge-group head on `merge_group`) into a separate `base-scripts/` path. PR-head code cannot modify the checked-in script contents. The redaction step runs via `env -i` with a pinned `PATH` so earlier job steps cannot poison the interpreter search path or dynamic-linker hooks.
 

--- a/scripts/redact-behaviour-artifacts.sh
+++ b/scripts/redact-behaviour-artifacts.sh
@@ -2,9 +2,10 @@
 # redact-behaviour-artifacts.sh — Strip job secrets from behaviour debug artifacts
 # before upload.
 #
-# Invoked from .github/workflows/e2e.yml after a behaviour job failure. The workflow
-# checks out this script from the base branch (not PR head) and runs it in a clean
-# environment so PR-head code cannot tamper with the redaction toolchain.
+# Invoked from .github/workflows/e2e.yml after every relevant behaviour test run,
+# whether it succeeds or fails. The workflow checks out this script from the base
+# branch (not PR head) and runs it in a clean environment so PR-head code cannot
+# tamper with the redaction toolchain.
 #
 # Handles plain text (logs, JSON, JSONL), nested archives (zip, tar.gz, gzip), and
 # replaces opaque or encrypted blobs that cannot be scanned safely.


### PR DESCRIPTION
## Summary

- run the trusted base-branch redaction script after every relevant behaviour test run
- upload behaviour artifacts after successful and failed runs when redaction succeeds
- leave artifact collector implementation to Issue #6117 and Issue #6118

## Verification

- make lint

Closes #6116