### PR TITLE
fix(#7140): map hyphens to underscores in role identifiers

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -1734,7 +1734,10 @@ jobs:
           FULLSEND_REPO_VARS: ${{ toJSON(vars) }}
         run: |
           set -euo pipefail
-          ROLE_UPPER=$(echo "${MATRIX_ROLE}" | tr '[:lower:]' '[:upper:]')
+          # GitHub Actions / bash identifiers cannot contain hyphens.
+          # Map the role the same way mintcore.RoleIdentifier does: uppercase
+          # and replace '-' with '_' so ci-check becomes CI_CHECK.
+          ROLE_UPPER=$(echo "${MATRIX_ROLE}" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
           export AGENT_PREFIX="${ROLE_UPPER}_"
           export "${ROLE_UPPER}_TARGET_REPO_DIR=target-repo"
           export "${ROLE_UPPER}_ANTHROPIC_VERTEX_PROJECT_ID=${GCP_PROJECT}"

--- a/docs/ADRs/0014-admin-install-github-apps-secrets-v1.md
+++ b/docs/ADRs/0014-admin-install-github-apps-secrets-v1.md
@@ -27,6 +27,8 @@ The admin CLI creates or reuses per-role GitHub Apps and must persist the minimu
 
 **Adopt credential surface v1**: expected app slugs and manifest/install behavior per role, and repository secrets `FULLSEND_<ROLE>_APP_PRIVATE_KEY` plus variables `FULLSEND_<ROLE>_CLIENT_ID` on the `.fullsend` repo, with uppercase role suffixes matching `internal/layers/secrets.go` and `internal/cli/admin.go`.
 
+> **Later note (hyphenated roles):** GitHub Actions secret and variable names cannot contain hyphens. Role suffixes now map hyphens to underscores (`ci-check` → `CI_CHECK`) via `mintcore.RoleIdentifier`. See [#7140](https://github.com/fullsend-ai/fullsend/issues/7140).
+
 ## Consequences
 
 - Any change to secret/variable names or install outcomes must update the implementation and this ADR together.

--- a/docs/ADRs/0060-cross-org-mint-authorization-via-org-variables.md
+++ b/docs/ADRs/0060-cross-org-mint-authorization-via-org-variables.md
@@ -101,3 +101,9 @@ mechanism with repo-level `FULLSEND_FOREIGN_<ROLE>_REPOS` variables.
 Repo-level grants additionally require `actions_variables: read` on the
 target repos (in addition to the `organization_actions_variables: read`
 needed for org-level grants from this ADR).
+
+## Later note (hyphenated roles)
+
+GitHub Actions variable names cannot contain hyphens. Role suffixes now map
+hyphens to underscores (`ci-check` → `FULLSEND_FOREIGN_CI_CHECK_REPOS`) via
+`mintcore.RoleIdentifier`. See [#7140](https://github.com/fullsend-ai/fullsend/issues/7140).

--- a/docs/guides/infrastructure/mint-administration.md
+++ b/docs/guides/infrastructure/mint-administration.md
@@ -692,5 +692,5 @@ If the `[[ratelimits]]` section is removed from `wrangler.toml`, the Worker logs
 - [Standalone Mint](standalone-mint.md) — Running the mint without GCP, with custom agent roles
 - [Infrastructure Reference](infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
 - [CLI Internals](../dev/cli-internals.md) — Command structure and implementation details
-- [Cross-org authorization (ADR 0060)](../../ADRs/0060-cross-org-mint-authorization-via-org-variables.md) — Org-level FOREIGN authorization via `FULLSEND_FOREIGN_<role>_REPOS` org variables
+- [Cross-org authorization (ADR 0060)](../../ADRs/0060-cross-org-mint-authorization-via-org-variables.md) — Org-level FOREIGN authorization via `FULLSEND_FOREIGN_<ROLE>_REPOS` org variables
 - [Repo-level foreign grants (ADR 0083)](../../ADRs/0083-repo-level-foreign-allow-list.md) — Per-repo FOREIGN authorization grants; manage with `fullsend admin foreign` commands

--- a/docs/guides/infrastructure/standalone-mint.md
+++ b/docs/guides/infrastructure/standalone-mint.md
@@ -292,6 +292,8 @@ Valid examples: `scanner`, `deploy-prod`, `code_review`, `my-agent-v2`
 
 Invalid examples: `Scanner` (uppercase), `123scanner` (starts with digit), `my--agent` (double hyphen)
 
+Role-prefixed identifiers (environment variables, GitHub Actions secrets and variables such as `FULLSEND_<ROLE>_APP_PRIVATE_KEY`, `FULLSEND_<ROLE>_CLIENT_ID`, `<ROLE>_FULLSEND_MODEL`, and `FULLSEND_FOREIGN_<ROLE>_REPOS`) map the role with `role.upper().replace("-", "_")`. For `ci-check` that is `CI_CHECK`, so the foreign allow-list variable is `FULLSEND_FOREIGN_CI_CHECK_REPOS` and the model override is `CI_CHECK_FULLSEND_MODEL`. Roles that differ only by hyphen vs underscore (`ci-check` vs `ci_check`) share an identifier.
+
 ### Permissions must match the GitHub App
 
 The permissions in `CUSTOM_ROLE_PERMISSIONS` must be a subset of what the GitHub App is installed with. When the installation lookup includes its granted permissions, custom-role permissions are required by default: if an installation does not grant one, the mint reports the missing permission before making the token request. If GitHub omits that map, the mint preserves the requested permissions and lets the token request validate them. During a built-in permission rollout, only permissions explicitly listed in the mint's `optionalRolePermissions` map may be omitted; see the [permission rollout runbook](infrastructure-reference.md#roll-out-a-github-app-permission).

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1607,8 +1607,7 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 		})
 	} else if mintURL == "" {
 		setup = setup.WithSecretExists(func(role string) (bool, error) {
-			secretName := fmt.Sprintf("FULLSEND_%s_APP_PRIVATE_KEY", strings.ToUpper(role))
-			return client.RepoSecretExists(ctx, org, forge.ConfigRepoName, secretName)
+			return client.RepoSecretExists(ctx, org, forge.ConfigRepoName, roleAppPrivateKeySecret(role))
 		})
 	}
 
@@ -1622,8 +1621,7 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 		})
 	} else if mintURL == "" {
 		setup = setup.WithStoreSecret(func(sctx context.Context, role, pem string) error {
-			secretName := fmt.Sprintf("FULLSEND_%s_APP_PRIVATE_KEY", strings.ToUpper(role))
-			return client.CreateRepoSecret(sctx, org, forge.ConfigRepoName, secretName, pem)
+			return client.CreateRepoSecret(sctx, org, forge.ConfigRepoName, roleAppPrivateKeySecret(role), pem)
 		})
 	}
 
@@ -1642,6 +1640,13 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 
 	printer.Blank()
 	return creds, nil
+}
+
+// roleAppPrivateKeySecret is the .fullsend repo secret that stores a role's
+// GitHub App PEM. Hyphens in the role become underscores so the name is a
+// valid GitHub Actions secret identifier.
+func roleAppPrivateKeySecret(role string) string {
+	return fmt.Sprintf("FULLSEND_%s_APP_PRIVATE_KEY", mintcore.RoleIdentifier(role))
 }
 
 // ensureConfigRepoExists creates the .fullsend config repo if it doesn't

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
+func TestRoleAppPrivateKeySecret(t *testing.T) {
+	assert.Equal(t, "FULLSEND_TRIAGE_APP_PRIVATE_KEY", roleAppPrivateKeySecret("triage"))
+	assert.Equal(t, "FULLSEND_CI_CHECK_APP_PRIVATE_KEY", roleAppPrivateKeySecret("ci-check"))
+}
+
 func TestAdminCommand_HasSubcommands(t *testing.T) {
 	cmd := newAdminCmd()
 	names := make(map[string]bool)

--- a/internal/cli/foreign.go
+++ b/internal/cli/foreign.go
@@ -18,7 +18,9 @@ func newForeignCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "foreign",
 		Short: "Manage cross-org mint authorization on a target org or repo",
-		Long: "Manage FULLSEND_FOREIGN_<role>_REPOS variables that authorize foreign workflows to mint tokens.\n\n" +
+		Long: "Manage FULLSEND_FOREIGN_<ROLE>_REPOS variables that authorize foreign workflows to mint tokens.\n\n" +
+			"<ROLE> is the role name uppercased with hyphens mapped to underscores\n" +
+			"(ci-check → FULLSEND_FOREIGN_CI_CHECK_REPOS).\n\n" +
 			"Without --repo, manages org-level variables (installation-wide grants).\n" +
 			"With --repo, manages repo-level variables (repo-scoped grants).\n\n" +
 			"--repo accepts owner/repo (e.g. acme/api) so --org can be omitted,\n" +

--- a/internal/cli/foreign_test.go
+++ b/internal/cli/foreign_test.go
@@ -30,6 +30,10 @@ func TestParseForeignVariableName(t *testing.T) {
 	if !ok || role != "e2e" {
 		t.Fatalf("got role=%q ok=%v", role, ok)
 	}
+	role, ok = parseForeignVariableName("FULLSEND_FOREIGN_CI_CHECK_REPOS")
+	if !ok || role != "ci_check" {
+		t.Fatalf("hyphen-mapped identifier: got role=%q ok=%v", role, ok)
+	}
 	if _, ok := parseForeignVariableName("FULLSEND_MINT_URL"); ok {
 		t.Fatal("expected non-foreign name to fail")
 	}
@@ -268,6 +272,16 @@ func TestForeignAllowCmd_CreatesVariable(t *testing.T) {
 	require.NoError(t, err)
 	_ = out
 	assert.Equal(t, "fullsend-ai/fullsend", state.vars["FULLSEND_FOREIGN_E2E_REPOS"])
+}
+
+func TestForeignAllowCmd_HyphenatedRole(t *testing.T) {
+	state := &foreignVarState{vars: map[string]string{}}
+	srv := httptest.NewServer(state.handler(t))
+	defer srv.Close()
+
+	_, err := runForeignCmd(t, srv.URL, "allow", "--org", "pool-org", "--role", "ci-check", "--caller", "fullsend-ai/fullsend")
+	require.NoError(t, err)
+	assert.Equal(t, "fullsend-ai/fullsend", state.vars["FULLSEND_FOREIGN_CI_CHECK_REPOS"])
 }
 
 func TestForeignAllowCmd_AppendsCaller(t *testing.T) {

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -1217,9 +1217,9 @@ func runGitHubStatus(ctx context.Context, client forge.Client, printer *ui.Print
 		printer.StepWarn("Could not list org variables: " + err.Error())
 	} else {
 		for _, v := range vars {
-			if role, ok := parseForeignVariableName(v.Name); ok {
+			if _, ok := parseForeignVariableName(v.Name); ok {
 				entries := mintcore.ParseForeignAllowlist(v.Value)
-				printer.StepDone(fmt.Sprintf("%s (%s): %s", v.Name, role, strings.Join(entries, ", ")))
+				printer.StepDone(fmt.Sprintf("%s: %s", v.Name, strings.Join(entries, ", ")))
 			}
 		}
 	}

--- a/internal/cli/github_test.go
+++ b/internal/cli/github_test.go
@@ -743,6 +743,29 @@ func TestRunGitHubStatus_BasicReport(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRunGitHubStatus_ForeignVariableOmitsParsedRole(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{
+		{Name: ".fullsend", FullName: "acme/.fullsend"},
+	}
+	client.OrgVariables = map[string]bool{
+		"acme/FULLSEND_MINT_URL":               true,
+		"acme/FULLSEND_FOREIGN_CI_CHECK_REPOS": true,
+	}
+	client.OrgVariableValues = map[string]string{
+		"acme/FULLSEND_FOREIGN_CI_CHECK_REPOS": "fullsend-ai/fullsend",
+	}
+	var buf strings.Builder
+	printer := ui.New(&buf)
+
+	err := runGitHubStatus(context.Background(), client, printer, "acme")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "FULLSEND_FOREIGN_CI_CHECK_REPOS: fullsend-ai/fullsend")
+	assert.NotContains(t, out, "(ci_check)")
+	assert.NotContains(t, out, "(ci-check)")
+}
+
 func TestRunGitHubStatus_NoConfigRepo(t *testing.T) {
 	client := forge.NewFakeClient()
 	printer := ui.New(&discardWriter{})

--- a/internal/dispatch/cf/provisioner.go
+++ b/internal/dispatch/cf/provisioner.go
@@ -663,8 +663,7 @@ func validateSourceDir(dir string) error {
 // PEM key. Follows the convention <ROLE>_APP_PEM with hyphens mapped
 // to underscores (CF secret names must be valid JS identifiers).
 func pemSecretName(role string) string {
-	mapped := mintcore.PemSecretRole(role)
-	return strings.ToUpper(strings.ReplaceAll(mapped, "-", "_")) + "_APP_PEM"
+	return mintcore.RoleIdentifier(mintcore.PemSecretRole(role)) + "_APP_PEM"
 }
 
 // ValidateWorkerName checks if a string is a valid CF Worker name.

--- a/internal/dispatch/cf/provisioner_test.go
+++ b/internal/dispatch/cf/provisioner_test.go
@@ -881,6 +881,8 @@ func TestPemSecretName(t *testing.T) {
 		{"coder", "CODER_APP_PEM"},
 		{"triage", "TRIAGE_APP_PEM"},
 		{"review", "REVIEW_APP_PEM"},
+		{"ci-check", "CI_CHECK_APP_PEM"},
+		{"fix", "CODER_APP_PEM"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.role, func(t *testing.T) {

--- a/internal/dispatch/gcf/mintsrc/mintcore/foreign.go.embed
+++ b/internal/dispatch/gcf/mintsrc/mintcore/foreign.go.embed
@@ -12,7 +12,7 @@ const (
 
 // ForeignVariableName returns the org variable name for cross-org allowlist policy.
 func ForeignVariableName(role string) string {
-	return foreignVarPrefix + strings.ToUpper(role) + foreignVarSuffix
+	return foreignVarPrefix + RoleIdentifier(role) + foreignVarSuffix
 }
 
 // ParseForeignAllowlist splits a comma-separated FOREIGN variable value into entries.

--- a/internal/dispatch/gcf/mintsrc/mintcore/patterns.go.embed
+++ b/internal/dispatch/gcf/mintsrc/mintcore/patterns.go.embed
@@ -46,6 +46,17 @@ func ValidateRoleName(role string) error {
 	return nil
 }
 
+// RoleIdentifier maps a role name onto the identifier used in environment
+// variables, GitHub Actions secrets/variables, and similar. Hyphens become
+// underscores and the result is uppercased so the identifier is a valid
+// bash/Actions name. For example, "ci-check" becomes "CI_CHECK".
+//
+// Roles that differ only by hyphen vs underscore (ci-check vs ci_check)
+// share an identifier.
+func RoleIdentifier(role string) string {
+	return strings.ToUpper(strings.ReplaceAll(role, "-", "_"))
+}
+
 // ValidateLevelName checks that a privilege level name matches LevelPattern.
 // Empty names are allowed (callers treat them as "omitted").
 func ValidateLevelName(level string) error {

--- a/internal/layers/secrets.go
+++ b/internal/layers/secrets.go
@@ -3,9 +3,9 @@ package layers
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/fullsend-ai/fullsend/internal/forge"
+	"github.com/fullsend-ai/fullsend/internal/mintcore"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
@@ -181,9 +181,9 @@ func (s *SecretsLayer) Analyze(ctx context.Context) (*LayerReport, error) {
 }
 
 func secretName(role string) string {
-	return fmt.Sprintf("FULLSEND_%s_APP_PRIVATE_KEY", strings.ToUpper(role))
+	return fmt.Sprintf("FULLSEND_%s_APP_PRIVATE_KEY", mintcore.RoleIdentifier(role))
 }
 
 func variableName(role string) string {
-	return fmt.Sprintf("FULLSEND_%s_CLIENT_ID", strings.ToUpper(role))
+	return fmt.Sprintf("FULLSEND_%s_CLIENT_ID", mintcore.RoleIdentifier(role))
 }

--- a/internal/layers/secrets_test.go
+++ b/internal/layers/secrets_test.go
@@ -45,6 +45,12 @@ func TestSecretsLayer_Name(t *testing.T) {
 	assert.Equal(t, "secrets", layer.Name())
 }
 
+func TestSecretAndVariableNames_HyphenatedRole(t *testing.T) {
+	assert.Equal(t, "FULLSEND_CI_CHECK_APP_PRIVATE_KEY", secretName("ci-check"))
+	assert.Equal(t, "FULLSEND_CI_CHECK_CLIENT_ID", variableName("ci-check"))
+	assert.Equal(t, "FULLSEND_TRIAGE_APP_PRIVATE_KEY", secretName("triage"))
+}
+
 func TestSecretsLayer_Install_StoresSecrets(t *testing.T) {
 	client := &forge.FakeClient{}
 	agents := twoAgents()

--- a/internal/mintcore/foreign.go
+++ b/internal/mintcore/foreign.go
@@ -12,7 +12,7 @@ const (
 
 // ForeignVariableName returns the org variable name for cross-org allowlist policy.
 func ForeignVariableName(role string) string {
-	return foreignVarPrefix + strings.ToUpper(role) + foreignVarSuffix
+	return foreignVarPrefix + RoleIdentifier(role) + foreignVarSuffix
 }
 
 // ParseForeignAllowlist splits a comma-separated FOREIGN variable value into entries.

--- a/internal/mintcore/foreign_test.go
+++ b/internal/mintcore/foreign_test.go
@@ -6,6 +6,9 @@ func TestForeignVariableName(t *testing.T) {
 	if got := ForeignVariableName("e2e"); got != "FULLSEND_FOREIGN_E2E_REPOS" {
 		t.Fatalf("got %q", got)
 	}
+	if got := ForeignVariableName("ci-check"); got != "FULLSEND_FOREIGN_CI_CHECK_REPOS" {
+		t.Fatalf("hyphenated role: got %q", got)
+	}
 }
 
 func TestParseForeignAllowlist(t *testing.T) {

--- a/internal/mintcore/patterns.go
+++ b/internal/mintcore/patterns.go
@@ -46,6 +46,17 @@ func ValidateRoleName(role string) error {
 	return nil
 }
 
+// RoleIdentifier maps a role name onto the identifier used in environment
+// variables, GitHub Actions secrets/variables, and similar. Hyphens become
+// underscores and the result is uppercased so the identifier is a valid
+// bash/Actions name. For example, "ci-check" becomes "CI_CHECK".
+//
+// Roles that differ only by hyphen vs underscore (ci-check vs ci_check)
+// share an identifier.
+func RoleIdentifier(role string) string {
+	return strings.ToUpper(strings.ReplaceAll(role, "-", "_"))
+}
+
 // ValidateLevelName checks that a privilege level name matches LevelPattern.
 // Empty names are allowed (callers treat them as "omitted").
 func ValidateLevelName(level string) error {

--- a/internal/mintcore/patterns_test.go
+++ b/internal/mintcore/patterns_test.go
@@ -1,0 +1,23 @@
+package mintcore
+
+import "testing"
+
+func TestRoleIdentifier(t *testing.T) {
+	tests := []struct {
+		role string
+		want string
+	}{
+		{"triage", "TRIAGE"},
+		{"ci-check", "CI_CHECK"},
+		{"deploy-prod", "DEPLOY_PROD"},
+		{"my-role", "MY_ROLE"},
+		{"my_role", "MY_ROLE"},
+		{"my-custom_role", "MY_CUSTOM_ROLE"},
+		{"e2e", "E2E"},
+	}
+	for _, tc := range tests {
+		if got := RoleIdentifier(tc.role); got != tc.want {
+			t.Errorf("RoleIdentifier(%q) = %q, want %q", tc.role, got, tc.want)
+		}
+	}
+}

--- a/internal/scaffold/fullsend-repo/.github/scripts/setup-agent-env.sh
+++ b/internal/scaffold/fullsend-repo/.github/scripts/setup-agent-env.sh
@@ -9,7 +9,9 @@
 # allowlisted FULLSEND_* override variables are exported too, so a repo can
 # switch a role's runtime/model/effort with a repository variable instead of
 # a pull request. A role-prefixed variable (TRIAGE_FULLSEND_MODEL) wins over
-# the plain one (FULLSEND_MODEL). Values must be single-line and limited to
+# the plain one (FULLSEND_MODEL). AGENT_PREFIX is the role identifier plus '_'
+# (uppercase, hyphens mapped to underscores: ci-check → CI_CHECK_). Values must
+# be single-line and limited to
 # the characters a model id / runtime name can contain; anything else is
 # skipped with a warning. fullsend validates the values themselves.
 # The whole variable map is passed (not individual keys) because the

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -1379,6 +1379,20 @@ func TestHarnessRunResolvesBotIdentity(t *testing.T) {
 	assert.Less(t, identityIndex, setupIndex, "harness-run must resolve identity before agent environment setup")
 }
 
+// TestHarnessRunMapsHyphensInRoleIdentifiers pins the custom-harness env-prefix
+// mapping so a hyphenated role (ci-check) becomes a valid bash identifier
+// (CI_CHECK_), matching mintcore.RoleIdentifier (#7140).
+func TestHarnessRunMapsHyphensInRoleIdentifiers(t *testing.T) {
+	content := string(loadRepoFile(".github/workflows/reusable-dispatch.yml")(t))
+	harnessStart := strings.Index(content, "  harness-run:\n")
+	require.NotEqual(t, -1, harnessStart, "reusable-dispatch.yml must define harness-run")
+	harnessJob := content[harnessStart:]
+
+	setup := extractStepSection(t, harnessJob, "Setup agent environment")
+	assert.Contains(t, setup, `ROLE_UPPER=$(echo "${MATRIX_ROLE}" | tr '[:lower:]' '[:upper:]' | tr '-' '_')`,
+		"Setup agent environment must uppercase the role and map hyphens to underscores")
+}
+
 // TestLayeredDirsMatchWorkspacePreparation pins the LAYERED_DIRS list in
 // every workspace-preparation step to scaffold.layeredDirs. The scaffold
 // skips these directories at install time on the promise that workspace


### PR DESCRIPTION
## Summary

Custom harness roles with hyphens (`ci-check`) failed in **Setup agent environment** because the dispatch job uppercased `matrix.role` and exported names like `CI-CHECK_TARGET_REPO_DIR`, which bash rejects. Role-prefixed identifiers now share `mintcore.RoleIdentifier`: uppercase the role and replace hyphens with underscores (`ci-check` → `CI_CHECK`).

## Related Issue

Fixes #7140

## Changes

- Map hyphens to underscores in the custom-harness env prefix (`reusable-dispatch.yml`) so `ci-check` becomes `CI_CHECK_TARGET_REPO_DIR` / `CI_CHECK_`.
- Use the same helper for GitHub App secrets/variables (`FULLSEND_<ROLE>_APP_PRIVATE_KEY`, `FULLSEND_<ROLE>_CLIENT_ID`), FOREIGN allow-lists (`FULLSEND_FOREIGN_<ROLE>_REPOS`), and CF PEM names.
- Document the mapping once, in standalone-mint role naming rules. ADR 0014 and ADR 0060 get short later-notes; other guides do not restate that hyphens are allowed (the examples already show them).
- `fullsend github status` prints FOREIGN variable names without a reconstructed role in parentheses (`CI_CHECK` is not uniquely `ci-check` or `ci_check`).

## Testing

- [x] `make lint` passes (stage changes first, then run)
- [x] Tests added/updated for new or modified logic (`RoleIdentifier`, hyphenated foreign allow, `github status` output, dispatch hyphen mapping pin)

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it
