### PR TITLE
fix(web): include Codex in landing page runtimes

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -171,7 +171,7 @@ nav{
 }
 .hero-actions{display:flex;gap:0.75rem;flex-wrap:wrap;margin-bottom:2.5rem}
 .hero-stats{
-  display:flex;flex-wrap:wrap;gap:1rem 2rem;
+  display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1rem 2rem;
   padding-top:1.5rem;
   border-top:1px solid var(--border);
 }
@@ -585,7 +585,7 @@ footer{
     <div class="hero-stats">
       <div class="hero-stat">
         <span class="hero-stat-value">Multi-runtime</span>
-        <span class="hero-stat-label">Claude Code &middot; pi</span>
+        <span class="hero-stat-label">Claude Code &middot; Pi &middot; Codex</span>
       </div>
       <div class="hero-stat">
         <span class="hero-stat-value">6 Agents</span>


### PR DESCRIPTION
## Summary

The landing page omits the supported Codex runtime. List “Claude Code · Pi · Codex” and use a two-column stats grid so the longer label does not leave uneven rows on desktop or narrow phones.

## Related Issue

User-requested update; no linked issue.

## Changes

- Add Codex and capitalize Pi in the Multi-runtime label.
- Keep the four hero stats in a responsive 2×2 grid.

## Testing

- [x] `make lint` passed with the change staged.
- [x] `git diff --check` passed.
- [x] Playwright verified widths of 320, 375, 390, 768, 900, 901, 1024, and 1440px; no horizontal overflow or clipped stats.
- [x] Visually inspected desktop and mobile screenshots.
- No logic changes requiring unit tests.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Commit signed off (DCO).
