### PR TITLE
fix(#7058): canonicalize symlinks in harness base-path containment check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: go test -race ./internal/sandbox/...
+      - run: go test -race ./internal/sandbox/... ./internal/harnessdispatch/...
         env:
           GH_TOKEN: ""
           GITHUB_TOKEN: ""

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,8 +63,8 @@ jobs:
           files: coverage.out
 
   test-sandbox-darwin:
-    # Run Go tests on macOS to exercise darwin-specific behavior (e.g. bsdtar
-    # AppleDouble suppression via COPYFILE_DISABLE=1 in UploadDir).
+    # Run sandbox and harness tests on macOS to exercise Darwin-specific
+    # behavior, including path canonicalization and archive handling.
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,7 +73,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: go test -race ./internal/sandbox/... ./internal/harnessdispatch/...
+      - run: go test -race ./internal/sandbox/... ./internal/harness/... ./internal/harnessdispatch/...
         env:
           GH_TOKEN: ""
           GITHUB_TOKEN: ""

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -407,9 +407,26 @@ func loadBaseChain(
 			return nil, nil, fmt.Errorf("resolving containment root: %w", err)
 		}
 		absWorkspace = filepath.Clean(absWorkspace)
+		absWorkspace, err = filepath.EvalSymlinks(absWorkspace)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving containment root symlinks: %w", err)
+		}
+		// Resolve existing paths before comparing so workspace aliases such as
+		// macOS's /var and /private/var forms compare consistently.
+		resolvedBasePath, resolveErr := filepath.EvalSymlinks(absBasePath)
+		if resolveErr != nil {
+			// Keep rejecting lexical escapes before returning a missing-path
+			// error, preserving the containment error for traversal attempts.
+			rel, err := filepath.Rel(absWorkspace, absBasePath)
+			if err != nil || strings.HasPrefix(rel, "..") {
+				return nil, nil, fmt.Errorf("base path %q escapes workspace root", baseRef)
+			}
+			return nil, nil, fmt.Errorf("resolving base path symlinks: %w", resolveErr)
+		}
+		absBasePath = resolvedBasePath
 		rel, err := filepath.Rel(absWorkspace, absBasePath)
 		if err != nil || strings.HasPrefix(rel, "..") {
-			return nil, nil, fmt.Errorf("base path %q escapes workspace root", baseRef)
+			return nil, nil, fmt.Errorf("base path %q escapes workspace root via symlink", baseRef)
 		}
 
 		if visited[absBasePath] {

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -415,15 +415,22 @@ func loadBaseChain(
 		// macOS's /var and /private/var forms compare consistently.
 		resolvedBasePath, resolveErr := filepath.EvalSymlinks(absBasePath)
 		if resolveErr != nil {
-			// Keep rejecting lexical escapes before returning a missing-path
-			// error, preserving the containment error for traversal attempts.
-			rel, err := filepath.Rel(absWorkspace, absBasePath)
-			if err != nil || strings.HasPrefix(rel, "..") {
-				return nil, nil, fmt.Errorf("base path %q escapes workspace root", baseRef)
+			// The base file may not exist yet, but its parent should still be
+			// canonicalized so workspace aliases compare consistently.
+			resolvedBaseDir, dirErr := filepath.EvalSymlinks(filepath.Dir(absBasePath))
+			if dirErr != nil {
+				// Keep rejecting lexical escapes before returning a missing-path
+				// error, preserving the containment error for traversal attempts.
+				rel, relErr := filepath.Rel(absWorkspace, absBasePath)
+				if relErr != nil || strings.HasPrefix(rel, "..") {
+					return nil, nil, fmt.Errorf("base path %q escapes workspace root", baseRef)
+				}
+				return nil, nil, fmt.Errorf("resolving base path symlinks: %w", dirErr)
 			}
-			return nil, nil, fmt.Errorf("resolving base path symlinks: %w", resolveErr)
+			absBasePath = filepath.Join(resolvedBaseDir, filepath.Base(absBasePath))
+		} else {
+			absBasePath = resolvedBasePath
 		}
-		absBasePath = resolvedBasePath
 		rel, err := filepath.Rel(absWorkspace, absBasePath)
 		if err != nil || strings.HasPrefix(rel, "..") {
 			return nil, nil, fmt.Errorf("base path %q escapes workspace root via symlink", baseRef)

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -411,6 +411,11 @@ func loadBaseChain(
 		if err != nil {
 			return nil, nil, fmt.Errorf("resolving containment root symlinks: %w", err)
 		}
+		// Preserve the lexical base reference relative to the referencing harness
+		// directory. This distinguishes explicit traversal from an intermediate
+		// symlink escape without being confused by workspace-root aliases.
+		lexicalRel, lexicalRelErr := filepath.Rel(childDir, absBasePath)
+		lexicallyEscapes := lexicalRelErr != nil || strings.HasPrefix(lexicalRel, "..")
 		// Resolve existing paths before comparing so workspace aliases such as
 		// macOS's /var and /private/var forms compare consistently.
 		resolvedBasePath, resolveErr := filepath.EvalSymlinks(absBasePath)
@@ -421,25 +426,25 @@ func loadBaseChain(
 			if dirErr != nil {
 				// Keep rejecting lexical escapes before returning a missing-path
 				// error, preserving the containment error for traversal attempts.
-				rel, relErr := filepath.Rel(absWorkspace, absBasePath)
-				if relErr != nil || strings.HasPrefix(rel, "..") {
+				if lexicallyEscapes {
 					return nil, nil, fmt.Errorf("base path %q escapes workspace root", baseRef)
 				}
 				return nil, nil, fmt.Errorf("resolving base path symlinks: %w", dirErr)
 			}
-			absBasePath = filepath.Join(resolvedBaseDir, filepath.Base(absBasePath))
-		} else {
-			absBasePath = resolvedBasePath
+			resolvedBasePath = filepath.Join(resolvedBaseDir, filepath.Base(absBasePath))
 		}
-		rel, err := filepath.Rel(absWorkspace, absBasePath)
+		rel, err := filepath.Rel(absWorkspace, resolvedBasePath)
 		if err != nil || strings.HasPrefix(rel, "..") {
+			if lexicallyEscapes {
+				return nil, nil, fmt.Errorf("base path %q escapes workspace root", baseRef)
+			}
 			return nil, nil, fmt.Errorf("base path %q escapes workspace root via symlink", baseRef)
 		}
 
-		if visited[absBasePath] {
-			return nil, nil, fmt.Errorf("circular base reference: %s", absBasePath)
+		if visited[resolvedBasePath] {
+			return nil, nil, fmt.Errorf("circular base reference: %s", resolvedBasePath)
 		}
-		visited[absBasePath] = true
+		visited[resolvedBasePath] = true
 
 		base, err = LoadRaw(basePath)
 		if err != nil {

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -537,6 +537,46 @@ base: ../outside.yaml
 	assert.Contains(t, err.Error(), "escapes workspace root")
 }
 
+func TestLoadWithBase_LocalBase_WorkspaceRootSymlinkAlias(t *testing.T) {
+	realDir := t.TempDir()
+	aliasParent := t.TempDir()
+	workspaceAlias := filepath.Join(aliasParent, "workspace")
+	require.NoError(t, os.Symlink(realDir, workspaceAlias))
+
+	writeTestHarness(t, realDir, "base.yaml", `
+agent: agents/base.md
+role: test
+`)
+	path := writeTestHarness(t, realDir, "child.yaml", `
+base: base.yaml
+agent: agents/child.md
+role: test
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{WorkspaceRoot: workspaceAlias})
+	require.NoError(t, err)
+}
+
+func TestLoadWithBase_LocalBase_SymlinkEscapeRejected(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	linkedDir := filepath.Join(dir, "linked")
+	require.NoError(t, os.Symlink(outside, linkedDir))
+	writeTestHarness(t, outside, "base.yaml", `
+agent: agents/base.md
+role: test
+`)
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: linked/base.yaml
+agent: agents/child.md
+role: test
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{WorkspaceRoot: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes workspace root")
+}
+
 func TestLoadWithBase_DepthExceeded(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -557,6 +557,23 @@ role: test
 	require.NoError(t, err)
 }
 
+func TestLoadWithBase_LocalBase_MissingBaseWithWorkspaceSymlinkAlias(t *testing.T) {
+	realDir := t.TempDir()
+	aliasParent := t.TempDir()
+	workspaceAlias := filepath.Join(aliasParent, "workspace")
+	require.NoError(t, os.Symlink(realDir, workspaceAlias))
+
+	path := writeTestHarness(t, realDir, "child.yaml", `
+agent: agents/child.md
+role: test
+base: missing.yaml
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{WorkspaceRoot: workspaceAlias})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading base harness")
+}
+
 func TestLoadWithBase_LocalBase_SymlinkEscapeRejected(t *testing.T) {
 	dir := t.TempDir()
 	outside := t.TempDir()

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -516,6 +516,7 @@ base: ../../../etc/passwd
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "escapes workspace root")
+	assert.NotContains(t, err.Error(), "via symlink")
 }
 
 func TestLoadWithBase_LocalBase_PathTraversal_NoWorkspaceRoot(t *testing.T) {
@@ -591,7 +592,64 @@ role: test
 
 	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{WorkspaceRoot: dir})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "escapes workspace root")
+	assert.Contains(t, err.Error(), "escapes workspace root via symlink")
+}
+
+func TestLoadWithBase_LocalBase_SymlinkEscapeWithWorkspaceAliasRejected(t *testing.T) {
+	realDir := t.TempDir()
+	aliasParent := t.TempDir()
+	workspaceAlias := filepath.Join(aliasParent, "workspace")
+	outside := t.TempDir()
+	linkedDir := filepath.Join(realDir, "linked")
+	require.NoError(t, os.Symlink(realDir, workspaceAlias))
+	require.NoError(t, os.Symlink(outside, linkedDir))
+	writeTestHarness(t, outside, "base.yaml", `
+agent: agents/base.md
+role: test
+`)
+	path := writeTestHarness(t, realDir, "child.yaml", `
+base: linked/base.yaml
+agent: agents/child.md
+role: test
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{WorkspaceRoot: workspaceAlias})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes workspace root via symlink")
+}
+
+func TestLoadWithBase_LocalBase_SymlinkKeepsReferencingDirectory(t *testing.T) {
+	workspace := t.TempDir()
+	harnessDir := filepath.Join(workspace, "harness")
+	sharedDir := filepath.Join(workspace, "shared")
+
+	writeTestHarness(t, harnessDir, "defaults.yaml", `
+agent: agents/defaults.md
+role: test
+runner_env:
+  BASE_DIRECTORY: harness
+`)
+	writeTestHarness(t, sharedDir, "defaults.yaml", `
+agent: agents/defaults.md
+role: test
+runner_env:
+  BASE_DIRECTORY: shared
+`)
+	template := writeTestHarness(t, sharedDir, "template.yaml", `
+agent: agents/base.md
+role: test
+base: defaults.yaml
+`)
+	require.NoError(t, os.Symlink(template, filepath.Join(harnessDir, "base.yaml")))
+	path := writeTestHarness(t, harnessDir, "child.yaml", `
+agent: agents/child.md
+role: test
+base: base.yaml
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{WorkspaceRoot: workspace})
+	require.NoError(t, err)
+	assert.Equal(t, "harness", h.RunnerEnv["BASE_DIRECTORY"])
 }
 
 func TestLoadWithBase_DepthExceeded(t *testing.T) {

--- a/internal/harnessdispatch/enumerate_test.go
+++ b/internal/harnessdispatch/enumerate_test.go
@@ -208,6 +208,8 @@ func urlHarnessServer(t *testing.T, harnessName, harnessYAML string, badHash boo
 
 func TestListTriggeredHarnesses_BaseComposition(t *testing.T) {
 	dir := t.TempDir()
+	dir, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
 	harnessDir := filepath.Join(dir, "harness")
 	require.NoError(t, os.MkdirAll(harnessDir, 0o755))
 


### PR DESCRIPTION
## Summary

Canonicalize local harness base paths and the workspace containment root before
comparing them, so macOS `/var` to `/private/var` aliases do not falsely reject
valid composition and symlink escapes remain blocked. Load the same resolved
path that passed containment validation, closing an absolute-path
symlink-plus-`..` check/open divergence.

Extend the existing Darwin job to exercise the harness and harness-dispatch
packages that cover this behavior.

## Related Issue

Fixes #7058

## Changes

- resolve workspace roots and base paths through symlinks for containment checks
- preserve lexical traversal diagnostics and relative chained-base resolution
- open the validated resolved base path instead of the original absolute string
- cover workspace aliases, missing paths, symlink escapes, and absolute
  symlink-plus-`..` traversal with regression tests
- run `internal/harness` and `internal/harnessdispatch` tests in the existing
  Darwin CI job

## Testing

- [x] `make lint`
- [x] `make go-test`
- [x] `make go-vet`
- [x] targeted absolute symlink traversal regression verified RED then GREEN
- [x] `loadBaseChain` function coverage: 94.9%

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md)
- [x] Commits are signed off (DCO)
- [x] I wrote this contribution myself and can explain all changes in it

## Approval required

- [ ] Human approval for the protected `.github/workflows/lint.yml` change
