### PR TITLE
docs(#6817): add AgentEntry merge checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Detailed guidance lives in `docs/contributing/` and topic-specific guides under 
 | [Forge Abstraction](docs/contributing/forge-abstraction.md) | Adding forge operations — covers `forge.Client` interface rules |
 | [Harness Composition](docs/contributing/harness-composition.md) | Changing merge functions in `internal/harness/` — covers the invariant between compose and forge merge functions |
 | [Harness Field Reference](docs/contributing/harness-fields.md) | Adding or modifying fields in `Harness` or `ForgeConfig` — covers field classifications, merge rules, and the `ForgeConfig` struct |
+| [Per-repo AgentEntry fields](docs/contributing/harness-composition.md) | Adding or modifying fields in `AgentEntry` — covers layered merge handling, tests, documentation, and override-only semantics |
 | [Normative Event Specification](docs/normative/normalized-event/v1/README.md) | Adding or modifying fields in `event_payload` (`buildEventPayload`), normalized-event structures under `internal/normevent/`, or adapters — covers the projection table, transition vocabulary, adapter contracts, and CEL trigger examples |
 | [CEL Triggers](docs/contributing/cel-triggers.md) | Writing or reviewing harness `trigger` CEL expressions or `.feature` CEL filters — covers normalized transition kinds |
 | [ADRs](docs/contributing/adrs.md) | Touching `docs/ADRs/` or reviewing ADR changes — covers immutability and status rules |

--- a/docs/contributing/harness-composition.md
+++ b/docs/contributing/harness-composition.md
@@ -97,6 +97,33 @@ structs:
    - Merge and inheritance rules table
    - `ForgeConfig` struct definition
 
+## Checklist for `AgentEntry` field changes
+
+`AgentEntry` is also merged field by field, in
+`internal/config/interfaces.go`. A field added to
+`internal/config/config.go` is not automatically preserved when a per-repo
+configuration overlays a parent configuration.
+
+When adding or modifying a field in `AgentEntry`:
+
+1. **Determine the field's merge semantics.** Document whether an omitted,
+   empty, false, or nil value inherits the parent, replaces it, or explicitly
+   clears it. Pay particular attention to pointer and map fields.
+2. **Update `perRepoConfig.AgentEntries()`** in
+   `internal/config/interfaces.go` so matching entries merge the new field.
+   Preserve the existing keyed merge by `DerivedName()` and last-overlay-wins
+   behavior.
+3. **Add layered-merge test coverage** in
+   `internal/config/interfaces_test.go` or `internal/config/load_test.go`.
+   Test both the overriding value and the inheritance or clearing behavior.
+4. **Update the [layered configuration reference](../guides/infrastructure/layered-config-reference.md)**
+   with the field's YAML name, type, and merge rule.
+5. **Recheck `HasSettings()` and `IsOverrideOnly()`** in
+   `internal/config/config.go` when the field affects whether an entry is an
+   override-only agent.
+6. **Check all other consumers** of the field, including validation,
+   serialization, update commands, and runtime readers.
+
 ## When reviewing PRs
 
 **When reviewing PRs that touch merge functions:**


### PR DESCRIPTION
## Summary

- add contributor guidance for `AgentEntry` field changes
- document layered merge semantics, test coverage, config reference updates, and override-only checks
- link the checklist from `AGENTS.md`

## Validation

- `make lint`
- commit hooks passed, including Markdown link and docs link checks

Closes #6817
