### PR TITLE
fix(#827): dismiss stale bot approvals

### DIFF
--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -324,6 +324,7 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		printer.StepInfo("Could not list reviews, skipping stale review cleanup")
 	} else {
 		dismissStaleRequestChanges(ctx, client, owner, repo, pr, event, user, reviews, printer)
+		dismissStaleApprovals(ctx, client, owner, repo, pr, user, reviews, printer)
 		minimizeStaleReviews(ctx, client, user, reviews, printer)
 	}
 
@@ -682,6 +683,24 @@ func dismissStaleRequestChanges(ctx context.Context, client forge.Client, owner,
 			printer.StepInfo(fmt.Sprintf("Warning: could not dismiss review %d: %v", r.ID, err))
 		} else {
 			printer.StepDone("Stale review dismissed")
+		}
+	}
+}
+
+// dismissStaleApprovals dismisses all APPROVED reviews by the authenticated
+// user before a new verdict is posted. This prevents an approval for an older
+// commit from remaining active when the latest verdict is comment-only or
+// requests changes.
+func dismissStaleApprovals(ctx context.Context, client forge.Client, owner, repo string, pr int, user string, reviews []forge.PullRequestReview, printer *ui.Printer) {
+	for _, r := range reviews {
+		if r.User != user || r.State != "APPROVED" {
+			continue
+		}
+		printer.StepStart(fmt.Sprintf("Dismissing stale APPROVED review %d", r.ID))
+		if err := client.DismissPullRequestReview(ctx, owner, repo, pr, r.ID, "Superseded by updated review"); err != nil {
+			printer.StepInfo(fmt.Sprintf("Warning: could not dismiss review %d: %v", r.ID, err))
+		} else {
+			printer.StepDone("Stale approval dismissed")
 		}
 	}
 }

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -317,14 +317,18 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		return nil
 	}
 
+	var (
+		user         string
+		priorReviews []forge.PullRequestReview
+	)
 	user, err := client.GetAuthenticatedUser(ctx)
 	if err != nil {
 		printer.StepInfo("Could not determine authenticated user, skipping stale review cleanup")
 	} else if reviews, err := client.ListPullRequestReviews(ctx, owner, repo, pr); err != nil {
 		printer.StepInfo("Could not list reviews, skipping stale review cleanup")
 	} else {
+		priorReviews = reviews
 		dismissStaleRequestChanges(ctx, client, owner, repo, pr, event, user, reviews, printer)
-		dismissStaleApprovals(ctx, client, owner, repo, pr, user, reviews, printer)
 		minimizeStaleReviews(ctx, client, user, reviews, printer)
 	}
 
@@ -373,6 +377,9 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 	// a COMMENT review is submitted so the findings appear on the
 	// relevant code lines.
 	if event == "COMMENT" && len(inlineComments) == 0 {
+		// There is no replacement formal review to succeed, so remove stale
+		// approvals after the sticky verdict has been prepared.
+		dismissStaleApprovals(ctx, client, owner, repo, pr, user, priorReviews, printer)
 		printer.StepInfo("Skipping formal COMMENT review (sticky comment already updated)")
 		return nil
 	}
@@ -402,12 +409,14 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 				logAPIErrorDetails(retryErr, printer)
 				return fmt.Errorf("submitting review (fallback without inline comments also failed): %w", retryErr)
 			}
+			dismissStaleApprovals(ctx, client, owner, repo, pr, user, priorReviews, printer)
 			printer.StepDone("Review submitted (inline comments omitted due to 422)")
 			return nil
 		}
 		logAPIErrorDetails(err, printer)
 		return fmt.Errorf("submitting review: %w", err)
 	}
+	dismissStaleApprovals(ctx, client, owner, repo, pr, user, priorReviews, printer)
 	printer.StepDone("Review submitted")
 	return nil
 }

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -317,10 +317,7 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		return nil
 	}
 
-	var (
-		user         string
-		priorReviews []forge.PullRequestReview
-	)
+	var priorReviews []forge.PullRequestReview
 	user, err := client.GetAuthenticatedUser(ctx)
 	if err != nil {
 		printer.StepInfo("Could not determine authenticated user, skipping stale review cleanup")

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -316,6 +316,47 @@ func TestDismissStaleApprovals_ErrorTolerance(t *testing.T) {
 	assert.Empty(t, fc.DismissedReviews, "dismissal errors should be non-fatal")
 }
 
+func TestSubmitFormalReview_PreservesApprovalWhenReplacementFails(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.Errors["CreatePullRequestReview"] = fmt.Errorf("API error")
+	fc.PRReviews = map[string][]forge.PullRequestReview{
+		"acme/repo/1": {
+			{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "APPROVED", Body: "old approval"},
+		},
+	}
+
+	printer := ui.New(io.Discard)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", "", nil, false, printer)
+
+	assert.Error(t, err)
+	assert.Empty(t, fc.DismissedReviews, "the old approval must remain when replacement review creation fails")
+}
+
+func TestSubmitFormalReview_PreservesApprovalWhenFallbackFails(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.Errors["CreatePullRequestReview"] = &gh.APIError{StatusCode: http.StatusUnprocessableEntity, Message: "validation failed"}
+	fc.PRReviews = map[string][]forge.PullRequestReview{
+		"acme/repo/1": {
+			{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "APPROVED", Body: "old approval"},
+		},
+	}
+	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
+		"acme/repo/1": {
+			{Path: "internal/service.go", Patch: "@@ -1,1 +1,1 @@"},
+		},
+	}
+
+	printer := ui.New(io.Discard)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "", "", []ReviewFinding{{
+		File: "internal/service.go", Line: 1, Description: "invalid change",
+	}}, false, printer)
+
+	assert.Error(t, err)
+	assert.Empty(t, fc.DismissedReviews, "the old approval must remain when the fallback review also fails")
+}
+
 func TestSubmitFormalReview_DryRun(t *testing.T) {
 	fc := forge.NewFakeClient()
 	printer := ui.New(io.Discard)

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -241,7 +241,9 @@ func TestSubmitFormalReview_CreatesAndMinimizesStale(t *testing.T) {
 	assert.Equal(t, "PRR_300", fc.MinimizedComments[1].NodeID)
 	assert.Equal(t, "OUTDATED", fc.MinimizedComments[1].Reason)
 
-	assert.Empty(t, fc.DismissedReviews, "no CHANGES_REQUESTED reviews to dismiss")
+	require.Len(t, fc.DismissedReviews, 1, "the bot's stale approval should be dismissed")
+	assert.Equal(t, 300, fc.DismissedReviews[0].ReviewID)
+	assert.Equal(t, "Superseded by updated review", fc.DismissedReviews[0].Message)
 }
 
 func TestSubmitFormalReview_DismissesStaleRequestChanges(t *testing.T) {
@@ -279,6 +281,39 @@ func TestSubmitFormalReview_DismissesOnCommentVerdict(t *testing.T) {
 	require.Len(t, fc.DismissedReviews, 1, "COMMENT verdict must still dismiss stale CHANGES_REQUESTED")
 	assert.Equal(t, 100, fc.DismissedReviews[0].ReviewID)
 	assert.Empty(t, fc.CreatedReviews, "COMMENT with no inline findings skips formal review")
+}
+
+func TestSubmitFormalReview_DismissesStaleApproval(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.PRReviews = map[string][]forge.PullRequestReview{
+		"acme/repo/1": {
+			{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "APPROVED", Body: "old approval"},
+			{ID: 200, NodeID: "PRR_200", User: "someone-else", State: "APPROVED", Body: "human approval"},
+		},
+	}
+
+	printer := ui.New(io.Discard)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "", "", nil, false, printer)
+	require.NoError(t, err)
+
+	require.Len(t, fc.DismissedReviews, 1, "COMMENT verdict must dismiss the bot's stale approval")
+	assert.Equal(t, 100, fc.DismissedReviews[0].ReviewID)
+	assert.Equal(t, "Superseded by updated review", fc.DismissedReviews[0].Message)
+	assert.Empty(t, fc.CreatedReviews, "COMMENT with no inline findings skips formal review")
+}
+
+func TestDismissStaleApprovals_ErrorTolerance(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.Errors["DismissPullRequestReview"] = fmt.Errorf("API error")
+	reviews := []forge.PullRequestReview{
+		{ID: 100, User: "fullsend-bot", State: "APPROVED"},
+	}
+
+	printer := ui.New(io.Discard)
+	dismissStaleApprovals(context.Background(), fc, "acme", "repo", 1, "fullsend-bot", reviews, printer)
+
+	assert.Empty(t, fc.DismissedReviews, "dismissal errors should be non-fatal")
 }
 
 func TestSubmitFormalReview_DryRun(t *testing.T) {


### PR DESCRIPTION
## Summary

Dismiss stale approvals from the review bot before processing a new verdict,
so GitHub does not retain approval for an older commit.

## Related Issue

Fixes #827

## Changes

- dismiss prior `APPROVED` reviews belonging to the authenticated bot
- apply the cleanup to comment-only verdicts as well as formal reviews
- preserve other users' reviews and the existing `CHANGES_REQUESTED` cleanup
- add regression coverage for filtering and dismissal errors

## Testing

- [x] `make lint`
- [x] `make go-vet`
- [x] `go test ./internal/cli`
- [x] Focused review-flow tests
- [x] Coverage check for changed production code (`dismissStaleApprovals`: 100%)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] Codex co-author trailer included
