### PR TITLE
docs(#7185): align documentation update triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,4 @@ Detailed guidance lives in `docs/contributing/` and topic-specific guides under 
 | [Vouch System](docs/contributing/vouch-system.md) | Working with the contributor vouch gate or PR workflows |
 | [Tier Conventions](docs/contributing/tier-conventions.md) | Using the term "tier" in code or docs — covers the three distinct tier contexts |
 | [CI Workflows](docs/contributing/ci-workflows.md) | Adding or modifying GitHub Actions workflows under `.github/workflows/`, adding secrets to `pull_request_target` jobs, or reviewing refactors across inline-step, reusable-workflow, and composite-action boundaries for context-variable scoping |
-| [Documentation](docs/contributing/documentation.md) | Changing CLI command behavior, adding or removing subcommands, or renaming flags — covers cross-reference of CLI command groups to all documentation touchpoints |
+| [Documentation](docs/contributing/documentation.md) | Adding, removing, renaming, or changing CLI commands, flags, configuration variables, or environment variables — covers cross-reference of CLI command groups to all documentation touchpoints |

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -17,14 +17,25 @@ Before considering a CLI, configuration, or environment-variable change
 complete, search for the affected command or setting:
 
 ```bash
-grep -rn '<command-or-setting-name>' docs/ internal/cli/
+grep -rn '<command-or-setting-name>' docs/ internal/ .github/
 ```
 
-The `internal/cli/` path covers inline `Short`/`Long` help text in Go source.
-Review every hit and update references that describe behavior you changed. For
-new commands or settings with no literal match, also inspect tables and lists
-of comparable commands, flags, or variables. This catches files not listed in
-the cross-reference below.
+The `internal/cli/` path covers inline `Short`/`Long` help text in Go source,
+and `internal/config/` defines `config.yaml` fields. Review every hit and
+update references that describe behavior you changed. For new commands or
+settings with no literal match, also inspect tables and lists of comparable
+commands, flags, or variables. This catches files not listed in the
+cross-reference below.
+
+## Configuration and environment variables
+
+For a `.fullsend/config.yaml` field, update
+`docs/reference/config-reference.md`, the canonical reference for every field.
+If its layered resolution or defaults change, also check
+`docs/guides/infrastructure/layered-config-reference.md`. For an environment
+variable or repository variable, check the repository-variable table in
+`docs/guides/getting-started/operations.md` and the documentation for the
+feature that consumes it.
 
 ## ADR annotations
 

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -4,17 +4,27 @@ title: Documentation
 
 # Documentation
 
-When changing CLI command behavior, adding or removing subcommands, or renaming flags, you must update every documentation file that references the affected command. CLI commands are documented across CLI reference pages, user and operator guides, ADRs, and inline Go help text. Missing even one location causes documentation drift that surfaces as review findings on later PRs.
+When adding, removing, renaming, or changing the behavior of CLI commands,
+flags, configuration variables, or environment variables, you must update
+every documentation file that references the affected feature. CLI commands
+are documented across CLI reference pages, user and operator guides, ADRs,
+and inline Go help text. Missing even one location causes documentation drift
+that surfaces as review findings on later PRs.
 
 ## General discovery rule
 
-Before considering a CLI change complete, run:
+Before considering a CLI, configuration, or environment-variable change
+complete, search for the affected command or setting:
 
 ```bash
-grep -rn '<command-name>' docs/ internal/cli/
+grep -rn '<command-or-setting-name>' docs/ internal/cli/
 ```
 
-The `internal/cli/` path covers inline `Short`/`Long` help text in Go source. Review every hit and update references that describe behavior you changed. This catches files not listed in the cross-reference below.
+The `internal/cli/` path covers inline `Short`/`Long` help text in Go source.
+Review every hit and update references that describe behavior you changed. For
+new commands or settings with no literal match, also inspect tables and lists
+of comparable commands, flags, or variables. This catches files not listed in
+the cross-reference below.
 
 ## ADR annotations
 


### PR DESCRIPTION
## Summary

- align the documentation guide with the broadened documentation-update trigger
- cover CLI commands, flags, configuration variables, and environment variables
- clarify discovery for newly added settings that have no literal documentation match
- align the AGENTS.md documentation cross-reference

Closes #7185

## Validation

- `make lint`
- `pre-commit run --all-files`
- independent review of the two-file diff; fixed the environment-variable discovery gap it found