### PR TITLE
docs(#6966): point the CLI overview and customizing guide at `fullsend agent new`

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -14,7 +14,7 @@ Download the latest binary from [GitHub Releases](https://github.com/fullsend-ai
 
 | Command group | Description |
 |--------------|-------------|
-| [`fullsend agent`](agent.md) | Manage agent registrations — add, list, set, update, remove |
+| [`fullsend agent`](agent.md) | Generate a custom agent and manage agent registrations — new, add, list, set, update, remove |
 | [`fullsend github`](github.md) | Configure GitHub orgs and repos — setup, enrollment, day-2 operations |
 | [`fullsend inference`](inference.md) | Manage inference credentials — GCP Workload Identity Federation for Agent Platform, and OpenAI WIF enrolment for GPT on pi or codex |
 | [`fullsend mint`](mint.md) | Deploy and manage the OIDC token mint service |

--- a/docs/guides/user/customizing-overview.md
+++ b/docs/guides/user/customizing-overview.md
@@ -122,7 +122,14 @@ table, and a validated walkthrough.
   schemas/my-agent-result.schema.json  # What the agent must produce
   scripts/post-my-agent.sh      # Turns the result into one comment
   policies/base.yaml            # Sandbox policy (written when absent)
+  providers/vertex-ai.yaml      # Network access the role needs (written when absent)
+  providers/github-ro.yaml
+  profiles/fullsend-vertex-ai.yaml
+  profiles/fullsend-github-ro.yaml
 ```
+
+The provider and profile pair depends on `--role`; the one shown is for
+`triage`. See the [role table](../../cli/agent.md#agent-new) for the others.
 
 The agent runs automatically when matching events arrive. It runs on the
 hosted mint as long as it keeps a built-in `role:`; a distinct GitHub App

--- a/docs/guides/user/customizing-overview.md
+++ b/docs/guides/user/customizing-overview.md
@@ -12,7 +12,7 @@ so you can pick the right one.
 | Teach agents your coding style, test commands, or architecture rules | [AGENTS.md](#agentsmd) | Low |
 | Give an agent domain-specific knowledge or a new capability | [Skills](#skills) | Low |
 | Change model, timeout, image, or add env vars to an existing agent | [Harness configuration](#harness-configuration) | Medium |
-| Build a completely new agent with its own trigger, scripts, and schema | [Bring Your Own Agent](#bring-your-own-agent) | High |
+| Build a completely new agent with its own trigger, scripts, and schema | [Bring Your Own Agent](#bring-your-own-agent) | Medium with `fullsend agent new`, high by hand |
 
 Start at the top and move down only when a lighter option doesn't cover your
 needs. Most teams only need AGENTS.md and perhaps a skill or two.
@@ -103,21 +103,31 @@ adding skills via harness, extending the sandbox image, disabling agents.
 ## Bring Your Own Agent
 
 When you need a completely new agent — with its own trigger, scripts, and
-output schema — build one from scratch. It still runs on the hosted mint if it
-assumes a built-in `role:`; a distinct GitHub App identity requires your own
-mint (see [Custom Agent Identity](custom-agent-identity.md)):
+output schema — start with the generator:
+
+```bash
+fullsend agent new my-agent --fullsend-dir .fullsend --role triage
+```
+
+It writes the files below, registers the agent in `config.yaml`, and checks
+that the result loads. You then edit `agents/my-agent.md`, the instructions the
+agent follows; everything else is ready to run. See
+[`fullsend agent new`](../../cli/agent.md#agent-new) for the flags, the role
+table, and a validated walkthrough.
 
 ```
 .fullsend/
-  harness/my-agent.yaml    # Execution config
-  agents/my-agent.md       # Agent prompt
-  policies/base.yaml       # Sandbox policy
-  scripts/pre-my-agent.sh  # Data fetching (before sandbox)
-  scripts/post-my-agent.sh # Action execution (after sandbox)
+  harness/my-agent.yaml         # Execution config, including the trigger
+  agents/my-agent.md            # Agent prompt — the file you edit
+  schemas/my-agent-result.schema.json  # What the agent must produce
+  scripts/post-my-agent.sh      # Turns the result into one comment
+  policies/base.yaml            # Sandbox policy (written when absent)
 ```
 
-Register it in `config.yaml` and it runs automatically when matching
-events arrive.
+The agent runs automatically when matching events arrive. It runs on the
+hosted mint as long as it keeps a built-in `role:`; a distinct GitHub App
+identity requires your own mint (see
+[Custom Agent Identity](custom-agent-identity.md)).
 
 **Best for:** entirely new agent roles, custom triggers, specialized
 output schemas.


### PR DESCRIPTION
Follow-up to #6972, requested by @ralphbean in review: mention `fullsend agent new` where readers look for commands and customization options.

## What changed

- `docs/cli/README.md`: the `fullsend agent` row now says the group generates a custom agent as well as managing registrations, and lists `new` with the other verbs.
- `docs/guides/user/customizing-overview.md`: the decision-guide row and the Bring Your Own Agent section start with `fullsend agent new`, show the tree it writes, name the one file the author edits, and link to the command reference. The mint/identity note is kept.

## How to check

Both pages render as before; the links resolve to `docs/cli/agent.md#agent-new`, which #6972 added. No code changes.

Part of #6966.