### PR TITLE
chore(config): revert per-agent runtime/model routing (#7116)

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -5,13 +5,6 @@
 # See ADR 0033 for details.
 version: "1"
 runtime: claude
-# What the `sonnet` alias means in this repo, for the parent run of every agent
-# on both runtimes and for pi sub-agents. fullsend's pinned default is one
-# generation older; Vertex enables models per project, so this only works
-# where claude-sonnet-5 is served (a pinned alias has no fallback).
-models:
-    aliases:
-        sonnet: claude-sonnet-5
 roles:
     - fullsend
     - triage
@@ -21,27 +14,6 @@ roles:
     - prioritize
 agents:
     - source: https://raw.githubusercontent.com/redhat-community-ai-tools/qualityflow-fullsend/f6311b4f30ee5c23c597dba07bccc8ac0aa991be/harness/qualityflow.yaml#sha256=c0a51b2f75172aebd577fd38c8012a7c566a84f84812ebd9aa4cc07ad3b2220e
-    - name: code
-      runtime: pi
-      model: xai/grok-4.6
-    - name: fix
-      model: sonnet
-    - name: prioritize
-      runtime: pi
-      model: google-vertex/gemini-3.8-flash
-    - name: review
-      runtime: pi
-      model: sonnet
-      subagents:
-        challenger: xai/grok-4.6
-        correctness: xai/grok-4.6
-        docs-currency: google-vertex/gemini-3.8-flash
-        security: xai/grok-4.6
-        style-conventions: google-vertex/gemini-3.8-flash
-    - name: retro
-      model: sonnet
-    - name: triage
-      model: sonnet
 allowed_remote_resources:
     - https://raw.githubusercontent.com/redhat-community-ai-tools/qualityflow-fullsend/
 create_issues:


### PR DESCRIPTION
## What

Reverts the per-agent runtime/model routing merged today (fullsend-ai/fullsend#7116), restoring the previous config: every agent on Claude Code / `opus`, no `models.aliases`.

## Why — the fleet is failing at the first model call

First fleet review after the merge (fullsend-ai/fullsend#7167, run 34365183694): Bootstrap resolved all nine personas, then the orchestrator's first request failed:

```
404 Publisher model `projects/…/locations/global/publishers/anthropic/models/claude-sonnet-5` was not found or your project does not have access
→ Result: ERROR · Validation failed: output/agent-result.json not found · Agent exit code: 1
```

The Vertex project the fleet runs on does **not** serve `claude-sonnet-5`. The alias `sonnet: claude-sonnet-5` is on every `sonnet` parent (review, fix, triage, retro), and a pinned alias has no fallback, so every one of those agents fails on every trigger until this is reverted. `code` (Grok) and `prioritize` (Gemini) may or may not be served there — nothing has proven it on the fleet project, so the whole routing goes back until it is.

The local validation runs were done against a project that serves all three ids; the fleet's project is a different one. That is the mistake — the served-model check must be run against the project the fleet actually uses, which is the secret `FULLSEND_GCP_PROJECT_ID`, not a probe from a laptop.

## Re-apply plan

1. Confirm which ids the fleet project serves — a one-line `fullsend run` from CI against it, or an admin `rawPredict` probe from the project itself.
2. Re-apply only the routing that project serves; keep `sonnet` on the default alias unless `claude-sonnet-5` is enabled there.
