### PR TITLE
fix(#2187): normalize fix instruction line endings

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1097,7 +1097,7 @@ jobs:
 
           INSTRUCTION="none"
           if [[ ! "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
-            COMMENT_BODY="$(echo "${EVENT_PAYLOAD}" | jq -r '.comment.body // empty')"
+            COMMENT_BODY="$(echo "${EVENT_PAYLOAD}" | jq -r '.comment.body // empty' | tr -d '\r')"
             if [[ -n "${COMMENT_BODY}" ]]; then
               INSTRUCTION="${COMMENT_BODY#/fs-fix}"
               INSTRUCTION="$(printf '%s\n' "${INSTRUCTION}" | sed 's/^[.,;:!?]*//')"

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -3,6 +3,7 @@ package scaffold
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -349,6 +350,58 @@ func TestReusableDispatchProjectNumberInput(t *testing.T) {
 	s := string(content)
 	assert.True(t, strings.Contains(s, "PRIORITIZE_PROJECT_NUMBER: ${{ inputs.project_number }}"),
 		"prioritize job should thread project_number to PRIORITIZE_PROJECT_NUMBER env var")
+}
+
+func TestReusableDispatchFixInstructionNormalizesCRLF(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "reusable-dispatch.yml"))
+	require.NoError(t, err)
+
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.Unmarshal(content, &workflow))
+
+	var script string
+	for _, step := range workflow.Jobs["fix"].Steps {
+		if step.Name == "Extract PR number and context" {
+			script = step.Run
+			break
+		}
+	}
+	require.NotEmpty(t, script)
+
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"gh":      "#!/bin/sh\nprintf '[]\\n'\n",
+		"openssl": "#!/bin/sh\nprintf 'fixed-delimiter\\n'\n",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o755))
+	}
+	outputPath := filepath.Join(dir, "github-output")
+	payload := `{"pull_request":{"number":42,"head":{"ref":"fix-branch"},"base":{"ref":"main"}},"comment":{"body":"/fs-fix\r\nChange A\r\nChange B"}}`
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"EVENT_PAYLOAD="+payload,
+		"INPUT_PR_NUMBER=",
+		"INPUT_INSTRUCTION=",
+		"TRIGGER_SOURCE=contributor",
+		"SOURCE_REPO=fullsend-ai/fullsend",
+		"GITHUB_OUTPUT="+outputPath,
+	)
+	result, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s", result)
+
+	output, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "instruction<<INSTRUCTION_fixed-delimiter\nChange A\nChange B\nINSTRUCTION_fixed-delimiter\n")
+	assert.NotContains(t, string(output), "\r")
 }
 
 // TestOTELHeadersSecretThreading validates that the optional OTLP headers

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -352,6 +352,8 @@ func TestReusableDispatchProjectNumberInput(t *testing.T) {
 		"prioritize job should thread project_number to PRIORITIZE_PROJECT_NUMBER env var")
 }
 
+// TestReusableDispatchFixInstructionNormalizesCRLF validates that CRLF line endings
+// in a comment body are stripped before the fix instruction is written to GITHUB_OUTPUT.
 func TestReusableDispatchFixInstructionNormalizesCRLF(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "reusable-dispatch.yml"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Normalize CRLF comment bodies before forwarding human instructions to the
supported per-repo fix agent. This prevents invisible carriage-return bytes
from reaching the agent while preserving the comment's line structure.

The deprecated per-org `reusable-fix.yml` path is intentionally unchanged in
accordance with ADR 0044. That path retains the same latent CRLF exposure,
which is accepted as follow-up work under the deprecation timeline; this PR
adds no new per-org behavior.

## Related Issue

Fixes #2187

## Changes

- strip `\r` from fix comment bodies in the inline per-repo fix stage
- execute the real workflow step in a regression test with a CRLF payload
- assert that the generated instruction contains only LF line endings
- document the accepted deprecated per-org path limitation

## Testing

- [x] `make lint`
- [x] `go test ./internal/scaffold -count=1`
- [x] focused regression test passes 10 consecutive runs
- [ ] `make go-test` (unrelated existing macOS failures covered by #7058 and #7059 / PRs #7061 and #7060)

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md)
- [x] Commits are signed off (DCO)
- [x] I wrote this contribution myself and can explain all changes in it
