### PR TITLE
docs(#6629): document packages without test files

### DIFF
--- a/docs/contributing/go-code.md
+++ b/docs/contributing/go-code.md
@@ -89,6 +89,13 @@ of `codecov/patch` failures on first push.
      | sed 's|^|./|'
    ```
 
+   Before running coverage, check each affected package for `_test.go`
+   files; if none exist, add direct unit tests for the changed code
+   first, since missing or zero coverage cannot satisfy the patch
+   coverage threshold. See the
+   [check-patch-coverage skill](../../skills/check-patch-coverage/SKILL.md#3-check-for-packages-with-no-test-files)
+   for the detection script.
+
 3. **Run tests with a cover profile** for the affected packages:
 
    ```bash


### PR DESCRIPTION
## Summary

The local patch-coverage guide skips the missing-test-file check already present in the coverage skill. Add a short note before coverage runs so contributors create direct unit tests when an affected package has no `_test.go` files.

## Related Issue

Fixes #6629

## Changes

- Link to the existing detection script instead of copying it.
- Preserve the numbered steps, retry reference, coverage threshold, and skip conditions.

## Testing

- [x] `make lint` passes after staging the change, including Markdown link and fragment validation.
- [x] `git diff --cached --check` passes.
- Tests added/updated: not applicable; documentation-only change.
- The issue's next-agent-run criterion remains unverified until a subsequent coverage-skill change is reviewed.

## Pre-submission review

- Verified: an independent reviewer inspected the full staged diff, adjacent documentation, linked issue history, VitePress link handling, policy, and this PR description; no actionable findings.
- Verified: the callout appears before coverage execution and matches the skill's missing-test remediation; adjacent coverage instructions and skip conditions were reviewed.
- Not applicable: dispatch gates, cross-forge producer/consumer values, adversarial re-review scenarios, prompt/input surfaces, and orchestration behavioral tests. This change only adds contributor documentation and does not alter review behavior or contracts.
- Historical context: #6301 added the skill check; #6163 addressed a similar parallel-documentation gap. This change links the existing script and preserves the prior staging warning.

## Checklist

- [x] PR title follows Conventional Commits (`docs`, no breaking change).
- [x] Commit is signed off for the human-directed contribution and includes the Codex co-author trailer.
- [x] Contribution prepared with Codex assistance; scope and adjacent documentation reviewed.
