### PR TITLE
chore(config): route agents across runtimes and models

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -5,6 +5,13 @@
 # See ADR 0033 for details.
 version: "1"
 runtime: claude
+# What the `sonnet` alias means in this repo, for the parent run of every agent
+# on both runtimes and for pi sub-agents. fullsend's pinned default is one
+# generation older; Vertex enables models per project, so this only works
+# where claude-sonnet-5 is served (a pinned alias has no fallback).
+models:
+    aliases:
+        sonnet: claude-sonnet-5
 roles:
     - fullsend
     - triage
@@ -14,6 +21,27 @@ roles:
     - prioritize
 agents:
     - source: https://raw.githubusercontent.com/redhat-community-ai-tools/qualityflow-fullsend/f6311b4f30ee5c23c597dba07bccc8ac0aa991be/harness/qualityflow.yaml#sha256=c0a51b2f75172aebd577fd38c8012a7c566a84f84812ebd9aa4cc07ad3b2220e
+    - name: code
+      runtime: pi
+      model: xai/grok-4.6
+    - name: fix
+      model: sonnet
+    - name: prioritize
+      runtime: pi
+      model: google-vertex/gemini-3.8-flash
+    - name: review
+      runtime: pi
+      model: sonnet
+      subagents:
+        challenger: xai/grok-4.6
+        correctness: xai/grok-4.6
+        docs-currency: google-vertex/gemini-3.8-flash
+        security: xai/grok-4.6
+        style-conventions: google-vertex/gemini-3.8-flash
+    - name: retro
+      model: sonnet
+    - name: triage
+      model: sonnet
 allowed_remote_resources:
     - https://raw.githubusercontent.com/redhat-community-ai-tools/qualityflow-fullsend/
 create_issues:


### PR DESCRIPTION
**Depends on fullsend-ai/agents#1211** (pr-review dispatches sub-agents by persona when the runtime registers them). Without it the `subagents` block below is inert on pi: the current skill tells the orchestrator to pass the frontmatter `model` and not set `subagent_type`, so every child runs anonymously on opus/sonnet (measured, see the first review thread). Order: #1211 merges on maintainer approval → next fullsend release (so release-installed repos pick up the fixed skill through the agents tag; repos on `main` get it at once) → this PR, right after fullsend-ai/agents#1209 (no waiting period).

## What

Persist per-agent runtime and model selection in `.fullsend/config.yaml` (fullsend v0.42.0 `agents:` entries, written with `fullsend agent set`), instead of the fleet-wide `opus` on Claude Code that every harness carries today. Config in the repo is visible and reviewable; repository variables (`<ROLE>_FULLSEND_MODEL`) are not, so none are used and rollback is also a PR.

| agent | runtime | model | children |
|---|---|---|---|
| `code` | pi | `xai/grok-4.6` | — |
| `fix` | claude (repo default) | `sonnet` | — |
| `prioritize` | pi | `google-vertex/gemini-3.8-flash` | — |
| `review` | pi | `sonnet` (orchestrator) | `correctness`, `security`, `challenger` → `xai/grok-4.6`; `docs-currency`, `style-conventions` → `google-vertex/gemini-3.8-flash`; `risk-assessment`, `intent-coherence`, `cross-repo-contracts` keep their frontmatter `sonnet`; `security-triage` keeps `haiku` |
| `retro` | claude | `sonnet` | its children name no persona and pass no model, so on Claude they inherit `sonnet` from the parent |
| `triage` | claude | `sonnet` | — |

Every line was produced by `fullsend agent set … --fullsend-dir .fullsend` and validated with `fullsend agent list`; the only hand edit is reverting the CLI's cosmetic re-serialisation (header comment, `status_notifications` indentation) so the diff is the `agents:` block alone.

## Why

`opus` everywhere is the cost driver. `code` is the from-scratch implementer whose commits are kept, so it gets the more capable model; `fix` fires after every review round and is the run most often superseded by a human takeover, so it gets `sonnet`. The review keeps no opus persona at all.

## Model alias

```yaml
models:
    aliases:
        sonnet: claude-sonnet-5
```

fullsend's pinned default for `sonnet` is one generation older (`claude-sonnet-4-6`), so every `sonnet` above would silently run that without this block. The alias applies to the parent run of every agent on both runtimes and to pi sub-agents. It does **not** reach Claude Code sub-agents (`code`, `fix`, `retro` children on Claude), which resolve `sonnet` through the agents harness env pin `ANTHROPIC_DEFAULT_SONNET_MODEL` — bumping that is a fullsend-ai/agents change, tracked separately. This repo's config is meant to be the worked example other repos copy, which is why the alias is explicit rather than left to the default table.

## Merge gates (do not merge before all are ticked)

- [x] The repository's Vertex project serves `claude-sonnet-5`, `xai/grok-4.6` and `gemini-3.8-flash` — confirmed 2026-09-08 (all three enabled there; probed with a one-token request) (a pinned alias or persona model that cannot be served has no fallback: the review fails at Bootstrap after the sandbox is created, `code` and the Claude agents fail at the first model call). Or point `XAI_VERTEX_PROJECT_ID` at a project that does.
- [x] fullsend-ai/agents#1194 merged (`a35983272`: sandbox images repinned to the 0.42.0 digests — pi 0.85.0, pi-xai-vertex 0.2.1 with the Grok keepalive fix).
- [x] The repin is live on the fleet without any tag move: the dispatch workflows build fullsend from `main` (a source build carries no release tag), and such a build fetches the built-in agents from `fullsend-ai/agents` at `heads/main`, not at `v0`. Verified on a fleet review run on 2026-09-08 19:29 UTC: `fullsend version 41e7a66`, agents fetched at `a35983272`, sandbox image `fullsend-code@sha256:623fc745…` (the 0.42.0 image). `v0` only matters to a release-tagged binary, which the fleet runs just between a fullsend release and the next merge to `main`.
- [x] fullsend-ai/agents#1211 merged 2026-09-09 (`4749344e9`; pr-review skill dispatches by persona when the runtime lists them). Found by the local review run on 2026-09-08: Bootstrap resolved all nine personas as configured, but the current skill tells the orchestrator to pass `model` from the frontmatter and not set `subagent_type`, so every child ran as an anonymous sub-agent on opus/sonnet and the `subagents` block here was inert. Without #1211 this PR changes the review's orchestrator model only.
- [x] Local `fullsend run review` and `fullsend run code` with this config on 2026-09-08: Bootstrap resolves all nine personas as configured; with the agents#1211 skill all eight review dispatches go out by persona on the configured models (Grok ×3, Gemini ×2, sonnet-5 ×3), exit 0, $5.34 — at parity with the fleet's own Claude/opus reviews of the same PR ($3.81–$5.91 across six runs); `code` on Grok passed validation twice ($0.72–$1.00, `effort: high` accepted, gopls plugin skipped as expected). Full evidence on agents#1209's first review thread.
- [ ] fullsend-ai/agents#1209 merged first (agents is the pilot); this PR follows the same day.

## What this PR's own checks do and do not prove

The dispatch workflows check out `.fullsend` from the **base** SHA, so the review that runs on this PR uses the current config, not this one. Green here proves the file parses and nothing else; the gates above are the real test.

## Rollback

A PR: `git revert` of this commit, or one `fullsend agent set <agent> --fullsend-dir .fullsend --runtime claude --model opus` line for a single role.
