### PR TITLE
docs(runtimes): say what to write in tools: on pi

### DIFF
--- a/docs/guides/user/building-custom-agents.md
+++ b/docs/guides/user/building-custom-agents.md
@@ -120,7 +120,7 @@ Write to `$FULLSEND_OUTPUT_DIR/agent-result.json`:
 | Field | Purpose |
 |-------|---------|
 | `name` | Must match the filename (without `.md`) |
-| `tools` | Bash commands the agent can run. Restrict to what's needed. |
+| `tools` | The tools the agent may use, in Claude Code's names (`Read`, `Grep`, `Glob`, `LS`, `Bash(gh,jq)`, ...). Restrict to what's needed. On pi the names are translated, and two of them surprise people — see [What to write in `tools:`](../../runtimes/pi.md#what-to-write-in-tools) |
 | `model` | LLM model (`opus`, `sonnet`, etc.) |
 | `skills` | [Skill](../../glossary.md#skill) directories to mount (relative to `skills/`) |
 | `disallowedTools` | Bash patterns the agent is forbidden from running |

--- a/docs/runtimes/pi.md
+++ b/docs/runtimes/pi.md
@@ -195,6 +195,25 @@ What a local pi run needs, beyond the guide:
 - **Fast release cadence** (~weekly minors, with wire-format changes inside a minor) — versions are
   pinned exactly and the stream-parser fixtures are tied to the pinned version.
 
+### What to write in `tools:`
+
+`tools:` is written in Claude Code's names on every runtime, and the runner translates. On pi:
+
+| You write | pi runs | Worth knowing |
+|---|---|---|
+| `Bash`, `Read`, `Write`, `Edit`, `Grep` | `bash`, `read`, `write`, `edit`, `grep` | — |
+| `MultiEdit` | `edit` | pi has one edit tool |
+| `Glob` | `find` | `find` takes a **glob pattern**, not a bare directory. A model that means "list this directory" and sends `{"path": "docs/"}` gets a validation error and has to retry |
+| `LS` | `ls` | The tool to grant for directory listing. Claude Code itself dropped `LS`, so the entry does nothing on that runtime, and codex lists through the shell — it is pi where it counts |
+| anything else | — | A persona naming a Claude-only tool (`WebFetch`, `TodoWrite`, ...) fails rather than silently losing it; see [Sub-agents troubleshooting](#troubleshooting-sub-agents) |
+
+So an agent that browses the tree wants `Glob` **and** `LS`: `Glob` to match a pattern, `LS` to see
+what is in a directory. With `Glob` alone the model tends to reach for a listing it cannot make.
+
+If your org enables the optional `tool_allowlist_pretool.py` hook, write `LS` in
+`FULLSEND_TOOL_ALLOWLIST` too — the hook's vocabulary is Claude Code's, and pi's `ls` arrives as
+`LS`.
+
 ## Plugins (pi extensions)
 
 pi's tool surface grows through extensions — JavaScript/TypeScript modules pi loads with `-e`. A


### PR DESCRIPTION
## Summary

Document what to write in an agent's `tools:` when it runs on pi. Two of the translations surprise people, and both have cost real runs.

## Related Issue

Follows on from [fullsend-ai/agents#1269](https://github.com/fullsend-ai/agents/issues/1269), where two `pr-review` sub-agents failed a tool call each because they had `Glob` but not `LS`.

## Changes

- **`docs/runtimes/pi.md`** — a short "What to write in `tools:`" table under Behaviour differences: the name-by-name mapping, plus the two that bite.
  - `Glob` becomes pi's `find`, which takes a **glob pattern**, not a bare directory. A model that means "list this directory" sends `{"path": "docs/"}`, gets a validation error, and retries.
  - `LS` becomes `ls` and is the tool to grant for listing — even though Claude Code itself no longer has `LS`, so the entry is inert there and codex lists through the shell.
  - The practical advice: an agent that browses the tree wants `Glob` **and** `LS`.
  - A note that `FULLSEND_TOOL_ALLOWLIST` needs `LS` too, since the hook vocabulary is Claude Code's and pi's `ls` arrives as `LS`.
- **`docs/guides/user/building-custom-agents.md`** — the `tools` row said "Bash commands the agent can run", which is only part of the truth. It now names the vocabulary and links to the table.

No behaviour change; documentation only. The mapping itself is `piToolForClaude` in `internal/runtime/pi_agent.go` and `security.LegacyClaudeTools`, both unchanged here.

## Testing

- [x] `make lint` passes (staged first)
- [x] Tests added/updated for new or modified logic — n/a, docs only
- `npx vitepress build docs` builds clean, including the new cross-page anchor

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md)
- [x] Commits are signed off (DCO)
- [ ] I wrote this contribution myself and can explain all changes in it
