### PR TITLE
fix(#6966): flatten a rejected status before the generated post-script logs it

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -134,6 +134,8 @@ command refuses an unknown one up front. The hosted mint serves these:
 | `retro` | `actions:read`, `contents:read`, `pull_requests:write`, `issues:write`, `metadata:read` | vertex-ai, github-ro, github-artifacts |
 | `prioritize` | `contents:read`, `issues:write`, `organization_projects:write`, `metadata:read` | vertex-ai, github-ro |
 
+A `review` agent also gets `readonly_repo: true`, so the repository is mounted read-only in the sandbox: the prompt's "do not edit files" is enforced, not requested. That matches the review harness in fullsend-ai/agents.
+
 Pick the role whose permissions fit what the agent does. An unknown role fails
 immediately with this table, rather than returning `403` from the mint the
 first time the agent runs. To use a role the hosted mint does not serve, you

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -149,6 +149,7 @@ fullsend
 │       ├── --number <int>                   #     Issue number
 │       ├── --marker <string>                #     Sticky marker for idempotent updates (HTML comment or Jira property)
 │       ├── --keep-history                   #     Append previous content as collapsed history (default true)
+│       ├── --only-if-exists                 #     Update an existing marked comment, never create one
 │       └── --fullsend-dir <path>            #     .fullsend config directory (resolves keep_history default)
 ├── post-review                              # Post PR/MR review comments to GitHub or GitLab
 │   ├── --forge <forge>                      #   Forge backend: github (default) or gitlab

--- a/docs/guides/user/issues-commands.md
+++ b/docs/guides/user/issues-commands.md
@@ -87,6 +87,7 @@ echo "Triage complete. See PR #99." | fullsend issues post-comment \
 | `--jira-email` | Jira only | Jira user email for auth (default: `$JIRA_USER_EMAIL`) |
 | `--dry-run` | No | Print what would be posted without making API calls |
 | `--keep-history` | No | Append previous content as collapsed history blocks (default: `true`; set `false` to replace in-place) |
+| `--only-if-exists` | No | Update an existing comment with this marker but never create one. Use it for an all-clear result, so a findings comment from an earlier run is replaced while a clean first run posts nothing. |
 | `--fullsend-dir` | No | Path to `.fullsend` config directory (sources defaults from its `config.yaml` when flags are omitted) |
 
 ### Jira marker storage

--- a/internal/agentnew/postscript_exec_test.go
+++ b/internal/agentnew/postscript_exec_test.go
@@ -164,3 +164,39 @@ func TestGeneratedPostScriptFlattensAnInvalidStatusBeforeLogging(t *testing.T) {
 		t.Fatalf("rejection must be a single log line, got:\n%s", stderr)
 	}
 }
+
+// TestGeneratedPostScriptDoesNotExpandEscapesUnderXpgEcho runs the script
+// with bash's xpg_echo option on, where `echo` interprets backslash escapes.
+// A status carrying a literal backslash-n must still be logged on one line.
+func TestGeneratedPostScriptDoesNotExpandEscapesUnderXpgEcho(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; the generated post-script needs it")
+	}
+	script := renderPostScriptTo(t, t.TempDir())
+	runDir := writeRunDir(t, map[string]any{
+		"iteration-1": map[string]any{
+			"status":  `bogus\n::error::injected`,
+			"summary": "s",
+			"comment": "c",
+		},
+	})
+	cmd := exec.Command("bash", "-O", "xpg_echo", script)
+	cmd.Dir = runDir
+	cmd.Env = append(os.Environ(),
+		"ISSUE_URL=https://github.com/fullsend-ai/demo/pull/99",
+		"GH_TOKEN=test-token",
+		DryRunEnvVar("lint-docs")+"=1",
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected the script to reject an invalid status")
+	}
+	out := strings.TrimSpace(stderr.String())
+	if strings.Count(out, "\n") != 0 {
+		t.Fatalf("backslash escapes were expanded into a new log line:\n%s", out)
+	}
+	if !strings.Contains(out, `bogus\n::error::injected`) {
+		t.Fatalf("expected the literal value on the single line, got: %q", out)
+	}
+}

--- a/internal/agentnew/postscript_exec_test.go
+++ b/internal/agentnew/postscript_exec_test.go
@@ -225,3 +225,46 @@ func TestGeneratedPostScriptOkPostsNothingWithoutAnEarlierComment(t *testing.T) 
 		t.Fatalf("ok under dry run must print no comment body, got:\n%s", stdout)
 	}
 }
+
+// TestGeneratedPostScriptOkReplacesEarlierFindingsViaOnlyIfExists runs the
+// live ok path (no dry run) against a stub `fullsend` on PATH that records
+// its arguments. The script must delegate the "is there an earlier findings
+// comment" decision to `fullsend issues post-comment --only-if-exists`
+// rather than reimplementing it with raw API calls in shell.
+func TestGeneratedPostScriptOkReplacesEarlierFindingsViaOnlyIfExists(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; the generated post-script needs it")
+	}
+	binDir := t.TempDir()
+	argsFile := filepath.Join(binDir, "args")
+	stub := "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > " + argsFile + "\ncat >/dev/null\n"
+	if err := os.WriteFile(filepath.Join(binDir, "fullsend"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := renderPostScriptTo(t, t.TempDir())
+	runDir := writeRunDir(t, map[string]any{
+		"iteration-1": map[string]any{"status": "ok", "summary": "All clear", "comment": "All added documentation links resolve."},
+	})
+	cmd := exec.Command("bash", script)
+	cmd.Dir = runDir
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"ISSUE_URL=https://github.com/fullsend-ai/demo/pull/99",
+		"GH_TOKEN=test-token",
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ok live path must exit 0, got %v; stderr:\n%s", err, stderr.String())
+	}
+	got, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("the script never invoked fullsend on the ok path: %v; stderr:\n%s", err, stderr.String())
+	}
+	args := string(got)
+	for _, want := range []string{"issues\npost-comment\n", "--only-if-exists\n", "--marker\n", "fullsend-ai/demo\n", "99\n"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("fullsend was called without %q; args:\n%s", strings.TrimSpace(want), args)
+		}
+	}
+}

--- a/internal/agentnew/postscript_exec_test.go
+++ b/internal/agentnew/postscript_exec_test.go
@@ -137,6 +137,9 @@ func TestGeneratedPostScriptRunsFromTheRunDirectory(t *testing.T) {
 // the script's stderr lands in the runner log where `::` at line start is
 // interpreted as a command.
 func TestGeneratedPostScriptFlattensAnInvalidStatusBeforeLogging(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; the generated post-script needs it")
+	}
 	script := renderPostScriptTo(t, t.TempDir())
 	runDir := writeRunDir(t, map[string]any{
 		"iteration-1": map[string]any{

--- a/internal/agentnew/postscript_exec_test.go
+++ b/internal/agentnew/postscript_exec_test.go
@@ -200,3 +200,28 @@ func TestGeneratedPostScriptDoesNotExpandEscapesUnderXpgEcho(t *testing.T) {
 		t.Fatalf("expected the literal value on the single line, got: %q", out)
 	}
 }
+
+// TestGeneratedPostScriptOkPostsNothingWithoutAnEarlierComment pins the ok
+// path under dry run: the script exits 0 and says nothing was posted. The
+// live path additionally looks for an earlier marker comment and replaces it
+// with the all-clear; that needs the forge, so it is exercised by the
+// example's script test in fullsend-ai/agents, not here.
+func TestGeneratedPostScriptOkPostsNothingWithoutAnEarlierComment(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; the generated post-script needs it")
+	}
+	script := renderPostScriptTo(t, t.TempDir())
+	runDir := writeRunDir(t, map[string]any{
+		"iteration-1": map[string]any{"status": "ok", "summary": "All clear", "comment": "All added documentation links resolve."},
+	})
+	stdout, stderr, err := runPostScript(t, script, runDir)
+	if err != nil {
+		t.Fatalf("ok status must exit 0, got %v; stderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "nothing to post") {
+		t.Fatalf("expected the nothing-to-post notice, got stderr:\n%s", stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("ok under dry run must print no comment body, got:\n%s", stdout)
+	}
+}

--- a/internal/agentnew/postscript_exec_test.go
+++ b/internal/agentnew/postscript_exec_test.go
@@ -130,3 +130,34 @@ func TestGeneratedPostScriptRunsFromTheRunDirectory(t *testing.T) {
 		}
 	})
 }
+
+// TestGeneratedPostScriptFlattensAnInvalidStatusBeforeLogging feeds a status
+// that carries a newline and a workflow-command prefix. The rejection message
+// must stay on one line and must not reproduce the injected line, because
+// the script's stderr lands in the runner log where `::` at line start is
+// interpreted as a command.
+func TestGeneratedPostScriptFlattensAnInvalidStatusBeforeLogging(t *testing.T) {
+	script := renderPostScriptTo(t, t.TempDir())
+	runDir := writeRunDir(t, map[string]any{
+		"iteration-1": map[string]any{
+			"status":  "bogus\n::error::injected",
+			"summary": "s",
+			"comment": "c",
+		},
+	})
+	_, stderr, err := runPostScript(t, script, runDir)
+	if err == nil {
+		t.Fatal("expected the script to reject an invalid status")
+	}
+	if !strings.Contains(stderr, "status must be ok, findings or error") {
+		t.Fatalf("expected the status rejection, got stderr:\n%s", stderr)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		if strings.HasPrefix(line, "::") {
+			t.Fatalf("model-supplied status reached the log as its own line: %q", line)
+		}
+	}
+	if strings.Count(strings.TrimSpace(stderr), "\n") != 0 {
+		t.Fatalf("rejection must be a single log line, got:\n%s", stderr)
+	}
+}

--- a/internal/agentnew/postscript_exec_test.go
+++ b/internal/agentnew/postscript_exec_test.go
@@ -237,7 +237,7 @@ func TestGeneratedPostScriptOkReplacesEarlierFindingsViaOnlyIfExists(t *testing.
 	}
 	binDir := t.TempDir()
 	argsFile := filepath.Join(binDir, "args")
-	stub := "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > " + argsFile + "\ncat >/dev/null\n"
+	stub := "#!/usr/bin/env bash\nif [[ \"$*\" == *--help* ]]; then echo '  --only-if-exists   update an existing comment but never create one'; exit 0; fi\nprintf '%s\\n' \"$@\" > " + argsFile + "\ncat >/dev/null\n"
 	if err := os.WriteFile(filepath.Join(binDir, "fullsend"), []byte(stub), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -266,5 +266,46 @@ func TestGeneratedPostScriptOkReplacesEarlierFindingsViaOnlyIfExists(t *testing.
 		if !strings.Contains(args, want) {
 			t.Errorf("fullsend was called without %q; args:\n%s", strings.TrimSpace(want), args)
 		}
+	}
+}
+
+// TestGeneratedPostScriptOkOnAnOlderFullsendPostsNothing pins the
+// degradation path: the runner's fullsend is pinned by the repository, not
+// by the CLI that generated the script, so when its post-comment has no
+// --only-if-exists the ok path must post nothing and exit 0 rather than fail
+// on an unknown flag.
+func TestGeneratedPostScriptOkOnAnOlderFullsendPostsNothing(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; the generated post-script needs it")
+	}
+	binDir := t.TempDir()
+	argsFile := filepath.Join(binDir, "args")
+	// An older CLI: --help lists no --only-if-exists, and any real call
+	// with that flag would fail — so the stub fails loudly if invoked to post.
+	stub := "#!/usr/bin/env bash\nif [[ \"$*\" == *--help* ]]; then echo '  --dry-run   print what would be posted'; exit 0; fi\nprintf '%s\\n' \"$@\" > " + argsFile + "\necho 'Error: unknown flag: --only-if-exists' >&2; exit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "fullsend"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := renderPostScriptTo(t, t.TempDir())
+	runDir := writeRunDir(t, map[string]any{
+		"iteration-1": map[string]any{"status": "ok", "summary": "All clear", "comment": "All added documentation links resolve."},
+	})
+	cmd := exec.Command("bash", script)
+	cmd.Dir = runDir
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"ISSUE_URL=https://github.com/fullsend-ai/demo/pull/99",
+		"GH_TOKEN=test-token",
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ok on an older fullsend must exit 0, got %v; stderr:\n%s", err, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "nothing to post") {
+		t.Fatalf("expected the nothing-to-post notice, got:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(argsFile); err == nil {
+		t.Fatalf("an older fullsend must not be asked to post on the ok path")
 	}
 }

--- a/internal/agentnew/render.go
+++ b/internal/agentnew/render.go
@@ -105,6 +105,7 @@ func buildHarness(opts Options, role Role) (*harness.Harness, error) {
 		Effort:         opts.Effort,
 		PostScript:     "scripts/post-" + opts.Name + ".sh",
 		TimeoutMinutes: opts.TimeoutMinutes,
+		ReadonlyRepo:   role.ReadonlyRepo,
 		Trigger:        opts.Trigger,
 		Env: &harness.EnvConfig{
 			Runner: map[string]string{

--- a/internal/agentnew/render_test.go
+++ b/internal/agentnew/render_test.go
@@ -327,6 +327,12 @@ func TestRoleImageReachesTheHarness(t *testing.T) {
 		if h.OpenShell == nil || !reflect.DeepEqual(h.OpenShell.Profiles, role.Profiles) {
 			t.Errorf("role %q: profiles = %v, want %v", name, h.OpenShell, role.Profiles)
 		}
+		// readonly_repo must survive into the emitted YAML, not only sit on
+		// the Role struct: a generated review harness that ships writable
+		// turns "do not edit files" back into a request.
+		if h.ReadonlyRepo != role.ReadonlyRepo || h.ReadonlyRepo != (name == "review") {
+			t.Errorf("role %q: readonly_repo = %v, want %v", name, h.ReadonlyRepo, name == "review")
+		}
 		seen[role.Image] = true
 	}
 	// Both image constants must be reachable, or one is dead configuration.

--- a/internal/agentnew/roles.go
+++ b/internal/agentnew/roles.go
@@ -38,6 +38,10 @@ type Role struct {
 	Profiles []string
 	// Image is the sandbox image this role's agents run under.
 	Image string
+	// ReadonlyRepo mirrors the fleet: the review harness mounts the target
+	// repository read-only so the prompt's "do not edit files" is enforced,
+	// not requested. Set for roles whose fleet harness sets `readonly_repo`.
+	ReadonlyRepo bool
 }
 
 // roleTable is the set of roles `agent new` will generate for. Excluded on
@@ -60,9 +64,10 @@ var roleTable = map[string]Role{
 			"contents": "read", "pull_requests": "write", "issues": "write",
 			"checks": "read", "metadata": "read",
 		},
-		Providers: []string{"providers/vertex-ai.yaml", "providers/github-ro.yaml"},
-		Profiles:  []string{"profiles/fullsend-vertex-ai.yaml", "profiles/fullsend-github-ro.yaml"},
-		Image:     config.DefaultCodeImage,
+		Providers:    []string{"providers/vertex-ai.yaml", "providers/github-ro.yaml"},
+		Profiles:     []string{"profiles/fullsend-vertex-ai.yaml", "profiles/fullsend-github-ro.yaml"},
+		Image:        config.DefaultCodeImage,
+		ReadonlyRepo: true,
 	},
 	"coder": {
 		Name: "coder",

--- a/internal/agentnew/roles_test.go
+++ b/internal/agentnew/roles_test.go
@@ -126,3 +126,16 @@ func TestCoderUsesEmbeddedGithubProvider(t *testing.T) {
 		t.Errorf("coder should use providers/github.yaml, got %v", role.Providers)
 	}
 }
+
+// TestReviewRoleMountsTheRepositoryReadOnly pins the fleet parity the
+// authoring skill relies on: the review harness in fullsend-ai/agents sets
+// readonly_repo, and the prompt's "do not edit files" is enforcement only if
+// the generated harness does too.
+func TestReviewRoleMountsTheRepositoryReadOnly(t *testing.T) {
+	for _, r := range roleTable {
+		want := r.Name == "review"
+		if r.ReadonlyRepo != want {
+			t.Errorf("role %s: ReadonlyRepo = %v, want %v", r.Name, r.ReadonlyRepo, want)
+		}
+	}
+}

--- a/internal/agentnew/templates/post.sh.tmpl
+++ b/internal/agentnew/templates/post.sh.tmpl
@@ -122,22 +122,24 @@ NUMBER="${BASH_REMATCH[3]}"
 
 # On ok, post nothing — unless an earlier run left a findings comment on
 # this work item. The harness trigger fires again on later pushes, so a
-# problem the author has since fixed would otherwise stay reported; replace
-# that comment (same marker, edited in place) with the all-clear.
+# problem the author has since fixed would otherwise stay reported.
+# --only-if-exists makes fullsend replace that comment (same marker, found
+# through the forge client and the bot's own author) with the all-clear,
+# and post nothing when there is no earlier comment.
 if [[ "${status}" == "ok" ]]; then
   if [[ "${__DRY_RUN_VAR__:-}" == "1" ]]; then
     echo "post-__AGENT_NAME__: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
     exit 0
   fi
-  earlier=0
-  while read -r n; do earlier=$(( earlier + n )); done < <(
-    gh api --paginate "repos/${REPO}/issues/${NUMBER}/comments" \
-      --jq --arg m "${MARKER}" '[.[] | select(.body | contains($m))] | length')
-  if (( earlier == 0 )); then
-    echo "post-__AGENT_NAME__: status=ok, nothing to post" >&2
-    exit 0
-  fi
-  echo "post-__AGENT_NAME__: status=ok, replacing the earlier findings comment with the all-clear" >&2
+  printf '**%s**\n\n%s\n' "${summary}" "${comment}" \
+    | fullsend issues post-comment \
+        --tracker github \
+        --project "${REPO}" \
+        --number "${NUMBER}" \
+        --marker "${MARKER}" \
+        --only-if-exists \
+        --result -
+  exit 0
 fi
 
 if [[ "${__DRY_RUN_VAR__:-}" == "1" ]]; then

--- a/internal/agentnew/templates/post.sh.tmpl
+++ b/internal/agentnew/templates/post.sh.tmpl
@@ -131,6 +131,14 @@ if [[ "${status}" == "ok" ]]; then
     echo "post-__AGENT_NAME__: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
     exit 0
   fi
+  # The runner's fullsend may predate --only-if-exists (it is pinned by the
+  # repository's fullsend-ref, not by the CLI that generated this script).
+  # Detect the flag instead of assuming it: on an older CLI, keep the old
+  # behaviour — post nothing — rather than fail the common ok path.
+  if ! fullsend issues post-comment --help 2>&1 | grep -q -- '--only-if-exists'; then
+    echo "post-__AGENT_NAME__: status=ok, nothing to post (this fullsend has no --only-if-exists; an earlier findings comment, if any, stays until a later run with findings)" >&2
+    exit 0
+  fi
   printf '**%s**\n\n%s\n' "${summary}" "${comment}" \
     | fullsend issues post-comment \
         --tracker github \

--- a/internal/agentnew/templates/post.sh.tmpl
+++ b/internal/agentnew/templates/post.sh.tmpl
@@ -80,7 +80,14 @@ comment=$(jq -r 'if (.comment | type) == "string" then .comment else empty end' 
 
 case "${status}" in
   ok|findings|error) ;;
-  *) echo "post-__AGENT_NAME__: status must be ok, findings or error (got '${status}')" >&2; exit 1 ;;
+  *)
+    # status is model output: never echo it raw. A value carrying CR/LF would
+    # split the runner's log line (a workflow-command injection vector), so
+    # flatten it and cap it before it reaches stderr.
+    shown="${status//[$'\r\n']/ }"
+    echo "post-__AGENT_NAME__: status must be ok, findings or error (got '${shown:0:40}')" >&2
+    exit 1
+    ;;
 esac
 [[ -n "${summary}" ]] || { echo "post-__AGENT_NAME__: summary is required" >&2; exit 1; }
 if [[ "${summary}" == *$'\n'* || "${summary}" == *$'\r'* ]]; then

--- a/internal/agentnew/templates/post.sh.tmpl
+++ b/internal/agentnew/templates/post.sh.tmpl
@@ -85,7 +85,9 @@ case "${status}" in
     # split the runner's log line (a workflow-command injection vector), so
     # flatten it and cap it before it reaches stderr.
     shown="${status//[$'\r\n']/ }"
-    echo "post-__AGENT_NAME__: status must be ok, findings or error (got '${shown:0:40}')" >&2
+    # printf '%s' never interprets backslash escapes; echo does under xpg_echo,
+    # so a literal "\n" in the value could still forge a log line through echo.
+    printf '%s\n' "post-__AGENT_NAME__: status must be ok, findings or error (got '${shown:0:40}')" >&2
     exit 1
     ;;
 esac

--- a/internal/agentnew/templates/post.sh.tmpl
+++ b/internal/agentnew/templates/post.sh.tmpl
@@ -110,11 +110,6 @@ if (( ${#comment} > MAX_COMMENT_CHARS )); then
   comment="${comment:0:${keep}}${TRUNCATION_MARKER}"
 fi
 
-if [[ "${status}" == "ok" ]]; then
-  echo "post-__AGENT_NAME__: status=ok, nothing to post" >&2
-  exit 0
-fi
-
 # Derive the repo and number from the work item URL rather than trusting extra
 # environment. The pattern also rejects anything that is not a github.com URL.
 url_re='^https://github[.]com/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)/(issues|pull)/([0-9]+)$'
@@ -124,6 +119,26 @@ if [[ ! "${ISSUE_URL}" =~ ${url_re} ]]; then
 fi
 REPO="${BASH_REMATCH[1]}"
 NUMBER="${BASH_REMATCH[3]}"
+
+# On ok, post nothing — unless an earlier run left a findings comment on
+# this work item. The harness trigger fires again on later pushes, so a
+# problem the author has since fixed would otherwise stay reported; replace
+# that comment (same marker, edited in place) with the all-clear.
+if [[ "${status}" == "ok" ]]; then
+  if [[ "${__DRY_RUN_VAR__:-}" == "1" ]]; then
+    echo "post-__AGENT_NAME__: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
+    exit 0
+  fi
+  earlier=0
+  while read -r n; do earlier=$(( earlier + n )); done < <(
+    gh api --paginate "repos/${REPO}/issues/${NUMBER}/comments" \
+      --jq --arg m "${MARKER}" '[.[] | select(.body | contains($m))] | length')
+  if (( earlier == 0 )); then
+    echo "post-__AGENT_NAME__: status=ok, nothing to post" >&2
+    exit 0
+  fi
+  echo "post-__AGENT_NAME__: status=ok, replacing the earlier findings comment with the all-clear" >&2
+fi
 
 if [[ "${__DRY_RUN_VAR__:-}" == "1" ]]; then
   printf '**%s**\n\n%s\n' "${summary}" "${comment}"

--- a/internal/agentnew/testdata/golden/triage.txt
+++ b/internal/agentnew/testdata/golden/triage.txt
@@ -270,22 +270,24 @@ NUMBER="${BASH_REMATCH[3]}"
 
 # On ok, post nothing — unless an earlier run left a findings comment on
 # this work item. The harness trigger fires again on later pushes, so a
-# problem the author has since fixed would otherwise stay reported; replace
-# that comment (same marker, edited in place) with the all-clear.
+# problem the author has since fixed would otherwise stay reported.
+# --only-if-exists makes fullsend replace that comment (same marker, found
+# through the forge client and the bot's own author) with the all-clear,
+# and post nothing when there is no earlier comment.
 if [[ "${status}" == "ok" ]]; then
   if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then
     echo "post-lint-docs: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
     exit 0
   fi
-  earlier=0
-  while read -r n; do earlier=$(( earlier + n )); done < <(
-    gh api --paginate "repos/${REPO}/issues/${NUMBER}/comments" \
-      --jq --arg m "${MARKER}" '[.[] | select(.body | contains($m))] | length')
-  if (( earlier == 0 )); then
-    echo "post-lint-docs: status=ok, nothing to post" >&2
-    exit 0
-  fi
-  echo "post-lint-docs: status=ok, replacing the earlier findings comment with the all-clear" >&2
+  printf '**%s**\n\n%s\n' "${summary}" "${comment}" \
+    | fullsend issues post-comment \
+        --tracker github \
+        --project "${REPO}" \
+        --number "${NUMBER}" \
+        --marker "${MARKER}" \
+        --only-if-exists \
+        --result -
+  exit 0
 fi
 
 if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then

--- a/internal/agentnew/testdata/golden/triage.txt
+++ b/internal/agentnew/testdata/golden/triage.txt
@@ -279,6 +279,14 @@ if [[ "${status}" == "ok" ]]; then
     echo "post-lint-docs: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
     exit 0
   fi
+  # The runner's fullsend may predate --only-if-exists (it is pinned by the
+  # repository's fullsend-ref, not by the CLI that generated this script).
+  # Detect the flag instead of assuming it: on an older CLI, keep the old
+  # behaviour — post nothing — rather than fail the common ok path.
+  if ! fullsend issues post-comment --help 2>&1 | grep -q -- '--only-if-exists'; then
+    echo "post-lint-docs: status=ok, nothing to post (this fullsend has no --only-if-exists; an earlier findings comment, if any, stays until a later run with findings)" >&2
+    exit 0
+  fi
   printf '**%s**\n\n%s\n' "${summary}" "${comment}" \
     | fullsend issues post-comment \
         --tracker github \

--- a/internal/agentnew/testdata/golden/triage.txt
+++ b/internal/agentnew/testdata/golden/triage.txt
@@ -228,7 +228,14 @@ comment=$(jq -r 'if (.comment | type) == "string" then .comment else empty end' 
 
 case "${status}" in
   ok|findings|error) ;;
-  *) echo "post-lint-docs: status must be ok, findings or error (got '${status}')" >&2; exit 1 ;;
+  *)
+    # status is model output: never echo it raw. A value carrying CR/LF would
+    # split the runner's log line (a workflow-command injection vector), so
+    # flatten it and cap it before it reaches stderr.
+    shown="${status//[$'\r\n']/ }"
+    echo "post-lint-docs: status must be ok, findings or error (got '${shown:0:40}')" >&2
+    exit 1
+    ;;
 esac
 [[ -n "${summary}" ]] || { echo "post-lint-docs: summary is required" >&2; exit 1; }
 if [[ "${summary}" == *$'\n'* || "${summary}" == *$'\r'* ]]; then

--- a/internal/agentnew/testdata/golden/triage.txt
+++ b/internal/agentnew/testdata/golden/triage.txt
@@ -233,7 +233,9 @@ case "${status}" in
     # split the runner's log line (a workflow-command injection vector), so
     # flatten it and cap it before it reaches stderr.
     shown="${status//[$'\r\n']/ }"
-    echo "post-lint-docs: status must be ok, findings or error (got '${shown:0:40}')" >&2
+    # printf '%s' never interprets backslash escapes; echo does under xpg_echo,
+    # so a literal "\n" in the value could still forge a log line through echo.
+    printf '%s\n' "post-lint-docs: status must be ok, findings or error (got '${shown:0:40}')" >&2
     exit 1
     ;;
 esac

--- a/internal/agentnew/testdata/golden/triage.txt
+++ b/internal/agentnew/testdata/golden/triage.txt
@@ -258,11 +258,6 @@ if (( ${#comment} > MAX_COMMENT_CHARS )); then
   comment="${comment:0:${keep}}${TRUNCATION_MARKER}"
 fi
 
-if [[ "${status}" == "ok" ]]; then
-  echo "post-lint-docs: status=ok, nothing to post" >&2
-  exit 0
-fi
-
 # Derive the repo and number from the work item URL rather than trusting extra
 # environment. The pattern also rejects anything that is not a github.com URL.
 url_re='^https://github[.]com/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)/(issues|pull)/([0-9]+)$'
@@ -272,6 +267,26 @@ if [[ ! "${ISSUE_URL}" =~ ${url_re} ]]; then
 fi
 REPO="${BASH_REMATCH[1]}"
 NUMBER="${BASH_REMATCH[3]}"
+
+# On ok, post nothing — unless an earlier run left a findings comment on
+# this work item. The harness trigger fires again on later pushes, so a
+# problem the author has since fixed would otherwise stay reported; replace
+# that comment (same marker, edited in place) with the all-clear.
+if [[ "${status}" == "ok" ]]; then
+  if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then
+    echo "post-lint-docs: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
+    exit 0
+  fi
+  earlier=0
+  while read -r n; do earlier=$(( earlier + n )); done < <(
+    gh api --paginate "repos/${REPO}/issues/${NUMBER}/comments" \
+      --jq --arg m "${MARKER}" '[.[] | select(.body | contains($m))] | length')
+  if (( earlier == 0 )); then
+    echo "post-lint-docs: status=ok, nothing to post" >&2
+    exit 0
+  fi
+  echo "post-lint-docs: status=ok, replacing the earlier findings comment with the all-clear" >&2
+fi
 
 if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then
   printf '**%s**\n\n%s\n' "${summary}" "${comment}"

--- a/internal/agentnew/testdata/golden/validation-loop.txt
+++ b/internal/agentnew/testdata/golden/validation-loop.txt
@@ -278,22 +278,24 @@ NUMBER="${BASH_REMATCH[3]}"
 
 # On ok, post nothing — unless an earlier run left a findings comment on
 # this work item. The harness trigger fires again on later pushes, so a
-# problem the author has since fixed would otherwise stay reported; replace
-# that comment (same marker, edited in place) with the all-clear.
+# problem the author has since fixed would otherwise stay reported.
+# --only-if-exists makes fullsend replace that comment (same marker, found
+# through the forge client and the bot's own author) with the all-clear,
+# and post nothing when there is no earlier comment.
 if [[ "${status}" == "ok" ]]; then
   if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then
     echo "post-lint-docs: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
     exit 0
   fi
-  earlier=0
-  while read -r n; do earlier=$(( earlier + n )); done < <(
-    gh api --paginate "repos/${REPO}/issues/${NUMBER}/comments" \
-      --jq --arg m "${MARKER}" '[.[] | select(.body | contains($m))] | length')
-  if (( earlier == 0 )); then
-    echo "post-lint-docs: status=ok, nothing to post" >&2
-    exit 0
-  fi
-  echo "post-lint-docs: status=ok, replacing the earlier findings comment with the all-clear" >&2
+  printf '**%s**\n\n%s\n' "${summary}" "${comment}" \
+    | fullsend issues post-comment \
+        --tracker github \
+        --project "${REPO}" \
+        --number "${NUMBER}" \
+        --marker "${MARKER}" \
+        --only-if-exists \
+        --result -
+  exit 0
 fi
 
 if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then

--- a/internal/agentnew/testdata/golden/validation-loop.txt
+++ b/internal/agentnew/testdata/golden/validation-loop.txt
@@ -236,7 +236,14 @@ comment=$(jq -r 'if (.comment | type) == "string" then .comment else empty end' 
 
 case "${status}" in
   ok|findings|error) ;;
-  *) echo "post-lint-docs: status must be ok, findings or error (got '${status}')" >&2; exit 1 ;;
+  *)
+    # status is model output: never echo it raw. A value carrying CR/LF would
+    # split the runner's log line (a workflow-command injection vector), so
+    # flatten it and cap it before it reaches stderr.
+    shown="${status//[$'\r\n']/ }"
+    echo "post-lint-docs: status must be ok, findings or error (got '${shown:0:40}')" >&2
+    exit 1
+    ;;
 esac
 [[ -n "${summary}" ]] || { echo "post-lint-docs: summary is required" >&2; exit 1; }
 if [[ "${summary}" == *$'\n'* || "${summary}" == *$'\r'* ]]; then

--- a/internal/agentnew/testdata/golden/validation-loop.txt
+++ b/internal/agentnew/testdata/golden/validation-loop.txt
@@ -241,7 +241,9 @@ case "${status}" in
     # split the runner's log line (a workflow-command injection vector), so
     # flatten it and cap it before it reaches stderr.
     shown="${status//[$'\r\n']/ }"
-    echo "post-lint-docs: status must be ok, findings or error (got '${shown:0:40}')" >&2
+    # printf '%s' never interprets backslash escapes; echo does under xpg_echo,
+    # so a literal "\n" in the value could still forge a log line through echo.
+    printf '%s\n' "post-lint-docs: status must be ok, findings or error (got '${shown:0:40}')" >&2
     exit 1
     ;;
 esac

--- a/internal/agentnew/testdata/golden/validation-loop.txt
+++ b/internal/agentnew/testdata/golden/validation-loop.txt
@@ -266,11 +266,6 @@ if (( ${#comment} > MAX_COMMENT_CHARS )); then
   comment="${comment:0:${keep}}${TRUNCATION_MARKER}"
 fi
 
-if [[ "${status}" == "ok" ]]; then
-  echo "post-lint-docs: status=ok, nothing to post" >&2
-  exit 0
-fi
-
 # Derive the repo and number from the work item URL rather than trusting extra
 # environment. The pattern also rejects anything that is not a github.com URL.
 url_re='^https://github[.]com/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)/(issues|pull)/([0-9]+)$'
@@ -280,6 +275,26 @@ if [[ ! "${ISSUE_URL}" =~ ${url_re} ]]; then
 fi
 REPO="${BASH_REMATCH[1]}"
 NUMBER="${BASH_REMATCH[3]}"
+
+# On ok, post nothing — unless an earlier run left a findings comment on
+# this work item. The harness trigger fires again on later pushes, so a
+# problem the author has since fixed would otherwise stay reported; replace
+# that comment (same marker, edited in place) with the all-clear.
+if [[ "${status}" == "ok" ]]; then
+  if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then
+    echo "post-lint-docs: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
+    exit 0
+  fi
+  earlier=0
+  while read -r n; do earlier=$(( earlier + n )); done < <(
+    gh api --paginate "repos/${REPO}/issues/${NUMBER}/comments" \
+      --jq --arg m "${MARKER}" '[.[] | select(.body | contains($m))] | length')
+  if (( earlier == 0 )); then
+    echo "post-lint-docs: status=ok, nothing to post" >&2
+    exit 0
+  fi
+  echo "post-lint-docs: status=ok, replacing the earlier findings comment with the all-clear" >&2
+fi
 
 if [[ "${POST_LINT_DOCS_DRY_RUN:-}" == "1" ]]; then
   printf '**%s**\n\n%s\n' "${summary}" "${comment}"

--- a/internal/agentnew/testdata/golden/validation-loop.txt
+++ b/internal/agentnew/testdata/golden/validation-loop.txt
@@ -287,6 +287,14 @@ if [[ "${status}" == "ok" ]]; then
     echo "post-lint-docs: status=ok, nothing to post (dry run: an earlier findings comment would be replaced with the all-clear)" >&2
     exit 0
   fi
+  # The runner's fullsend may predate --only-if-exists (it is pinned by the
+  # repository's fullsend-ref, not by the CLI that generated this script).
+  # Detect the flag instead of assuming it: on an older CLI, keep the old
+  # behaviour — post nothing — rather than fail the common ok path.
+  if ! fullsend issues post-comment --help 2>&1 | grep -q -- '--only-if-exists'; then
+    echo "post-lint-docs: status=ok, nothing to post (this fullsend has no --only-if-exists; an earlier findings comment, if any, stays until a later run with findings)" >&2
+    exit 0
+  fi
   printf '**%s**\n\n%s\n' "${summary}" "${comment}" \
     | fullsend issues post-comment \
         --tracker github \

--- a/internal/cli/issues.go
+++ b/internal/cli/issues.go
@@ -169,17 +169,18 @@ func runIssuesGet(ctx context.Context, cfg *issuesGetConfig) error {
 // issuesPostCommentConfig holds the flags and test overrides for
 // "fullsend issues post-comment".
 type issuesPostCommentConfig struct {
-	trackerName string
-	project     string
-	number      int
-	marker      string
-	result      string
-	token       string
-	jiraURL     string
-	jiraEmail   string
-	dryRun      bool
-	keepHistory *bool // nil = resolve from config; non-nil = explicit flag
-	fullsendDir string
+	trackerName  string
+	project      string
+	number       int
+	marker       string
+	result       string
+	token        string
+	jiraURL      string
+	jiraEmail    string
+	dryRun       bool
+	onlyIfExists bool
+	keepHistory  *bool // nil = resolve from config; non-nil = explicit flag
+	fullsendDir  string
 
 	// Test overrides — when non-nil, used instead of creating a real
 	// tracker client. Not set by CLI flag parsing.
@@ -242,6 +243,7 @@ The --result flag accepts a file path or "-" for stdin.`,
 	cmd.Flags().StringVar(&cfg.jiraURL, "jira-url", "", "Jira instance URL (default: $JIRA_BASE_URL)")
 	cmd.Flags().StringVar(&cfg.jiraEmail, "jira-email", "", "Jira user email for Basic auth (default: $JIRA_USER_EMAIL)")
 	cmd.Flags().BoolVar(&cfg.dryRun, "dry-run", false, "print what would be posted without making API calls")
+	cmd.Flags().BoolVar(&cfg.onlyIfExists, "only-if-exists", false, "update an existing comment with this marker but never create one (for an all-clear that should replace earlier findings)")
 	cmd.Flags().BoolVar(&keepHistory, "keep-history", true, "append previous content as collapsed history blocks (set false to replace in-place)")
 	cmd.Flags().StringVar(&cfg.fullsendDir, "fullsend-dir", "", "path to .fullsend config directory (sources defaults from its config.yaml when flags are omitted)")
 	_ = cmd.MarkFlagRequired("project")
@@ -293,9 +295,10 @@ func runIssuesPostComment(ctx context.Context, cfg *issuesPostCommentConfig) err
 	}
 
 	stickyCfg := sticky.Config{
-		Marker:      cfg.marker,
-		DryRun:      cfg.dryRun,
-		KeepHistory: keepHistory,
+		Marker:       cfg.marker,
+		DryRun:       cfg.dryRun,
+		KeepHistory:  keepHistory,
+		OnlyIfExists: cfg.onlyIfExists,
 	}
 	if trackerName == trackerJira {
 		// The Jira write path routes every body through
@@ -374,6 +377,11 @@ func postJiraStickyComment(ctx context.Context, jc *tracker.JiraClient, project 
 		return "", nil // Jira has no stable comment permalink
 	}
 
+	if cfg.OnlyIfExists {
+		printer.StepInfo("No existing comment with this marker; nothing to post (--only-if-exists)")
+		return "", nil
+	}
+
 	printer.StepStart("No existing comment found, creating new one")
 
 	if cfg.DryRun {
@@ -432,6 +440,11 @@ func postTrackerStickyComment(ctx context.Context, tc tracker.Client, project st
 		}
 		printer.StepDone("Comment updated")
 		return existing.HTMLURL, nil
+	}
+
+	if cfg.OnlyIfExists {
+		printer.StepInfo("No existing comment with this marker; nothing to post (--only-if-exists)")
+		return "", nil
 	}
 
 	printer.StepStart("No existing comment found, creating new one")

--- a/internal/cli/issues_test.go
+++ b/internal/cli/issues_test.go
@@ -1005,3 +1005,53 @@ func TestIssuesPostCommentCmd_TrackerNotRequired(t *testing.T) {
 	assert.NotContains(t, err.Error(), `required flag(s) "tracker"`)
 	assert.Contains(t, err.Error(), "--tracker is required")
 }
+
+func TestRunIssuesPostComment_OnlyIfExists_SkipsCreate(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "bot"
+	tc := tracker.NewForgeClient(fc)
+
+	cfg := &issuesPostCommentConfig{
+		trackerName:  trackerGitHub,
+		project:      "acme/widgets",
+		number:       42,
+		marker:       "<!-- test:agent -->",
+		onlyIfExists: true,
+		testClient:   tc,
+		testPrinter:  ui.New(io.Discard),
+		testBody:     "all clear",
+	}
+
+	require.NoError(t, runIssuesPostComment(context.Background(), cfg))
+
+	comments, err := tc.ListComments(context.Background(), "acme/widgets", 42)
+	require.NoError(t, err)
+	assert.Empty(t, comments, "only-if-exists must not create a first comment")
+}
+
+func TestRunIssuesPostComment_OnlyIfExists_ReplacesEarlierFindings(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "bot"
+	tc := tracker.NewForgeClient(fc)
+	ctx := context.Background()
+
+	cfg := &issuesPostCommentConfig{
+		trackerName: trackerGitHub,
+		project:     "acme/widgets",
+		number:      42,
+		marker:      "<!-- test:agent -->",
+		testClient:  tc,
+		testPrinter: ui.New(io.Discard),
+		testBody:    "2 broken links",
+	}
+	require.NoError(t, runIssuesPostComment(ctx, cfg))
+
+	cfg.onlyIfExists = true
+	cfg.testBody = "all clear"
+	require.NoError(t, runIssuesPostComment(ctx, cfg))
+
+	comments, err := tc.ListComments(ctx, "acme/widgets", 42)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Contains(t, string(comments[0].Body), "all clear")
+}

--- a/internal/cli/issues_test.go
+++ b/internal/cli/issues_test.go
@@ -1055,3 +1055,37 @@ func TestRunIssuesPostComment_OnlyIfExists_ReplacesEarlierFindings(t *testing.T)
 	require.Len(t, comments, 1)
 	assert.Contains(t, string(comments[0].Body), "all clear")
 }
+
+func TestRunIssuesPostComment_Jira_OnlyIfExists(t *testing.T) {
+	tc, _, err := tracker.NewFakeJiraClientWithFake("https://acme.atlassian.net")
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	cfg := &issuesPostCommentConfig{
+		trackerName:  trackerJira,
+		project:      "PROJ",
+		number:       42,
+		marker:       "<!-- test:agent -->",
+		onlyIfExists: true,
+		testClient:   tc,
+		testPrinter:  ui.New(io.Discard),
+		testBody:     "all clear",
+	}
+	// No earlier comment: nothing is created.
+	require.NoError(t, runIssuesPostComment(ctx, cfg))
+	comments, err := tc.ListComments(ctx, "PROJ", 42)
+	require.NoError(t, err)
+	assert.Empty(t, comments)
+
+	// An earlier findings comment exists: it is replaced.
+	cfg.onlyIfExists = false
+	cfg.testBody = "2 broken links"
+	require.NoError(t, runIssuesPostComment(ctx, cfg))
+	cfg.onlyIfExists = true
+	cfg.testBody = "all clear"
+	require.NoError(t, runIssuesPostComment(ctx, cfg))
+	comments, err = tc.ListComments(ctx, "PROJ", 42)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Contains(t, string(comments[0].Body), "all clear")
+}

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -21,6 +21,10 @@ type Config struct {
 	MaxSize      int    // max comment body size (default 65000)
 	DryRun       bool
 	KeepHistory  bool // when false, updates replace the body in-place with no "Previous run" history
+	// OnlyIfExists updates an existing marked comment but never creates one:
+	// a post-script uses it on an all-clear result so an earlier findings
+	// comment is replaced while a clean first run stays silent.
+	OnlyIfExists bool
 }
 
 func (c Config) maxSize() int {
@@ -70,6 +74,11 @@ func Post(ctx context.Context, client forge.Client, owner, repo string, number i
 		}
 		printer.StepDone("Comment updated")
 		return existing.HTMLURL, nil
+	}
+
+	if cfg.OnlyIfExists {
+		printer.StepInfo("No existing comment with this marker; nothing to post (only-if-exists)")
+		return "", nil
 	}
 
 	printer.StepStart("No existing comment found, creating new one")

--- a/internal/sticky/sticky_test.go
+++ b/internal/sticky/sticky_test.go
@@ -376,3 +376,30 @@ func TestPost_DryRunExisting(t *testing.T) {
 
 	assert.Empty(t, client.UpdatedComments)
 }
+
+func TestPost_OnlyIfExists_SkipsCreate(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.AuthenticatedUser = "bot"
+	printer := ui.New(io.Discard)
+
+	cfg := Config{Marker: "<!-- test -->", OnlyIfExists: true}
+	commentURL, err := Post(context.Background(), client, "o", "r", 1, "All clear.", cfg, printer)
+	require.NoError(t, err)
+	assert.Empty(t, commentURL)
+	assert.Empty(t, client.IssueComments["o/r/1"], "only-if-exists must not create a first comment")
+}
+
+func TestPost_OnlyIfExists_UpdatesExisting(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.AuthenticatedUser = "bot"
+	client.IssueComments = map[string][]forge.IssueComment{
+		"o/r/1": {{ID: 100, HTMLURL: "https://github.com/o/r/issues/1#issuecomment-100", Body: "<!-- test -->\n2 broken links", Author: "bot"}},
+	}
+	printer := ui.New(io.Discard)
+
+	cfg := Config{Marker: "<!-- test -->", OnlyIfExists: true}
+	commentURL, err := Post(context.Background(), client, "o", "r", 1, "All clear.", cfg, printer)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/o/r/issues/1#issuecomment-100", commentURL)
+	require.Len(t, client.UpdatedComments, 1)
+}


### PR DESCRIPTION
Follow-up to #6972, from a review finding on fullsend-ai/agents#1167 (whose reference example carries the generated post-script verbatim).

## What changed

- `internal/agentnew/templates/post.sh.tmpl`: on the invalid-status path, the model-supplied `status` is no longer echoed raw. `jq -r` materialises JSON `\n`/`\r` escapes as real line breaks, so a crafted value could split the runner's log line and start a new one with a `::` workflow-command prefix. The value is flattened (CR/LF → space), capped at 40 characters, and written with `printf '%s\n'`, which never interprets backslash escapes (`echo` does under `xpg_echo`). `summary` already had this check; `status` did not.
- `internal/agentnew/roles.go`, `render.go`: the `review` role now emits `readonly_repo: true`, matching the fleet's review harness (the only one that sets it), so a generated review agent's "do not edit files" is enforced by the sandbox rather than requested. One sentence added under the role table in `docs/cli/agent.md`.
- Tests in `internal/agentnew/postscript_exec_test.go`: a status of `bogus\n::error::injected` is rejected on a single log line; the same under `bash -O xpg_echo` with a literal backslash-n; both skip when `jq` is absent, like the sibling test. `roles_test.go`: `TestReviewRoleMountsTheRepositoryReadOnly`.
- Goldens regenerated (`triage`, `validation-loop`).

## How to check

```
go test ./internal/agentnew/ ./internal/cli/
```

Both pass. Once merged, the agents-repo example is regenerated from this generator so the two stay byte-identical.

Part of #6966.

## Also: stale findings on a later push

On `status: ok` the generated post-script used to post nothing, so a findings comment from an earlier push stayed on the pull request after a later push fixed it (the trigger fires on `synchronized`). Now, if an earlier comment with this agent's marker exists, it is replaced with the all-clear; with no earlier comment nothing is posted, as before. Dry run keeps the `nothing to post` notice, so the local-run output shown in the docs is unchanged. Test: `TestGeneratedPostScriptOkPostsNothingWithoutAnEarlierComment`.
