### PR TITLE
config: raise code agent timeout to 60 minutes

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -24,6 +24,7 @@ agents:
     - name: code
       runtime: pi
       model: xai/grok-4.6
+      timeout_minutes: 60
     - name: fix
       model: sonnet
     - name: prioritize


### PR DESCRIPTION
## What

Adds `timeout_minutes: 60` to the `code` agent entry in `.fullsend/config.yaml`, overriding the base code-agent harness default of 35 minutes (`fullsend-ai/agents` → `harness/code.yaml`).

## Why

This repo overrides the code agent to `runtime: pi` / `model: xai/grok-4.6`, which is slower than the `sonnet`/`opus` defaults the other agents use. On [#7218](https://github.com/fullsend-ai/fullsend/issues/7218), the code agent ([run 34516625497](https://github.com/fullsend-ai/fullsend/actions/runs/34516625497)) implemented the change in full — 16 files, 806 insertions — and staged everything, but was killed at the 35-minute budget ~17s before `git commit`. No commit meant no PR, and the run was misreported as "✅ Success / no changes needed" (tracked separately in fullsend-ai/agents#1256).

Raising the code agent's budget to 60 minutes gives grok-4.6 room to finish and commit within a single iteration.